### PR TITLE
(feature): enable ai sre agent shadow mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ book
 local
 data
 AGENTS.md
+reactflow

--- a/README.md
+++ b/README.md
@@ -402,13 +402,10 @@ agent:
     # Named rules are tried first, in order. The first match wins.
     rules:
       - name: oom
-        severity: critical
         pattern: "(?i)out of memory|OOMKilled|java\\.lang\\.OutOfMemoryError"
       - name: db-timeout
-        severity: high
         pattern: "(?i)(connection|query) timeout|deadlock detected"
       - name: auth-failure
-        severity: medium
         pattern: "(?i)401 unauthorized|invalid credentials|permission denied"
 
 redis: # Required for the agent to persist source cursors across restarts
@@ -433,7 +430,7 @@ The `agent` section includes:
 7. `miner`: Controls how aggressively the agent groups similar log lines together. The defaults work well for most setups.
 8. `regex`: Acts as a **pre-filter** for the agent. Only signals whose message matches at least one rule (a named entry under `rules` or `default_pattern`) are forwarded to the pattern miner and stored in the catalog. Anything that doesn't match is dropped before clustering, so boring noise (200-OK requests, debug lines, etc.) never bloats `patterns.json`.
 
-   - Named `rules` are tried in order; the first match wins and tags the signal with that `name` and `severity`.
+   - Named `rules` are tried in order; the first match wins and tags the signal with that `name` (stored as `rule_name` on the pattern).
    - If no named rule hits, `default_pattern` is tried. Matches there are tagged with `name=default`.
    - **To learn from every line, set `default_pattern: ".*"`.** This is useful in early training when you don't yet know what's interesting.
    - **To filter aggressively, set `default_pattern: ""` (empty)** and rely on your named rules — anything that doesn't match an explicit rule is dropped.
@@ -710,13 +707,10 @@ agent:
     rules:
       - name: oom-killer
         pattern: "Out of memory: Killed process"
-        severity: critical
       - name: panic
         pattern: "(?i)panic:"
-        severity: critical
       - name: 5xx-burst
         pattern: "HTTP/[0-9.]+\\s+5\\d\\d"
-        severity: high
 ```
 
 ## Environment Variables

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -166,6 +166,19 @@ func startAgent(ctx context.Context, app *fiber.App, cfg c.AgentConfig, rdb *red
 	}
 	log.Printf("agent: catalog loaded mode=%s path=%s patterns=%d", mode, catalogPath, catalog.Len())
 
+	// Shadow log: only meaningful when running in shadow mode, but we always
+	// load it so a mode switch (e.g. operator flips agent.mode=shadow at
+	// runtime) doesn't lose history. Path lives next to the catalog under
+	// <data_dir>/shadow.json.
+	shadowPath := cfg.ShadowPath()
+	shadowLog, err := agent.LoadShadowLog(shadowPath, 0)
+	if err != nil {
+		log.Printf("agent: shadow log load warning: %v (starting fresh)", err)
+	}
+	if cfg.Mode == "shadow" {
+		log.Printf("agent: shadow log loaded path=%s events=%d", shadowPath, shadowLog.Len())
+	}
+
 	miner := agent.NewMiner(cfg.Miner.SimilarityThreshold, cfg.Miner.TreeDepth, cfg.Miner.MaxChildren)
 	for _, p := range catalog.All() {
 		miner.AddCluster(p.ID, p.Template, p.Count)
@@ -199,6 +212,7 @@ func startAgent(ctx context.Context, app *fiber.App, cfg c.AgentConfig, rdb *red
 		Matcher:  matcher,
 		Miner:    miner,
 		Catalog:  catalog,
+		Shadow:   shadowLog,
 	})
 	if err != nil {
 		return nil, err
@@ -211,7 +225,7 @@ func startAgent(ctx context.Context, app *fiber.App, cfg c.AgentConfig, rdb *red
 		return nil, fmt.Errorf("agent: gateway_secret is not configured — /api/agent/* admin endpoints require a secret")
 	}
 	api := app.Group("/api")
-	controllers.NewAgentController(catalog).Register(api)
+	controllers.NewAgentController(catalog, shadowLog).Register(api)
 
 	return catalog, nil
 }

--- a/config/agent_sources.yaml
+++ b/config/agent_sources.yaml
@@ -22,6 +22,7 @@ sources:
       path: ./local/resource/noisy-app.log
       format: text
       from_beginning: true
+      max_lines_per_pull: 5000
 
   # - name: sample-app
   #   type: file
@@ -32,6 +33,7 @@ sources:
   #     from_beginning: true        # set false in production to tail from EOF
   #     # cursor_path: ./data/cursors/file-sample-app.cursor
   #     max_line_bytes: 65536
+  #     max_lines_per_pull: 1000
   #     timestamp_layout: "2006-01-02T15:04:05Z07:00"
   #     JSON-mode field overrides:
   #     message_field: message

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -125,7 +125,8 @@ redis: # Required for on-call functionality
 #
 # Recommended rollout:
 #   1: mode=training, review the catalog via /api/agent/patterns
-#   2: mode=shadow,   review log lines `agent[shadow]: would alert ...`
+#   2: mode=shadow,   review the would-have-alerted log via /api/agent/shadow
+#                     (also visible in stdout as `agent[shadow]: would alert ...`)
 #   3: mode=detect    (AI emission ships in a follow-up milestone)
 #
 # See local/plans/ai-incident-detection/ for the full design.
@@ -135,8 +136,8 @@ agent:
   mode: training                  # training | shadow | detect (env: AGENT_MODE)
   poll_interval: 30s              # how often each source is pulled
   lookback: 5m                    # initial backfill window on startup
-  batch_max: 1000                 # safety cap per tick
-  signal_max_bytes: 8192          # cap on Signal.Raw
+  batch_max: 5000                 # safety cap per tick
+  signal_max_bytes: 65536         # cap on Signal.Raw
   gateway_secret: ${AGENT_GATEWAY_SECRET}  # shared secret for /api/agent/* endpoints (sent in X-Gateway-Secret header)
   data_dir: ./data
 
@@ -155,7 +156,7 @@ agent:
   catalog:
     mode: file                    # storage backend; only "file" is supported today (planned: redis, database)
     persist_interval: 30s
-    auto_promote_after: 100       # in detect mode, this many sightings = "known"
+    auto_promote_after: 50       # in detect mode, this many sightings = "known"
 
   miner:
     similarity_threshold: 0.4
@@ -169,10 +170,7 @@ agent:
     rules:
       - name: oom-killer
         pattern: "Out of memory: Killed process"
-        severity: critical
       - name: panic
         pattern: "(?i)panic:"
-        severity: critical
       - name: 5xx-burst
         pattern: "HTTP/[0-9.]+\\s+5\\d\\d"
-        severity: high

--- a/pkg/agent/catalog.go
+++ b/pkg/agent/catalog.go
@@ -24,11 +24,14 @@ type Pattern struct {
 	// BaselineFrequency is the EWMA of per-tick counts. Computed during
 	// training; consumed by the spike detector in detect mode.
 	BaselineFrequency float64 `json:"baseline_frequency"`
-	// Severity is operator-assigned ("known", "info", "warning", ...).
-	// Empty means "not yet labeled".
-	Severity string `json:"severity"`
-	// Label is a short operator-assigned name (e.g. "db-retry-expected").
-	Label string `json:"label"`
+	// Verdict is the agent's classification of this pattern: "known" once
+	// it is part of baseline (auto-promoted by count or set explicitly via
+	// the admin API), otherwise empty. Operators flip a pattern to
+	// "known" by POSTing {"verdict":"known"} to /api/agent/patterns/:id.
+	Verdict string `json:"verdict"`
+	// RuleName is the regex tag attached on first sighting ("default" when
+	// only the default pattern matched, or the named rule otherwise).
+	RuleName string `json:"rule_name"`
 	// Source is the SignalSource name where the pattern was first observed.
 	Source string `json:"source"`
 	// Tags are arbitrary operator-supplied markers.
@@ -58,7 +61,7 @@ type catalogFile struct {
 const catalogFileVersion = 1
 
 // LoadCatalog opens an existing patterns file or returns an empty catalog if
-// none exists. Backups (`.1`..`.5`) are tried in order on parse failure.
+// none exists.
 func LoadCatalog(path string) (*Catalog, error) {
 	c := &Catalog{
 		path:     path,
@@ -68,37 +71,21 @@ func LoadCatalog(path string) (*Catalog, error) {
 		return c, nil
 	}
 
-	candidates := []string{path}
-	for i := 1; i <= 5; i++ {
-		candidates = append(candidates, fmt.Sprintf("%s.%d", path, i))
-	}
-
-	var lastErr error
-	for _, p := range candidates {
-		data, err := os.ReadFile(p)
-		if os.IsNotExist(err) {
-			lastErr = err
-			continue
-		}
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		var f catalogFile
-		if err := json.Unmarshal(data, &f); err != nil {
-			lastErr = fmt.Errorf("parse %s: %w", p, err)
-			continue
-		}
-		if f.Patterns != nil {
-			c.patterns = f.Patterns
-		}
-		return c, nil
-	}
-
-	if lastErr != nil && os.IsNotExist(lastErr) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
 		return c, nil // fresh start
 	}
-	return c, lastErr
+	if err != nil {
+		return c, err
+	}
+	var f catalogFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return c, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if f.Patterns != nil {
+		c.patterns = f.Patterns
+	}
+	return c, nil
 }
 
 // Get returns a pattern by ID (nil when not found).
@@ -106,6 +93,22 @@ func (c *Catalog) Get(id string) *Pattern {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.patterns[id]
+}
+
+// MarkKnown stamps a pattern as auto-promoted ("known") in the catalog.
+func (c *Catalog) MarkKnown(patternID string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	p, ok := c.patterns[patternID]
+	if !ok {
+		return false
+	}
+	if p.Verdict == "known" {
+		return false
+	}
+	p.Verdict = "known"
+	c.dirty = true
+	return true
 }
 
 // All returns a stable, sorted snapshot of every pattern (sorted by Count
@@ -138,11 +141,11 @@ func (c *Catalog) Len() int {
 // is updated. tickCount is the number of matches observed in the current
 // worker tick — used to update the EWMA baseline.
 //
-// ruleName / severity come from the regex pre-filter and are applied:
+// ruleName comes from the regex pre-filter and is applied:
 //   - on first-seen: always
-//   - subsequently: only if currently empty, OR if a non-default named rule
-//     supersedes a previous default tag
-func (c *Catalog) Upsert(patternID, template, source string, tickCount int, alpha float64, ruleName, severity string) *Pattern {
+//   - subsequently: only when a non-default named rule supersedes a previous
+//     default tag, or when the previous tag was empty
+func (c *Catalog) Upsert(patternID, template, source string, tickCount int, alpha float64, ruleName string) *Pattern {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	now := time.Now().UTC()
@@ -155,21 +158,16 @@ func (c *Catalog) Upsert(patternID, template, source string, tickCount int, alph
 			LastSeen:  now,
 			Count:     0,
 			Source:    source,
-			Severity:  severity,
-			Label:     ruleName,
+			RuleName:  ruleName,
 		}
 		c.patterns[patternID] = p
 	} else {
 		// Promote tag if we now have a more specific (non-default) hit, or
 		// fill in if it was previously empty.
-		if ruleName != "" && ruleName != "default" && p.Label != ruleName {
-			p.Label = ruleName
-			p.Severity = severity
-		} else if p.Severity == "" && severity != "" {
-			p.Severity = severity
-			if p.Label == "" {
-				p.Label = ruleName
-			}
+		if ruleName != "" && ruleName != "default" && p.RuleName != ruleName {
+			p.RuleName = ruleName
+		} else if p.RuleName == "" && ruleName != "" {
+			p.RuleName = ruleName
 		}
 	}
 	p.Template = template // keep template fresh as miner refines it
@@ -187,20 +185,17 @@ func (c *Catalog) Upsert(patternID, template, source string, tickCount int, alph
 	return p
 }
 
-// Label updates operator-curated metadata for a pattern.
-// Returns false when the pattern doesn't exist.
-func (c *Catalog) Label(patternID, severity, label string, tags []string) bool {
+// Label updates operator-curated metadata for a pattern. Empty fields are
+// left unchanged. Returns false when the pattern doesn't exist.
+func (c *Catalog) Label(patternID, verdict string, tags []string) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	p, ok := c.patterns[patternID]
 	if !ok {
 		return false
 	}
-	if severity != "" {
-		p.Severity = severity
-	}
-	if label != "" {
-		p.Label = label
+	if verdict != "" {
+		p.Verdict = verdict
 	}
 	if tags != nil {
 		p.Tags = append([]string(nil), tags...)
@@ -228,8 +223,8 @@ func (c *Catalog) Dirty() bool {
 	return c.dirty
 }
 
-// Persist flushes the in-memory catalog to disk atomically and rotates
-// up to 5 backups. Safe to call concurrently with Upsert/Label/Delete.
+// Persist flushes the in-memory catalog to disk atomically. Safe to call
+// concurrently with Upsert/Label/Delete.
 func (c *Catalog) Persist() error {
 	if c.path == "" {
 		return nil
@@ -251,16 +246,6 @@ func (c *Catalog) Persist() error {
 	data, err := json.MarshalIndent(f, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal catalog: %w", err)
-	}
-
-	// rotate backups: .4 → .5, .3 → .4, ..., current → .1
-	for i := 4; i >= 1; i-- {
-		oldP := fmt.Sprintf("%s.%d", c.path, i)
-		newP := fmt.Sprintf("%s.%d", c.path, i+1)
-		_ = os.Rename(oldP, newP) // ignore: file may not exist yet
-	}
-	if _, err := os.Stat(c.path); err == nil {
-		_ = os.Rename(c.path, c.path+".1")
 	}
 
 	// atomic write: temp + rename

--- a/pkg/agent/catalog_test.go
+++ b/pkg/agent/catalog_test.go
@@ -17,9 +17,9 @@ func TestCatalog_RoundTrip(t *testing.T) {
 		t.Fatalf("expected empty catalog, got %d", cat.Len())
 	}
 
-	cat.Upsert("p-aaa", "user <*> failed login", "src1", 5, 0.2, "", "")
-	cat.Upsert("p-bbb", "connection refused <*>", "src1", 12, 0.2, "", "")
-	cat.Upsert("p-aaa", "user <*> failed login", "src1", 3, 0.2, "", "")
+	cat.Upsert("p-aaa", "user <*> failed login", "src1", 5, 0.2, "")
+	cat.Upsert("p-bbb", "connection refused <*>", "src1", 12, 0.2, "")
+	cat.Upsert("p-aaa", "user <*> failed login", "src1", 3, 0.2, "")
 
 	if cat.Len() != 2 {
 		t.Errorf("expected 2 patterns, got %d", cat.Len())
@@ -54,16 +54,16 @@ func TestCatalog_RoundTrip(t *testing.T) {
 func TestCatalog_LabelAndDelete(t *testing.T) {
 	dir := t.TempDir()
 	cat, _ := LoadCatalog(filepath.Join(dir, "patterns.json"))
-	cat.Upsert("p-x", "hello <*>", "src", 1, 0.2, "", "")
+	cat.Upsert("p-x", "hello <*>", "src", 1, 0.2, "")
 
-	if !cat.Label("p-x", "high", "auth-failure", []string{"auth", "noisy"}) {
+	if !cat.Label("p-x", "known", []string{"auth", "noisy"}) {
 		t.Fatalf("Label should return true for existing pattern")
 	}
-	if cat.Label("missing", "high", "x", nil) {
+	if cat.Label("missing", "known", nil) {
 		t.Fatalf("Label should return false for missing pattern")
 	}
 	got := cat.Get("p-x")
-	if got.Severity != "high" || got.Label != "auth-failure" || len(got.Tags) != 2 {
+	if got.Verdict != "known" || len(got.Tags) != 2 {
 		t.Errorf("label not applied: %+v", got)
 	}
 
@@ -82,28 +82,27 @@ func TestCatalog_UpsertAppliesRegexTag(t *testing.T) {
 	dir := t.TempDir()
 	cat, _ := LoadCatalog(filepath.Join(dir, "patterns.json"))
 
-	// First-seen with named rule -> label + severity stored.
-	cat.Upsert("p-1", "Out of memory <*>", "src", 1, 0.2, "oom-killer", "critical")
-	got := cat.Get("p-1")
-	if got.Severity != "critical" || got.Label != "oom-killer" {
-		t.Errorf("expected critical/oom-killer, got %+v", got)
+	// First-seen with named rule -> RuleName stored.
+	cat.Upsert("p-1", "Out of memory <*>", "src", 1, 0.2, "oom-killer")
+	if got := cat.Get("p-1"); got.RuleName != "oom-killer" {
+		t.Errorf("expected oom-killer, got %+v", got)
 	}
 
-	// First-seen with default rule -> severity stored.
-	cat.Upsert("p-2", "something <*>", "src", 1, 0.2, "default", "low")
-	if got := cat.Get("p-2"); got.Severity != "low" || got.Label != "default" {
-		t.Errorf("expected low/default, got %+v", got)
+	// First-seen with default rule -> RuleName=default.
+	cat.Upsert("p-2", "something <*>", "src", 1, 0.2, "default")
+	if got := cat.Get("p-2"); got.RuleName != "default" {
+		t.Errorf("expected default, got %+v", got)
 	}
 
 	// Default rule first, then named rule -> promote.
-	cat.Upsert("p-2", "something <*>", "src", 1, 0.2, "panic", "critical")
-	if got := cat.Get("p-2"); got.Severity != "critical" || got.Label != "panic" {
-		t.Errorf("expected promotion to critical/panic, got %+v", got)
+	cat.Upsert("p-2", "something <*>", "src", 1, 0.2, "panic")
+	if got := cat.Get("p-2"); got.RuleName != "panic" {
+		t.Errorf("expected promotion to panic, got %+v", got)
 	}
 
 	// Named rule first, then default -> stay with the named one.
-	cat.Upsert("p-1", "Out of memory <*>", "src", 1, 0.2, "default", "low")
-	if got := cat.Get("p-1"); got.Severity != "critical" || got.Label != "oom-killer" {
+	cat.Upsert("p-1", "Out of memory <*>", "src", 1, 0.2, "default")
+	if got := cat.Get("p-1"); got.RuleName != "oom-killer" {
 		t.Errorf("named tag should not be downgraded, got %+v", got)
 	}
 }

--- a/pkg/agent/miner.go
+++ b/pkg/agent/miner.go
@@ -189,11 +189,12 @@ func (m *Miner) indexCluster(c *MinerCluster) {
 
 // Variable detectors used during tokenization. Anything matching becomes <*>.
 var (
-	reNumber = regexp.MustCompile(`^[\-+]?[0-9]+(\.[0-9]+)?$`)
-	reHex    = regexp.MustCompile(`^0x[0-9a-fA-F]+$`)
-	reUUID   = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
-	reIPv4   = regexp.MustCompile(`^(\d{1,3}\.){3}\d{1,3}(:\d+)?$`)
-	reLong   = regexp.MustCompile(`^[A-Fa-f0-9]{16,}$`) // long hashes / IDs
+	reNumber   = regexp.MustCompile(`^[\-+]?[0-9]+(\.[0-9]+)?$`)
+	reHex      = regexp.MustCompile(`^0x[0-9a-fA-F]+$`)
+	reUUID     = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	reIPv4     = regexp.MustCompile(`^(\d{1,3}\.){3}\d{1,3}(:\d+)?$`)
+	reLong     = regexp.MustCompile(`^[A-Fa-f0-9]{16,}$`) // long hashes / IDs
+	reAlphaNum = regexp.MustCompile(`^[A-Za-z0-9_./:\-]+$`)
 	// REDACTED tokens emitted by the redactor are treated as wildcards.
 	reRedacted = regexp.MustCompile(`^<REDACTED:[^>]+>$`)
 )
@@ -232,6 +233,28 @@ func isVariable(t string) bool {
 	if reNumber.MatchString(t) || reHex.MatchString(t) || reUUID.MatchString(t) ||
 		reIPv4.MatchString(t) || reLong.MatchString(t) {
 		return true
+	}
+	if reAlphaNum.MatchString(t) && hasLetter(t) && hasDigit(t) {
+		return true
+	}
+	return false
+}
+
+func hasLetter(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDigit(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= '0' && s[i] <= '9' {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/agent/regex.go
+++ b/pkg/agent/regex.go
@@ -7,11 +7,10 @@ import (
 	"github.com/VersusControl/versus-incident/pkg/config"
 )
 
-// RegexRule is a compiled user-defined rule plus its severity tag.
+// RegexRule is a compiled user-defined rule.
 type RegexRule struct {
-	Name     string
-	Severity string
-	Pattern  *regexp.Regexp
+	Name    string
+	Pattern *regexp.Regexp
 }
 
 // RegexMatcher is a small helper around a list of RegexRule plus an optional
@@ -36,7 +35,7 @@ func NewRegexMatcher(cfg config.AgentRegexConfig) (*RegexMatcher, []error) {
 		if err != nil {
 			errs = append(errs, fmt.Errorf("regex.default_pattern %q: %w", cfg.DefaultPattern, err))
 		} else {
-			m.defaultRule = &RegexRule{Name: "default", Severity: "low", Pattern: re}
+			m.defaultRule = &RegexRule{Name: "default", Pattern: re}
 		}
 	}
 
@@ -50,7 +49,7 @@ func NewRegexMatcher(cfg config.AgentRegexConfig) (*RegexMatcher, []error) {
 			errs = append(errs, fmt.Errorf("regex rule %q: %w", r.Name, err))
 			continue
 		}
-		m.rules = append(m.rules, RegexRule{Name: r.Name, Severity: r.Severity, Pattern: re})
+		m.rules = append(m.rules, RegexRule{Name: r.Name, Pattern: re})
 	}
 	return m, errs
 }
@@ -58,8 +57,7 @@ func NewRegexMatcher(cfg config.AgentRegexConfig) (*RegexMatcher, []error) {
 // MatchResult is the (possibly empty) tag returned by Match.
 type MatchResult struct {
 	RuleName string // empty when no rule matched
-	Severity string
-	Default  bool // true when only the default pattern matched
+	Default  bool   // true when only the default pattern matched
 }
 
 // Matched reports whether at least one rule (named or default) hit. The
@@ -77,11 +75,11 @@ func (m *RegexMatcher) Match(message string) MatchResult {
 	}
 	for _, r := range m.rules {
 		if r.Pattern.MatchString(message) {
-			return MatchResult{RuleName: r.Name, Severity: r.Severity}
+			return MatchResult{RuleName: r.Name}
 		}
 	}
 	if m.defaultRule != nil && m.defaultRule.Pattern.MatchString(message) {
-		return MatchResult{RuleName: m.defaultRule.Name, Severity: m.defaultRule.Severity, Default: true}
+		return MatchResult{RuleName: m.defaultRule.Name, Default: true}
 	}
 	return MatchResult{}
 }

--- a/pkg/agent/shadow.go
+++ b/pkg/agent/shadow.go
@@ -1,0 +1,284 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+// ShadowEvent is one "we would have alerted on this" record produced by the
+// worker while running in shadow mode. Events are coalesced per
+// (source, pattern_id): repeat hits update Count / LastSeen / Occurrences
+// rather than appending new rows, so the on-disk log stays small and
+// operator-reviewable.
+type ShadowEvent struct {
+	PatternID     string    `json:"pattern_id"`
+	Template      string    `json:"template"`
+	Source        string    `json:"source"`
+	RuleName      string    `json:"rule_name,omitempty"`
+	Verdict       string    `json:"verdict"` // "unknown" | "spike"
+	SampleMessage string    `json:"sample_message"`
+	Count         int       `json:"count"`       // total signals across all ticks
+	Occurrences   int       `json:"occurrences"` // number of ticks that flagged this
+	FirstSeen     time.Time `json:"first_seen"`
+	LastSeen      time.Time `json:"last_seen"`
+}
+
+// ShadowLog is the in-memory + on-disk store of shadow-mode verdicts.
+//
+// All public methods are safe for concurrent use. Disk persistence is
+// debounced — Record sets a dirty flag that the worker flushes at most once
+// per `persist_interval`.
+type ShadowLog struct {
+	mu     sync.RWMutex
+	path   string
+	events map[string]*ShadowEvent // key = source + "\x00" + pattern_id
+	max    int
+	dirty  bool
+}
+
+// shadowFile is the on-disk schema. Versioned for future evolution.
+type shadowFile struct {
+	Version   int            `json:"version"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	Events    []*ShadowEvent `json:"events"`
+}
+
+const (
+	shadowFileVersion = 1
+	// shadowDefaultMax bounds the number of distinct (source, pattern)
+	// events kept in the log. When exceeded, the oldest by LastSeen is
+	// evicted on the next Record. 1000 is comfortably large for review
+	// while keeping the JSON file under a few hundred KB.
+	shadowDefaultMax = 1000
+	// shadowSampleMaxBytes bounds the SampleMessage field so a giant log
+	// line can't blow up the shadow file.
+	shadowSampleMaxBytes = 512
+)
+
+// LoadShadowLog opens an existing shadow log at `path` or returns an empty
+// one when no file is present. `max` caps distinct events; pass 0 for the
+// default. An empty path disables persistence (in-memory only).
+func LoadShadowLog(path string, max int) (*ShadowLog, error) {
+	if max <= 0 {
+		max = shadowDefaultMax
+	}
+	s := &ShadowLog{
+		path:   path,
+		events: make(map[string]*ShadowEvent),
+		max:    max,
+	}
+	if path == "" {
+		return s, nil
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return s, nil
+	}
+	if err != nil {
+		return s, fmt.Errorf("read shadow log: %w", err)
+	}
+	var f shadowFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		// Don't hard-fail on a corrupt shadow log: it's a debug artifact, not
+		// the source of truth. Start fresh and let the worker rebuild it.
+		return s, fmt.Errorf("parse shadow log %s: %w (starting fresh)", path, err)
+	}
+	for _, e := range f.Events {
+		if e == nil || e.PatternID == "" {
+			continue
+		}
+		s.events[shadowKey(e.Source, e.PatternID)] = e
+	}
+	return s, nil
+}
+
+func shadowKey(source, patternID string) string {
+	return source + "\x00" + patternID
+}
+
+// Record merges a shadow-mode hit into the log. The record is coalesced per
+// (source, pattern_id); repeat hits bump Count and Occurrences instead of
+// appending a new entry. `freq` is the number of signals observed in the
+// current worker tick.
+func (s *ShadowLog) Record(source, patternID, template, sample, rule, verdict string, freq int) {
+	if patternID == "" {
+		return
+	}
+	if freq <= 0 {
+		freq = 1
+	}
+	if len(sample) > shadowSampleMaxBytes {
+		sample = sample[:shadowSampleMaxBytes] + "…"
+	}
+	now := time.Now().UTC()
+	k := shadowKey(source, patternID)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if e, ok := s.events[k]; ok {
+		e.Template = template // keep refreshed as the miner refines it
+		e.Verdict = verdict
+		if rule != "" {
+			e.RuleName = rule
+		}
+		if sample != "" {
+			e.SampleMessage = sample
+		}
+		e.Count += freq
+		e.Occurrences++
+		e.LastSeen = now
+		s.dirty = true
+		return
+	}
+
+	// New entry — evict oldest if we're at capacity.
+	if len(s.events) >= s.max {
+		s.evictOldestLocked()
+	}
+	s.events[k] = &ShadowEvent{
+		PatternID:     patternID,
+		Template:      template,
+		Source:        source,
+		RuleName:      rule,
+		Verdict:       verdict,
+		SampleMessage: sample,
+		Count:         freq,
+		Occurrences:   1,
+		FirstSeen:     now,
+		LastSeen:      now,
+	}
+	s.dirty = true
+}
+
+// evictOldestLocked drops the event with the oldest LastSeen.
+// Caller must hold s.mu (write lock).
+func (s *ShadowLog) evictOldestLocked() {
+	var oldestKey string
+	var oldestTime time.Time
+	first := true
+	for k, e := range s.events {
+		if first || e.LastSeen.Before(oldestTime) {
+			oldestKey = k
+			oldestTime = e.LastSeen
+			first = false
+		}
+	}
+	if oldestKey != "" {
+		delete(s.events, oldestKey)
+	}
+}
+
+// All returns a snapshot of every shadow event, sorted by LastSeen
+// descending (most recent first). Returned events are copies — callers
+// cannot mutate the log.
+func (s *ShadowLog) All() []*ShadowEvent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]*ShadowEvent, 0, len(s.events))
+	for _, e := range s.events {
+		cp := *e
+		out = append(out, &cp)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].LastSeen.After(out[j].LastSeen) })
+	return out
+}
+
+// Len returns the number of distinct (source, pattern) events.
+func (s *ShadowLog) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.events)
+}
+
+// Stats returns aggregate counts useful for /api/agent/shadow/stats.
+func (s *ShadowLog) Stats() map[string]int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	stats := map[string]int{
+		"events":            len(s.events),
+		"total_signals":     0,
+		"verdict_unknown":   0,
+		"verdict_spike":     0,
+		"total_occurrences": 0,
+	}
+	for _, e := range s.events {
+		stats["total_signals"] += e.Count
+		stats["total_occurrences"] += e.Occurrences
+		switch e.Verdict {
+		case "unknown":
+			stats["verdict_unknown"]++
+		case "spike":
+			stats["verdict_spike"]++
+		}
+	}
+	return stats
+}
+
+// Clear removes every event. The change is persisted on the next Persist.
+func (s *ShadowLog) Clear() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := len(s.events)
+	if n == 0 {
+		return 0
+	}
+	s.events = make(map[string]*ShadowEvent)
+	s.dirty = true
+	return n
+}
+
+// Dirty reports whether there are unflushed changes.
+func (s *ShadowLog) Dirty() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.dirty
+}
+
+// Persist atomically writes the shadow log to disk. Safe to call concurrently
+// with Record / Clear. No-op when path is empty (in-memory mode).
+func (s *ShadowLog) Persist() error {
+	if s.path == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.dirty {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return fmt.Errorf("mkdir shadow log: %w", err)
+	}
+
+	// Materialize a stable, sorted slice (most-recent first) so the file
+	// diffs cleanly across runs.
+	out := make([]*ShadowEvent, 0, len(s.events))
+	for _, e := range s.events {
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].LastSeen.After(out[j].LastSeen) })
+
+	f := shadowFile{
+		Version:   shadowFileVersion,
+		UpdatedAt: time.Now().UTC(),
+		Events:    out,
+	}
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal shadow log: %w", err)
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write tmp shadow log: %w", err)
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		return fmt.Errorf("rename tmp shadow log: %w", err)
+	}
+	s.dirty = false
+	return nil
+}

--- a/pkg/agent/shadow_test.go
+++ b/pkg/agent/shadow_test.go
@@ -1,0 +1,180 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestShadowLog_RecordCoalescesByPattern(t *testing.T) {
+	s, err := LoadShadowLog("", 0)
+	if err != nil {
+		t.Fatalf("LoadShadowLog: %v", err)
+	}
+
+	s.Record("src-a", "p1", "tmpl one", "msg one", "oom", "unknown", 3)
+	s.Record("src-a", "p1", "tmpl one v2", "msg two", "oom", "unknown", 2)
+	s.Record("src-a", "p2", "tmpl two", "other", "", "unknown", 1)
+
+	if got := s.Len(); got != 2 {
+		t.Fatalf("Len=%d want 2 (p1 should coalesce)", got)
+	}
+
+	all := s.All()
+	var p1 *ShadowEvent
+	for _, e := range all {
+		if e.PatternID == "p1" {
+			p1 = e
+			break
+		}
+	}
+	if p1 == nil {
+		t.Fatal("p1 not found")
+	}
+	if p1.Count != 5 {
+		t.Errorf("Count=%d want 5", p1.Count)
+	}
+	if p1.Occurrences != 2 {
+		t.Errorf("Occurrences=%d want 2", p1.Occurrences)
+	}
+	if p1.Template != "tmpl one v2" {
+		t.Errorf("Template not refreshed: %q", p1.Template)
+	}
+	if p1.SampleMessage != "msg two" {
+		t.Errorf("SampleMessage not refreshed: %q", p1.SampleMessage)
+	}
+}
+
+func TestShadowLog_RecordEmptyPatternIgnored(t *testing.T) {
+	s, _ := LoadShadowLog("", 0)
+	s.Record("src", "", "tmpl", "msg", "", "unknown", 1)
+	if s.Len() != 0 {
+		t.Fatalf("expected empty, got %d", s.Len())
+	}
+}
+
+func TestShadowLog_EvictsOldestWhenFull(t *testing.T) {
+	s, _ := LoadShadowLog("", 3)
+	// Insert with monotonically advancing LastSeen so eviction is deterministic.
+	for i := 0; i < 5; i++ {
+		s.Record("src", "p"+string(rune('a'+i)), "tmpl", "msg", "", "unknown", 1)
+		// Force a measurable LastSeen difference.
+		time.Sleep(2 * time.Millisecond)
+	}
+	if s.Len() != 3 {
+		t.Fatalf("Len=%d want 3 (cap)", s.Len())
+	}
+	// The two earliest (pa, pb) should have been evicted.
+	for _, gone := range []string{"pa", "pb"} {
+		for _, e := range s.All() {
+			if e.PatternID == gone {
+				t.Errorf("expected %s evicted, still present", gone)
+			}
+		}
+	}
+}
+
+func TestShadowLog_SampleMessageTruncated(t *testing.T) {
+	s, _ := LoadShadowLog("", 0)
+	huge := strings.Repeat("x", shadowSampleMaxBytes+200)
+	s.Record("src", "p1", "tmpl", huge, "", "unknown", 1)
+	got := s.All()[0].SampleMessage
+	if len(got) > shadowSampleMaxBytes+10 { // +ellipsis bytes
+		t.Errorf("SampleMessage not truncated: len=%d", len(got))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("expected truncation ellipsis, got tail %q", got[len(got)-5:])
+	}
+}
+
+func TestShadowLog_PersistAndReload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shadow.json")
+
+	s, err := LoadShadowLog(path, 0)
+	if err != nil {
+		t.Fatalf("LoadShadowLog: %v", err)
+	}
+	s.Record("src", "p1", "tmpl one", "msg one", "oom", "unknown", 4)
+	s.Record("src", "p2", "tmpl two", "msg two", "", "spike", 7)
+	if !s.Dirty() {
+		t.Fatal("expected dirty after Record")
+	}
+	if err := s.Persist(); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	if s.Dirty() {
+		t.Error("expected clean after Persist")
+	}
+
+	// Reload from disk.
+	s2, err := LoadShadowLog(path, 0)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if s2.Len() != 2 {
+		t.Fatalf("reloaded Len=%d want 2", s2.Len())
+	}
+	stats := s2.Stats()
+	if stats["verdict_unknown"] != 1 || stats["verdict_spike"] != 1 {
+		t.Errorf("verdict stats = %+v", stats)
+	}
+	if stats["total_signals"] != 11 {
+		t.Errorf("total_signals=%d want 11", stats["total_signals"])
+	}
+}
+
+func TestShadowLog_ClearPersists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shadow.json")
+	s, _ := LoadShadowLog(path, 0)
+	s.Record("src", "p1", "t", "m", "", "unknown", 1)
+	if err := s.Persist(); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	if cleared := s.Clear(); cleared != 1 {
+		t.Errorf("Clear=%d want 1", cleared)
+	}
+	if !s.Dirty() {
+		t.Error("expected dirty after Clear")
+	}
+	if err := s.Persist(); err != nil {
+		t.Fatalf("Persist after clear: %v", err)
+	}
+
+	// File should now contain zero events.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var f shadowFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(f.Events) != 0 {
+		t.Errorf("file events=%d want 0", len(f.Events))
+	}
+}
+
+func TestShadowLog_CorruptFileStartsFresh(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shadow.json")
+	if err := os.WriteFile(path, []byte("not json"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	s, err := LoadShadowLog(path, 0)
+	if err == nil {
+		t.Log("LoadShadowLog returned nil err (acceptable: warning-only path)")
+	}
+	if s == nil || s.Len() != 0 {
+		t.Fatalf("expected fresh empty log on corrupt file")
+	}
+	// Should be writable from a clean state.
+	s.Record("src", "p1", "t", "m", "", "unknown", 1)
+	if err := s.Persist(); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+}

--- a/pkg/agent/worker.go
+++ b/pkg/agent/worker.go
@@ -50,6 +50,7 @@ type Worker struct {
 	matcher  *RegexMatcher
 	miner    *Miner
 	catalog  *Catalog
+	shadow   *ShadowLog // nil when shadow log is disabled
 
 	pollInterval time.Duration
 	persistEvery time.Duration
@@ -67,6 +68,7 @@ type WorkerOptions struct {
 	Matcher  *RegexMatcher
 	Miner    *Miner
 	Catalog  *Catalog
+	Shadow   *ShadowLog // optional; pass nil to disable shadow recording
 }
 
 // NewWorker validates options and applies defaults.
@@ -79,6 +81,7 @@ func NewWorker(opt WorkerOptions) (*Worker, error) {
 		matcher:  opt.Matcher,
 		miner:    opt.Miner,
 		catalog:  opt.Catalog,
+		shadow:   opt.Shadow,
 	}
 
 	if len(w.sources) == 0 {
@@ -128,6 +131,11 @@ func (w *Worker) Run(ctx context.Context) {
 			if err := w.catalog.Persist(); err != nil {
 				log.Printf("agent: final catalog flush failed: %v", err)
 			}
+			if w.shadow != nil {
+				if err := w.shadow.Persist(); err != nil {
+					log.Printf("agent: final shadow flush failed: %v", err)
+				}
+			}
 			return
 		case <-tick.C:
 			w.tick(ctx, mode)
@@ -137,6 +145,13 @@ func (w *Worker) Run(ctx context.Context) {
 					log.Printf("agent: catalog flush failed: %v", err)
 				} else {
 					log.Printf("agent: catalog flushed (%d patterns)", w.catalog.Len())
+				}
+			}
+			if w.shadow != nil && w.shadow.Dirty() {
+				if err := w.shadow.Persist(); err != nil {
+					log.Printf("agent: shadow flush failed: %v", err)
+				} else {
+					log.Printf("agent: shadow log flushed (%d events)", w.shadow.Len())
 				}
 			}
 		}
@@ -228,7 +243,7 @@ func (w *Worker) tickSource(ctx context.Context, src core.SignalSource, mode str
 	// Update catalog and produce verdicts.
 	verdicts := make(map[string]int) // verdict-name → count, for stats
 	for id, b := range buckets {
-		w.catalog.Upsert(id, b.template, src.Name(), len(b.signals), w.ewmaAlpha, b.tag.RuleName, b.tag.Severity)
+		w.catalog.Upsert(id, b.template, src.Name(), len(b.signals), w.ewmaAlpha, b.tag.RuleName)
 
 		tag := b.tag
 
@@ -244,6 +259,14 @@ func (w *Worker) tickSource(ctx context.Context, src core.SignalSource, mode str
 			v := w.classify(id, len(b.signals))
 			verdicts[v.String()]++
 			if v != core.VerdictKnownPattern {
+				sample := ""
+				if len(b.signals) > 0 {
+					sample = b.signals[0].Message
+				}
+				if w.shadow != nil {
+					w.shadow.Record(src.Name(), id, b.template, sample,
+						b.tag.RuleName, v.String(), len(b.signals))
+				}
 				log.Printf("%sagent[shadow]: would alert pattern=%s tag=%s verdict=%s freq=%d%s",
 					colorGreen, id, tag.RuleName, v, len(b.signals), colorReset)
 			}
@@ -284,7 +307,10 @@ func (w *Worker) classify(patternID string, _ int) core.AgentVerdict {
 	if threshold <= 0 {
 		threshold = 100
 	}
-	if p.Severity == "known" || p.Count >= threshold {
+	if p.Verdict == "known" || p.Count >= threshold {
+		if p.Verdict != "known" {
+			w.catalog.MarkKnown(patternID)
+		}
 		return core.VerdictKnownPattern
 	}
 	return core.VerdictUnknown

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -50,6 +50,10 @@ type AgentCatalogConfig struct {
 // Not user-configurable.
 const CatalogFileName = "patterns.json"
 
+// ShadowFileName is the fixed filename for the shadow-mode would-have-alerted
+// log. Lives alongside the catalog under `<data_dir>`.
+const ShadowFileName = "shadow.json"
+
 // ResolvedDataDir returns the configured data dir or the default ("data").
 func (a *AgentConfig) ResolvedDataDir() string {
 	if a.DataDir == "" {
@@ -64,6 +68,12 @@ func (a *AgentConfig) CatalogPath() string {
 	return filepath.Join(a.ResolvedDataDir(), CatalogFileName)
 }
 
+// ShadowPath returns the on-disk path used by the shadow log:
+// `<data_dir>/shadow.json`. The filename is fixed.
+func (a *AgentConfig) ShadowPath() string {
+	return filepath.Join(a.ResolvedDataDir(), ShadowFileName)
+}
+
 type AgentMinerConfig struct {
 	SimilarityThreshold float64 `mapstructure:"similarity_threshold"`
 	TreeDepth           int     `mapstructure:"tree_depth"`
@@ -71,9 +81,8 @@ type AgentMinerConfig struct {
 }
 
 type AgentRegexRule struct {
-	Name     string `mapstructure:"name"`
-	Pattern  string `mapstructure:"pattern"`
-	Severity string `mapstructure:"severity"`
+	Name    string `mapstructure:"name"`
+	Pattern string `mapstructure:"pattern"`
 }
 
 type AgentRegexConfig struct {
@@ -110,6 +119,14 @@ type AgentFileSourceConfig struct {
 	// MaxLineBytes caps a single line's length to protect memory; longer
 	// lines are truncated. Default 64 KiB.
 	MaxLineBytes int `mapstructure:"max_line_bytes"`
+	// MaxLinesPerPull caps the number of lines returned by a single Pull.
+	// When the file has a large backlog (e.g. from_beginning=true on a 100k-
+	// line file), this paginates the backfill across ticks so the worker's
+	// batch_max truncation never silently drops unread tail content. The
+	// byte offset only advances over what was actually consumed in this
+	// Pull, so the next tick resumes exactly where this one stopped.
+	// Default 1000.
+	MaxLinesPerPull int `mapstructure:"max_lines_per_pull"`
 
 	// Text-mode options ------------------------------------------------------
 

--- a/pkg/config/clone_config.go
+++ b/pkg/config/clone_config.go
@@ -295,6 +295,7 @@ func cloneAgentConfig(src AgentConfig) AgentConfig {
 					CursorPath:      s.File.CursorPath,
 					FromBeginning:   s.File.FromBeginning,
 					MaxLineBytes:    s.File.MaxLineBytes,
+					MaxLinesPerPull: s.File.MaxLinesPerPull,
 					TimestampLayout: s.File.TimestampLayout,
 					MessageField:    s.File.MessageField,
 					TimestampField:  s.File.TimestampField,

--- a/pkg/controllers/agent.go
+++ b/pkg/controllers/agent.go
@@ -14,12 +14,14 @@ import (
 // rejected — this is by design: an empty secret must not silently grant access.
 type AgentController struct {
 	catalog *agent.Catalog
+	shadow  *agent.ShadowLog
 }
 
-// NewAgentController wires the catalog into a controller. Pass `cat=nil` if
-// the agent is disabled — in that case every endpoint will return 503.
-func NewAgentController(cat *agent.Catalog) *AgentController {
-	return &AgentController{catalog: cat}
+// NewAgentController wires the catalog and shadow log into a controller.
+// Pass `cat=nil` if the agent is disabled — in that case every endpoint will
+// return 503. `sl` may be nil to disable the shadow endpoints.
+func NewAgentController(cat *agent.Catalog, sl *agent.ShadowLog) *AgentController {
+	return &AgentController{catalog: cat, shadow: sl}
 }
 
 // Register attaches the agent admin endpoints to the given fiber group.
@@ -28,10 +30,14 @@ func NewAgentController(cat *agent.Catalog) *AgentController {
 //
 //	GET    /patterns         list all patterns (sorted by Count desc)
 //	GET    /patterns/:id     get one pattern
-//	POST   /patterns/:id     update severity / label / tags
+//	POST   /patterns/:id     update verdict / tags
 //	DELETE /patterns/:id     remove a pattern
 //	POST   /flush            force-flush the catalog to disk
 //	GET    /status           lightweight status (catalog size, dirty flag)
+//	GET    /shadow           list shadow-mode "would have alerted" events
+//	GET    /shadow/stats     aggregate counts for the shadow log
+//	DELETE /shadow           clear the shadow log
+//	POST   /shadow/flush     force-flush the shadow log to disk
 func (a *AgentController) Register(router fiber.Router) {
 	g := router.Group("/agent", a.authMiddleware)
 	g.Get("/status", a.getStatus)
@@ -40,6 +46,10 @@ func (a *AgentController) Register(router fiber.Router) {
 	g.Post("/patterns/:id", a.updatePattern)
 	g.Delete("/patterns/:id", a.deletePattern)
 	g.Post("/flush", a.flush)
+	g.Get("/shadow", a.listShadow)
+	g.Get("/shadow/stats", a.shadowStats)
+	g.Delete("/shadow", a.clearShadow)
+	g.Post("/shadow/flush", a.flushShadow)
 }
 
 // authMiddleware enforces a shared gateway secret. Clients send the
@@ -57,10 +67,15 @@ func (a *AgentController) authMiddleware(c *fiber.Ctx) error {
 }
 
 func (a *AgentController) getStatus(c *fiber.Ctx) error {
-	return c.JSON(fiber.Map{
+	status := fiber.Map{
 		"patterns": a.catalog.Len(),
 		"dirty":    a.catalog.Dirty(),
-	})
+	}
+	if a.shadow != nil {
+		status["shadow_events"] = a.shadow.Len()
+		status["shadow_dirty"] = a.shadow.Dirty()
+	}
+	return c.JSON(status)
 }
 
 func (a *AgentController) listPatterns(c *fiber.Ctx) error {
@@ -77,9 +92,8 @@ func (a *AgentController) getPattern(c *fiber.Ctx) error {
 }
 
 type updatePatternRequest struct {
-	Severity string   `json:"severity"`
-	Label    string   `json:"label"`
-	Tags     []string `json:"tags"`
+	Verdict string   `json:"verdict"`
+	Tags    []string `json:"tags"`
 }
 
 func (a *AgentController) updatePattern(c *fiber.Ctx) error {
@@ -88,7 +102,7 @@ func (a *AgentController) updatePattern(c *fiber.Ctx) error {
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid body"})
 	}
-	if !a.catalog.Label(id, req.Severity, req.Label, req.Tags) {
+	if !a.catalog.Label(id, req.Verdict, req.Tags) {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "not found"})
 	}
 	return c.JSON(a.catalog.Get(id))
@@ -107,4 +121,44 @@ func (a *AgentController) flush(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
 	return c.JSON(fiber.Map{"ok": true, "patterns": a.catalog.Len()})
+}
+
+// listShadow returns every shadow-mode event sorted most-recent first.
+func (a *AgentController) listShadow(c *fiber.Ctx) error {
+	if a.shadow == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "shadow log not enabled"})
+	}
+	return c.JSON(fiber.Map{"events": a.shadow.All()})
+}
+
+// shadowStats returns aggregate counts for the shadow log (events,
+// total_signals, verdicts, occurrences).
+func (a *AgentController) shadowStats(c *fiber.Ctx) error {
+	if a.shadow == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "shadow log not enabled"})
+	}
+	return c.JSON(a.shadow.Stats())
+}
+
+// clearShadow drops every event and persists the empty log.
+func (a *AgentController) clearShadow(c *fiber.Ctx) error {
+	if a.shadow == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "shadow log not enabled"})
+	}
+	n := a.shadow.Clear()
+	if err := a.shadow.Persist(); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+	return c.JSON(fiber.Map{"ok": true, "cleared": n})
+}
+
+// flushShadow force-writes the shadow log to disk.
+func (a *AgentController) flushShadow(c *fiber.Ctx) error {
+	if a.shadow == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "shadow log not enabled"})
+	}
+	if err := a.shadow.Persist(); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+	return c.JSON(fiber.Map{"ok": true, "events": a.shadow.Len()})
 }

--- a/pkg/signalsources/file.go
+++ b/pkg/signalsources/file.go
@@ -45,11 +45,12 @@ type FileSource struct {
 
 // Defaults applied when the corresponding option is empty / zero.
 const (
-	defaultFileFormat         = "text"
-	defaultFileMaxLineBytes   = 64 * 1024
-	defaultJSONMessageField   = "message"
-	defaultJSONTimestampField = "@timestamp"
-	defaultJSONSeverityField  = "level"
+	defaultFileFormat          = "text"
+	defaultFileMaxLineBytes    = 64 * 1024
+	defaultFileMaxLinesPerPull = 1000
+	defaultJSONMessageField    = "message"
+	defaultJSONTimestampField  = "@timestamp"
+	defaultJSONSeverityField   = "level"
 )
 
 // defaultTextTimestampLayouts are tried in order when TimestampLayout is empty.
@@ -148,8 +149,12 @@ func (s *FileSource) Pull(_ context.Context, _ time.Time) ([]core.Signal, time.T
 	if maxLine <= 0 {
 		maxLine = defaultFileMaxLineBytes
 	}
+	maxLines := s.cfg.MaxLinesPerPull
+	if maxLines <= 0 {
+		maxLines = defaultFileMaxLinesPerPull
+	}
 
-	signals, bytesRead, err := s.readSignals(f, maxLine)
+	signals, bytesRead, err := s.readSignals(f, maxLine, maxLines)
 	// Advance offset by what we successfully consumed even if we hit a
 	// read error mid-stream — so we don't infinitely re-read a bad line.
 	s.offset += bytesRead
@@ -165,8 +170,11 @@ func (s *FileSource) Pull(_ context.Context, _ time.Time) ([]core.Signal, time.T
 
 // readSignals reads complete lines from r and converts them to signals.
 // It returns the number of bytes consumed (so the caller can advance the
-// persistent offset by exactly that much) plus any non-EOF error.
-func (s *FileSource) readSignals(r io.Reader, maxLine int) ([]core.Signal, int64, error) {
+// persistent offset by exactly that much) plus any non-EOF error. When
+// maxLines > 0 the loop stops after that many lines have been emitted as
+// signals, leaving the rest for the next Pull (the byte offset only
+// advances over the lines this call actually consumed).
+func (s *FileSource) readSignals(r io.Reader, maxLine, maxLines int) ([]core.Signal, int64, error) {
 	br := bufio.NewReaderSize(r, 64*1024)
 	var signals []core.Signal
 	var consumed int64
@@ -191,6 +199,9 @@ func (s *FileSource) readSignals(r io.Reader, maxLine int) ([]core.Signal, int64
 				return signals, consumed, nil
 			}
 			return signals, consumed, err
+		}
+		if maxLines > 0 && len(signals) >= maxLines {
+			return signals, consumed, nil
 		}
 	}
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -71,7 +71,7 @@ sources:
 If you want a clean run, clear the agent's stored state first:
 
 ```bash
-rm -f data/patterns.json data/patterns.json.* \
+rm -f data/patterns.json \
       local/resource/.versus-cursor-noisy-app
 ```
 

--- a/scripts/generate_noisy_logs.py
+++ b/scripts/generate_noisy_logs.py
@@ -257,6 +257,97 @@ def t_metrics_export() -> tuple[str, str]:
     return "INFO ", f'service=metrics message="exported metrics batch" count={random.randint(50, 500)} region={random.choice(REGIONS)}'
 
 
+# -----------------------------------------------------------------------------
+# Production-style anomaly templates
+#
+# Lines that look like things you might genuinely see (and want to be paged
+# about) on a real production cluster: kernel OOM, segfaults, data corruption,
+# expired TLS certs, NTP skew, replication lag, lost quorum, unexpected
+# shutdowns. They get LOW weights so they remain rare — exactly the kind of
+# signal the agent is supposed to surface in shadow / detect mode.
+# -----------------------------------------------------------------------------
+def t_kernel_oom_distinct() -> tuple[str, str]:
+    pid = random.randint(1000, 30000)
+    container = random.choice(["versus-worker", "versus-agent", "versus-api"])
+    return "ERROR", (
+        f'kernel: Out of memory: Killed process {pid} ({container}) '
+        f'score 999 anon-rss:2097152kB total-vm:8388608kB'
+    )
+
+
+def t_segfault() -> tuple[str, str]:
+    pid = random.randint(1000, 30000)
+    return "ERROR", (
+        f'kernel: worker[{pid}]: segfault at 7f3c8b21d000 ip 00007f3c8b21d042 '
+        f'sp 00007ffc12345678 error 4 in libc.so.6'
+    )
+
+
+def t_data_corruption() -> tuple[str, str]:
+    incident = uuid.uuid4()
+    return "ERROR", (
+        f'service=storage message="checksum mismatch detected: data corruption '
+        f'on disk" incident_id={incident} expected=sha256:a1b2c3 got=sha256:deadbeef'
+    )
+
+
+def t_security_breach() -> tuple[str, str]:
+    return "ERROR", (
+        f'service=auth message="security alert: privilege escalation attempt detected" '
+        f'user=root source_ip={random_ip()} target_role=admin action=BLOCKED'
+    )
+
+
+def t_quorum_lost() -> tuple[str, str]:
+    cluster = random.choice(["raft-incidents", "raft-oncall", "etcd-main"])
+    return "ERROR", (
+        f'service=cluster message="quorum lost" cluster={cluster} '
+        f'healthy_nodes=1 required=2 leader=unknown'
+    )
+
+
+def t_clock_skew() -> tuple[str, str]:
+    host = random.choice(HOSTS)
+    skew = random.randint(60, 600)
+    return "ERROR", (
+        f'service=monitor host={host} message="NTP clock skew exceeds threshold" '
+        f'offset_seconds={skew} action=service_paused'
+    )
+
+
+def t_certificate_expired() -> tuple[str, str]:
+    host = random.choice(TLS_HOSTS)
+    return "ERROR", (
+        f'service=notifier message="x509 certificate expired" host={host} '
+        f'expired_at=2026-04-29T00:00:00Z chain_position=leaf'
+    )
+
+
+def t_replication_lag() -> tuple[str, str]:
+    host = random.choice(DB_HOSTS)
+    lag = random.randint(300, 1800)
+    return "ERROR", (
+        f'service=db-replica replica={host} message="replication lag exceeds RPO" '
+        f'lag_seconds={lag} primary=db-primary'
+    )
+
+
+def t_kernel_taint() -> tuple[str, str]:
+    host = random.choice(HOSTS)
+    return "ERROR", (
+        f'kernel: {host} tainted: G W loaded module=nvidia_uvm '
+        f'reason="unsigned module loaded into kernel"'
+    )
+
+
+def t_unexpected_shutdown() -> tuple[str, str]:
+    pod = random.choice(PODS)
+    return "ERROR", (
+        f'service=k8s message="unexpected SIGTERM received before grace period" '
+        f'pod={pod} signal=15 grace_seconds_remaining=27'
+    )
+
+
 # (template_fn, weight)
 TEMPLATES: list[tuple[callable, int]] = [
     # Very common (the noisy baseline the agent should cluster as "boring")
@@ -295,6 +386,16 @@ TEMPLATES: list[tuple[callable, int]] = [
     (t_cron_fail, 1),
     (t_oom_killer, 1),
     (t_panic, 1),
+    (t_kernel_oom_distinct, 1),
+    (t_segfault, 1),
+    (t_data_corruption, 1),
+    (t_security_breach, 1),
+    (t_quorum_lost, 1),
+    (t_clock_skew, 1),
+    (t_certificate_expired, 1),
+    (t_replication_lag, 1),
+    (t_kernel_taint, 1),
+    (t_unexpected_shutdown, 1),
 ]
 
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -18,6 +18,7 @@
 # AI Agent
 - [Introduction](./agent/agent-introduction.md)
 - [Getting Started](./agent/getting-started.md)
+- [Shadow Mode](./agent/shadow-mode.md)
 - [Configuration](./agent/configuration.md)
 - [RedAction](./agent/redaction.md)
 - [Catalog](./agent/catalog.md)

--- a/src/agent/agent-introduction.md
+++ b/src/agent/agent-introduction.md
@@ -67,8 +67,9 @@ IDs, IPs, etc.). Configurable similarity threshold and tree depth.
 
 ### 5. [Catalog](./catalog.md)
 Long-term memory. Every template the miner produces is stored with a
-first-seen timestamp, sighting count, EWMA frequency, and operator-
-assignable label/severity/tags. Persisted as `data/patterns.json` (atomic
+first-seen timestamp, sighting count, EWMA frequency, the regex
+`rule_name` that flagged it, and an operator-curated verdict / tags.
+Persisted as `data/patterns.json` (atomic
 writes, rotated backups).
 
 ### 6. Worker & modes

--- a/src/agent/configuration.md
+++ b/src/agent/configuration.md
@@ -105,8 +105,7 @@ catalog:
 | `auto_promote_after` | int | `100` | A pattern seen this many times in `detect` mode is treated as known (won't alert). `0` disables the promotion. |
 
 The on-disk filename is fixed (`patterns.json`); the only configurable
-part is `data_dir`. The file is written atomically (tmp + rename) and
-five rotated backups are kept (`patterns.json.1` … `.5`).
+part is `data_dir`.
 
 ---
 
@@ -144,19 +143,16 @@ regex:
   rules:
     - name: oom-killer
       pattern: "Out of memory: Killed process"
-      severity: critical
     - name: panic
       pattern: "(?i)panic:"
-      severity: critical
     - name: 5xx-burst
       pattern: "HTTP/[0-9.]+\\s+5\\d\\d"
-      severity: high
 ```
 
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `default_pattern` | regex | `""` | Catch-all tried after every named rule misses. Empty = nothing matches by default → strict mode. `".*"` = learn from every line. |
-| `rules` | list | `[]` | Named rules. First match wins. Each rule has `name`, `pattern`, `severity`. |
+| `rules` | list | `[]` | Named rules. First match wins. Each rule has `name` and `pattern`. The matched `name` is stored on the pattern as `rule_name` so you can cross-reference shadow events back to the rule that flagged them. |
 
 Common recipes:
 
@@ -223,12 +219,75 @@ file:
   from_beginning: true        # replay-like; false tails from EOF
   cursor_path: ""             # default: <data_dir>/cursors/file-<name>.cursor
   max_line_bytes: 65536
+  max_lines_per_pull: 1000    # cap signals returned per tick; the rest carries to the next Pull
   timestamp_layout: ""        # Go time layout; empty = auto
   # JSON-mode only:
   message_field: message
   timestamp_field: "@timestamp"
   severity_field: level
 ```
+
+> When you start the agent against an existing log file with
+> `from_beginning: true`, the source paginates the backlog
+> `max_lines_per_pull` lines at a time. Each tick advances the byte
+> offset only over what was actually consumed, so a multi-million-line
+> file is drained safely across many ticks.
+
+#### `max_lines_per_pull` vs `agent.batch_max`
+
+These two caps look similar but live at different layers and protect
+against different things. Both apply on every tick, in this order:
+
+1. **`max_lines_per_pull`** (per-source, file source only). The file
+   source stops reading after this many non-empty lines and persists
+   its byte offset there. Lines past the cap stay in the file and are
+   read on the next tick — nothing is lost.
+2. **`agent.batch_max`** (worker-wide, every source). After the source
+   returns, the worker truncates the slice to `batch_max` and **drops**
+   anything beyond it. The source's cursor has already advanced, so
+   dropped signals are gone. This is a backstop for runaway sources,
+   not a normal flow-control knob.
+
+The practical rule: keep `max_lines_per_pull ≤ agent.batch_max`. If you
+flip them around, the worker's hard truncation kicks in and you lose
+signals on every tick.
+
+##### Worked example
+
+Suppose you have a 50,000-line backlog, `poll_interval: 30s`,
+`max_lines_per_pull: 1000`, and `agent.batch_max: 1000`:
+
+| Tick | Lines read by file source | After `batch_max` | Cursor advances by | Remaining backlog |
+|---|---|---|---|---|
+| 1 | 1,000 | 1,000 | 1,000 | 49,000 |
+| 2 | 1,000 | 1,000 | 1,000 | 48,000 |
+| … | … | … | … | … |
+| 50 | 1,000 | 1,000 | 1,000 | 0 |
+
+Total drain time: 50 ticks × 30s ≈ **25 minutes**. Nothing is dropped.
+
+To drain faster, raise `max_lines_per_pull` *and* `agent.batch_max`
+together, e.g. both to `5000`:
+
+| Tick | Read | After `batch_max` | Cursor | Remaining |
+|---|---|---|---|---|
+| 1 | 5,000 | 5,000 | 5,000 | 45,000 |
+| … | … | … | … | … |
+| 10 | 5,000 | 5,000 | 5,000 | 0 |
+
+Drain time: 10 ticks × 30s ≈ **5 minutes**.
+
+What happens if you only raise one of them? With
+`max_lines_per_pull: 5000` but `agent.batch_max: 1000`:
+
+| Tick | Read | After `batch_max` | Cursor | Lost |
+|---|---|---|---|---|
+| 1 | 5,000 | 1,000 | **5,000** | **4,000** |
+| 2 | 5,000 | 1,000 | **5,000** | **4,000** |
+
+The cursor jumps 5,000 lines forward on every tick but only 1,000 are
+actually mined — the other 4,000 are silently discarded. Always raise
+the two caps together.
 
 ### `elasticsearch` source
 
@@ -274,7 +333,7 @@ are not registered and the agent refuses to start.
 | `GET` | `/api/agent/status` | Catalog size, dirty flag, persist-interval, mode. |
 | `GET` | `/api/agent/patterns` | All patterns, sorted by sighting count desc. |
 | `GET` | `/api/agent/patterns/:id` | One pattern. |
-| `POST` | `/api/agent/patterns/:id` | Update `severity`, `label`, and/or `tags`. |
+| `POST` | `/api/agent/patterns/:id` | Update `verdict` and/or `tags`. |
 | `DELETE` | `/api/agent/patterns/:id` | Remove a pattern from the catalog. |
 | `POST` | `/api/agent/flush` | Force-flush the in-memory catalog to disk. |
 
@@ -283,7 +342,7 @@ Example:
 ```bash
 curl -H "X-Gateway-Secret: $AGENT_GATEWAY_SECRET" \
   -H 'Content-Type: application/json' \
-  -d '{"severity":"known","label":"deploy-rollout","tags":["benign"]}' \
+  -d '{"verdict":"known","tags":["deploy-rollout","benign"]}' \
   http://localhost:3000/api/agent/patterns/p-abc123
 ```
 

--- a/src/agent/getting-started.md
+++ b/src/agent/getting-started.md
@@ -249,18 +249,75 @@ Once you trust the catalog, replace the test file with the real one:
 2. Edit `config/agent_sources.yaml` so `file.path` points at your
    application's log file (mount it read-only into `/app/logs`).
 3. (Optional) Drop the old test catalog so the agent starts fresh:
-   `rm -f data/patterns.json data/patterns.json.*`.
+   `rm -f data/patterns.json`.
 4. Start the agent again.
 
 After a few days of training mode, when the new-pattern rate flattens
-out, switch `AGENT_MODE` to `shadow` and watch the
-`agent[shadow]: would alert ...` lines for a release cycle before
-promoting to `detect`.
+out, switch `AGENT_MODE` to `shadow` and watch the would-have-alerted
+events accumulate at `GET /api/agent/shadow` for a release cycle before
+promoting to `detect`. See [Shadow Mode](./shadow-mode.md) for the full
+review workflow.
+
+---
+
+## Common questions
+
+**Q: How long should I leave the agent in training mode?**
+Until the rate of new patterns flattens out. For a small service this is
+usually a few days; for a large estate it can be a week or two. Watch
+the `agent: new pattern …` lines in stdout — when they slow to a
+trickle over a full release cycle, you're ready for shadow mode.
+
+**Q: Does training mode send any alerts?**
+No. Training is observation-only. The agent learns templates and writes
+them to `patterns.json`, nothing else. No Slack, no email, no on-call.
+
+**Q: Where does `patterns.json` live and what's in it?**
+At `<data_dir>/patterns.json` (default `data/patterns.json`). Each entry
+is one pattern: ID, mined template, first/last seen timestamps, total
+sighting count, EWMA frequency baseline, the regex `rule_name` that
+flagged it, and any operator-assigned `verdict` / `tags`.
+
+**Q: What if my log file rotates?**
+The file source detects rotation by comparing the file's current size
+to the saved cursor offset. When the file shrinks (a fresh log after
+rotation), it restarts from offset 0. No special configuration needed.
+
+**Q: Do I need Redis?**
+Yes, when the agent is enabled. Redis stores per-source cursors so the
+agent picks up exactly where it left off across restarts. Without
+Redis, every restart would either replay your `lookback` window or
+miss entries written while the agent was down. For local testing the
+file source also writes a sidecar cursor file as a fallback, but
+Elasticsearch and other backends rely on Redis.
+
+**Q: My catalog is full of patterns I don't care about — how do I clean
+up?**
+Three options, in order of effort:
+
+1. Tighten `agent.regex.default_pattern` (or set it to empty and rely on
+   named rules) so noisy lines never reach the miner.
+2. Delete bad patterns one by one:
+   `DELETE /api/agent/patterns/<id>`.
+3. Wipe and start over: stop the agent, delete `data/patterns.json*`,
+   start it again. You'll lose your training history.
+
+**Q: Can I run multiple agents against the same Redis?**
+Yes, as long as their source `name`s are distinct (cursor keys are
+namespaced by source name). Each agent should have its own
+`data_dir` so they don't fight over `patterns.json`.
+
+**Q: What's the smallest config I can run with?**
+Effectively: `agent.enable=true`, `agent.gateway_secret=…`,
+`agent.sources_path=…`, plus a `redis` block. Everything else has
+sensible defaults.
 
 ---
 
 ## What's next
 
+- [Shadow Mode](./shadow-mode.md) — the next step after training: review
+  what the agent _would_ have alerted on without sending anything.
 - [Configuration](./configuration.md) — every knob, env override, and
   per-request parameter.
 - [Redaction](./redaction.md), [Regex](./regex.md), [Miner](./miner.md),

--- a/src/agent/shadow-mode.md
+++ b/src/agent/shadow-mode.md
@@ -1,0 +1,495 @@
+# AI Agent — Shadow Mode
+
+Shadow mode is the **dress rehearsal** between training and detect. The
+agent keeps learning, but it also classifies every batch of signals
+as if it were going to alert — and records the verdict to a file you
+can review at your own pace. **No notifications are sent.**
+
+Think of it as: "show me what you _would_ have woken me up for, so I can
+decide if I trust you."
+
+---
+
+## When to switch to shadow
+
+Stay in `training` until the rate of new patterns flattens out — typically
+a few days for a small service, longer for a large estate. Then switch
+the mode:
+
+```bash
+docker stop versus-agent
+docker run -d \
+  --name versus-agent \
+  ... \
+  -e AGENT_MODE=shadow \
+  ghcr.io/versuscontrol/versus-incident:latest
+```
+
+Or edit `agent.mode` in `config.yaml` and restart.
+
+The catalog and shadow log live alongside each other under `data_dir`:
+
+```
+data/
+├── patterns.json     # learned templates (built in training, kept growing in shadow)
+└── shadow.json       # would-have-alerted events (only written in shadow mode)
+```
+
+---
+
+## How shadow mode works
+
+Shadow mode reuses the entire training pipeline (read → redact → regex
+filter → cluster → catalog) and adds **one extra step at the end**:
+classify the result and, if the verdict isn't `known`, write a row to
+`shadow.json`. No alert is ever sent.
+
+```mermaid
+flowchart TD
+    A[New log line from source] --> B[Redact secrets]
+    B --> C{Matches regex<br/>pre-filter?}
+    C -- No --> X[Drop]
+    C -- Yes --> D[Cluster into pattern]
+    D --> E[Upsert into catalog<br/>count++, refresh template]
+    E --> F{Pattern known?<br/>verdict=known<br/>OR count ≥ auto_promote_after}
+    F -- Yes --> G[Silent: ignore]
+    F -- No --> H[Verdict = unknown]
+    H --> I[Coalesce by source + pattern_id<br/>bump count / occurrences]
+    I --> J[(shadow.json)]
+    H --> K[Stdout:<br/>agent shadow: would alert ...]
+
+    classDef drop fill:#fff3cd,stroke:#856404,color:#856404;
+    classDef silent fill:#d4edda,stroke:#155724,color:#155724;
+    classDef alert fill:#f8d7da,stroke:#721c24,color:#721c24;
+    classDef store fill:#cce5ff,stroke:#004085,color:#004085;
+    class X drop;
+    class G silent;
+    class H,K alert;
+    class J,E store;
+```
+
+Key things to take away from the diagram:
+
+- **The catalog still grows.** Every signal that survives redaction
+  and the regex filter is upserted, just like in training. Switching
+  to shadow doesn't pause learning.
+- **The verdict is the only new step.** A pattern is `known` when
+  either (a) you've labeled it `verdict: known` via the admin API,
+  or (b) its `count` has crossed `auto_promote_after`. Everything
+  else is `unknown` and ends up in the shadow log.
+- **Two sinks, never an alert.** A would-have-alerted event lands in
+  `shadow.json` (durable, reviewed via API) and prints a green stdout
+  line (ephemeral, easy to spot when you're tailing the container).
+  Slack, email, on-call — none of them are touched.
+
+---
+
+## What gets recorded
+
+Every poll tick the worker walks each source and, for every signal
+that survived the redactor and the regex pre-filter, decides one of
+three outcomes:
+
+1. **The cluster is `known`** — silently update the catalog and move
+   on. This is what most signals do once the agent has trained.
+2. **The cluster is `unknown` (verdict = `unknown`)** — write a row
+   to the shadow log. This is the case for a brand-new template, or
+   for a rare template whose `count` hasn't crossed
+   `auto_promote_after` yet.
+3. **The cluster is a frequency `spike` (verdict = `spike`)** —
+   reserved for a future milestone. The verdict exists in the
+   schema today but is never produced; you'll see `verdict_spike: 0`
+   in the stats endpoint.
+
+A signal is `known` when **either** of these is true:
+
+- An operator has explicitly set the pattern's verdict to `known` via
+  `POST /api/agent/patterns/<id>` with body `{"verdict":"known"}`
+  (this takes effect immediately and is permanent until you change
+  it).
+- The pattern's `Count` is `≥ agent.catalog.auto_promote_after`
+  (default `100`). The threshold is per-pattern, not per-source. The
+  agent persists this auto-promotion to `patterns.json` so you can
+  audit which patterns it considers baseline.
+
+### Coalescing: one row per pattern, not per signal
+
+A naive log of every flagged signal would explode on a busy cluster.
+Instead the shadow log stores **one row per `(source, pattern_id)`
+pair**. Every time the same pattern hits again, the existing row is
+updated:
+
+- `Count` += signals seen this tick (the raw firehose count).
+- `Occurrences` += 1 (one tick = one occurrence, regardless of how
+  many signals fired in that tick).
+- `Template` is refreshed in case the miner refined it.
+- `LastSeen` is set to now (UTC).
+- `RuleName` is upgraded if the regex matcher now has a more
+  specific tag than before.
+
+So if 200 NTP-skew lines arrive across 4 ticks, you don't get 200
+rows — you get **one** row with `count: 200, occurrences: 4`. That
+one row is what shows up in the API.
+
+### Every recorded field
+
+| Field | Meaning | Example |
+|---|---|---|
+| `pattern_id` | Stable ID assigned by the miner. Same as in the catalog, so you can cross-reference. | `p-9c2f01` |
+| `template` | Latest mined template. `<*>` marks variable parts. | `kernel: Out of memory: Killed process <*> (<*>) score 999 …` |
+| `source` | The source name from `agent_sources.yaml`. Lets you tell prod-app from staging-app at a glance. | `my-app` |
+| `rule_name` | Regex tag that fired. `default` means `default_pattern` matched but no named rule did. Empty when the regex pre-filter is disabled entirely. | `oom-killer` / `default` |
+| `verdict` | `unknown` today; `spike` reserved for future use. | `unknown` |
+| `sample_message` | One representative line, **post-redaction**, truncated to 512 bytes. The agent picks the first signal in the bucket; secrets are already gone. | `kernel: Out of memory: Killed process 1842 (versus-worker) score 999 …` |
+| `count` | Total raw signals across every coalesced tick. The "firehose volume" for this pattern. | `17` |
+| `occurrences` | How many distinct ticks flagged this pair. Always `≤ count`. | `3` |
+| `first_seen` | UTC timestamp of the very first time this pair was added. | `2026-04-30T18:21:04Z` |
+| `last_seen` | UTC timestamp of the most recent hit. Used for sorting and for eviction. | `2026-04-30T18:31:42Z` |
+
+### Bounded size and eviction
+
+The store is capped at **1000 distinct `(source, pattern_id)` pairs**
+(currently hard-coded). When you cross that cap, the row with the
+oldest `last_seen` is evicted to make room for the newcomer. In
+practice you should never hit this on a normally-sized service: a
+catalog of 1000 distinct anomalies in a single review window means
+something is *very* wrong (or the regex pre-filter is too permissive
+— see [Regex](./regex.md)).
+
+`shadow.json` itself is written atomically (`tmp` + `rename`), so
+you can `cat` it from disk while the agent is running without
+risking a partial read.
+
+### Stdout mirror
+
+You'll also see a green line in the agent's logs every time a row is
+recorded. It's the same data, formatted for humans:
+
+```
+agent[shadow]: would alert pattern=p-abc123 tag=default verdict=unknown freq=4
+```
+
+`freq` here is the **per-tick** count — the same number that gets
+added to `Count` in the JSON. Use stdout for live debugging while
+you're iterating on the regex rules; use the API for review.
+
+---
+
+## Try it locally with the noisy-logs script
+
+If you went through [Getting Started](./getting-started.md), you already
+have the agent running against `./logs/my-app.log` with `from_beginning:
+true`. The repo ships a [`scripts/generate_noisy_logs.py`][gen] generator
+that mixes ~30 common templates with a handful of low-weight,
+production-style anomalies (kernel OOM with score, segfaults, expired
+TLS certs, NTP clock skew, lost Raft quorum, replication lag,
+unexpected `SIGTERM`, …). Those rare lines are exactly what shadow mode
+is meant to surface.
+
+[gen]: https://github.com/VersusControl/versus-incident/blob/main/scripts/generate_noisy_logs.py
+
+**Step 1 — train the agent on the boring baseline.** While the agent is
+running in `training` mode, point the live-tail script at the log file
+and let it run for a few minutes:
+
+```bash
+./scripts/run_noisy_logs.sh \
+  --output ./logs/my-app.log \
+  --interval 1 --batch 50
+```
+
+Watch the agent logs: the rate of `agent: new pattern` lines should
+drop sharply within a minute or two. That's your baseline.
+
+**Step 2 — flip the agent to shadow mode.** Stop the container, start it
+again with `AGENT_MODE=shadow`. The catalog you just built is preserved
+on disk (`data/patterns.json`), so the agent already knows what "normal"
+looks like.
+
+**Step 3 — keep generating logs.** Restart the live-tail script (or just
+leave it running). Most of what comes through is now the noisy baseline,
+which the agent classifies as `known` and ignores. The rare anomaly
+lines, however, hit the catalog with `Count` well below
+`auto_promote_after` and end up in the shadow log:
+
+```
+agent[shadow]: would alert pattern=p-9c2f01 tag=default verdict=unknown freq=1
+agent[shadow]: would alert pattern=p-7e1a44 tag=default verdict=unknown freq=2
+```
+
+**Step 4 — review.** After a minute or two, hit the admin endpoint:
+
+```bash
+curl -H "X-Gateway-Secret: $SECRET" \
+  http://localhost:3000/api/agent/shadow | jq '.events[] | {template, count, occurrences}'
+```
+
+You'll see entries like:
+
+```json
+{ "template": "service=notifier message=\"x509 certificate expired\" host=<*> expired_at=<*> chain_position=<*>",  "count": 1, "occurrences": 1 }
+```
+
+This is the dry-run version of the on-call page you _would_ have
+received in detect mode. Use the loop in [A typical review
+loop](#a-typical-review-loop) below to triage them.
+
+> **Tip.** Want a forced demo? Generate a single batch of mostly
+> baseline + anomalies into the file the agent is tailing while in
+> shadow mode:
+>
+> ```bash
+> python3 scripts/generate_noisy_logs.py \
+>   --append --start-time now \
+>   --output ./logs/my-app.log --lines 500
+> ```
+>
+> 500 lines at default weights yields ~25 anomaly lines spread across
+> ~10 unique templates — a tidy worked example for review.
+
+---
+
+## Reviewing the shadow log
+
+The `/api/agent/shadow*` endpoints are how you actually consume the
+log. They're admin-only — every request needs the `X-Gateway-Secret`
+header (set via the `AGENT_GATEWAY_SECRET` env var). The examples
+below assume you've exported that value into a shell variable for
+brevity:
+
+```bash
+export SECRET=change-me   # whatever you set as AGENT_GATEWAY_SECRET
+```
+
+All responses are JSON; piping to `jq` (or `python -m json.tool`)
+makes them easier to read.
+
+### List every event (most recent first)
+
+Start here. The endpoint returns every distinct `(source, pattern_id)`
+the agent flagged in the current window, sorted by `last_seen`
+descending so the freshest noise floats to the top:
+
+```bash
+curl -H "X-Gateway-Secret: $SECRET" \
+  http://localhost:3000/api/agent/shadow | jq
+```
+
+Sample output:
+
+```json
+{
+  "events": [
+    {
+      "pattern_id": "p-abc123",
+      "template": "GET /api/users/<*> 500",
+      "source": "my-app",
+      "rule_name": "default",
+      "verdict": "unknown",
+      "sample_message": "GET /api/users/42 500",
+      "count": 17,
+      "occurrences": 3,
+      "first_seen": "2026-04-30T18:21:04Z",
+      "last_seen": "2026-04-30T18:31:42Z"
+    }
+  ]
+}
+```
+
+The two numbers to watch are:
+
+- **`count`** — how many raw signals matched the pattern in total.
+  High `count` + low `occurrences` means a brief flurry; high in both
+  means a steady drip you should care about.
+- **`occurrences`** — how many distinct ticks the pattern fired in.
+  Each tick is one poll cycle (`agent.poll_interval`).
+
+If you only want to see something specific, pipe through `jq`:
+
+```bash
+# templates and counts only
+curl -s -H "X-Gateway-Secret: $SECRET" http://localhost:3000/api/agent/shadow \
+  | jq '.events[] | {template, count, rule_name}'
+
+# everything tagged "oom"
+curl -s -H "X-Gateway-Secret: $SECRET" http://localhost:3000/api/agent/shadow \
+  | jq '.events[] | select(.rule_name == "oom")'
+```
+
+### Aggregate stats
+
+Useful for dashboards or a quick "is this getting better?" check
+between review windows:
+
+```bash
+curl -H "X-Gateway-Secret: $SECRET" \
+  http://localhost:3000/api/agent/shadow/stats | jq
+```
+
+```json
+{
+  "events": 12,
+  "total_signals": 248,
+  "total_occurrences": 41,
+  "verdict_unknown": 12,
+  "verdict_spike": 0
+}
+```
+
+What each number means:
+
+- **`events`** — distinct `(source, pattern_id)` pairs in the log.
+- **`total_signals`** — sum of `count` across every event. This is
+  the raw firehose volume.
+- **`total_occurrences`** — sum of `occurrences`. Roughly: "how many
+  ticks would have paged me?".
+- **`verdict_unknown`** / **`verdict_spike`** — breakdown by verdict.
+  Spike is reserved for a future milestone; today this is always 0.
+
+A healthy review cycle drives `events` and `total_occurrences` down
+over time, even as `total_signals` stays flat (because you're
+labelling the boring patterns as known).
+
+### Force-flush to disk
+
+The worker debounces writes to `shadow.json` at
+`catalog.persist_interval` (default 30s) so we don't thrash the disk.
+If you need a snapshot **right now** — to copy the file out of a
+container, attach to a bug report, or just check what would land on
+disk — ask the agent to flush:
+
+```bash
+curl -X POST -H "X-Gateway-Secret: $SECRET" \
+  http://localhost:3000/api/agent/shadow/flush
+```
+
+This is a no-op when the log is already clean (`shadow_dirty: false`).
+
+### Clear the log
+
+Once you've reviewed a batch of events and either curated the catalog
+(label-as-known) or fixed the underlying bug, drop the log so the
+next review window starts from zero:
+
+```bash
+curl -X DELETE -H "X-Gateway-Secret: $SECRET" \
+  http://localhost:3000/api/agent/shadow
+```
+
+This also persists the empty file so a restart doesn't resurrect the
+old entries. **The catalog is left alone** — every learned pattern
+stays exactly where it was. You're only wiping the "would have
+alerted" inbox.
+
+### Status endpoint
+
+A cheap health check that tells you both stores at a glance:
+
+```bash
+curl -H "X-Gateway-Secret: $SECRET" \
+  http://localhost:3000/api/agent/status | jq
+```
+
+```json
+{
+  "patterns": 87,
+  "dirty": false,
+  "shadow_events": 12,
+  "shadow_dirty": true
+}
+```
+
+- **`patterns`** — catalog size.
+- **`dirty`** — catalog has un-flushed changes since the last persist.
+- **`shadow_events`** — distinct events currently in the shadow log.
+- **`shadow_dirty`** — same idea for the shadow log.
+
+If you ever see `shadow_events` plateau and `shadow_dirty` stay
+`false` for many ticks, the agent has nothing new to flag — a good
+sign you're approaching readiness for `detect` mode.
+
+---
+
+## A typical review loop
+
+This is the workflow you'll repeat for as long as the agent stays in
+shadow mode. Each pass should make the next one quieter.
+
+1. **Run shadow mode for ~24 hours.** Long enough to capture at least
+   one full traffic cycle (peak hours, off-peak, any nightly cron
+   jobs).
+2. **Pull the events.** `GET /api/agent/shadow` and skim them. Sort
+   in your head into three buckets: real anomalies you'd page on,
+   noise that should have been silenced, and "new but legitimate"
+   patterns (fresh deploys, new endpoints, etc.).
+3. **For events you _would_ want to be paged about:**
+   - Add or refine a rule under `agent.regex.rules` in `config.yaml`
+     so the pattern gets the right `name` next time.
+   - Example: a `quorum lost` line that landed with `rule_name:
+     default` deserves its own rule:
+
+     ```yaml
+     agent:
+       regex:
+         rules:
+           - name: quorum-lost
+             pattern: "(?i)quorum lost"
+     ```
+4. **For events that are just noise:**
+   - Either bump `agent.catalog.auto_promote_after` (default 100) so
+     the pattern auto-graduates to known sooner, **or** mark it
+     `known` manually:
+
+     ```bash
+     curl -X POST -H "X-Gateway-Secret: $SECRET" \
+       -H "Content-Type: application/json" \
+       -d '{"verdict":"known","tags":["benign-validation-error"]}' \
+       http://localhost:3000/api/agent/patterns/p-abc123
+     ```
+
+     Once `verdict == "known"`, that pattern will never appear in the
+     shadow log again, regardless of frequency.
+5. **Clear the log:** `DELETE /api/agent/shadow`. The next review
+   window starts clean.
+6. **Repeat** until the shadow log is mostly empty over a full release
+   cycle (one or two weeks).
+7. **Promote to detect.** Set `AGENT_MODE=detect` and you're live.
+
+---
+
+## Common questions
+
+**Q: Will shadow mode send any alerts?**
+No. Not Slack, Telegram, email, on-call — nothing. It only writes to
+`shadow.json` and stdout.
+
+**Q: Does shadow mode keep adding patterns to the catalog?**
+Yes. Every signal that survives the redactor and regex pre-filter is
+clustered and upserted, exactly like in training. This is intentional:
+shadow mode is "training plus a verdict" so you don't lose ground while
+reviewing.
+
+**Q: What happens if I switch back to training?**
+The shadow log is preserved on disk and kept in memory; the worker just
+stops appending to it. Switch back to `shadow` later and it picks up
+where it left off.
+
+**Q: Can the shadow log fill up forever?**
+No. It's capped at 1000 distinct `(source, pattern_id)` pairs. When full,
+the oldest-by-`last_seen` is evicted to make room. The cap is currently
+hard-coded.
+
+**Q: Is `shadow.json` safe to delete by hand?**
+Yes — but only while the agent is stopped, and it'll come back on the
+next tick anyway.
+
+---
+
+## What's next
+
+- [Configuration](./configuration.md) — every knob, env override, and
+  per-request parameter.
+- [Catalog](./catalog.md) — labeling and curating patterns from the
+  shadow log.
+- [Regex](./regex.md) — fine-tuning what reaches the miner so shadow
+  noise stays manageable.

--- a/src/userguide/getting-started.md
+++ b/src/userguide/getting-started.md
@@ -568,13 +568,10 @@ agent:
     # Named rules are tried first, in order. The first match wins.
     rules:
       - name: oom
-        severity: critical
         pattern: "(?i)out of memory|OOMKilled|java\\.lang\\.OutOfMemoryError"
       - name: db-timeout
-        severity: high
         pattern: "(?i)(connection|query) timeout|deadlock detected"
       - name: auth-failure
-        severity: medium
         pattern: "(?i)401 unauthorized|invalid credentials|permission denied"
 
 redis: # Required for the agent to persist source cursors across restarts
@@ -599,7 +596,7 @@ The `agent` section includes:
 7. `miner`: Controls how aggressively the agent groups similar log lines together. The defaults work well for most setups.
 8. `regex`: Acts as a **pre-filter** for the agent. Only signals whose message matches at least one rule (a named entry under `rules` or `default_pattern`) are forwarded to the pattern miner and stored in the catalog. Anything that doesn't match is dropped before clustering, so boring noise (200-OK requests, debug lines, etc.) never bloats `patterns.json`.
 
-   - Named `rules` are tried in order; the first match wins and tags the signal with that `name` and `severity`.
+   - Named `rules` are tried in order; the first match wins and tags the signal with that `name` (stored as `rule_name` on the pattern).
    - If no named rule hits, `default_pattern` is tried. Matches there are tagged with `name=default`.
    - **To learn from every line, set `default_pattern: ".*"`.** This is useful in early training when you don't yet know what's interesting.
    - **To filter aggressively, set `default_pattern: ""` (empty)** and rely on your named rules — anything that doesn't match an explicit rule is dropped.


### PR DESCRIPTION
feat: shadow mode, data-model simplification, file-source backlog control

Shadow mode (agent.mode=shadow):
- Reuses entire training pipeline, adds classify step at the end
- Writes would-have-alerted events to data/shadow.json (append-only NDJSON)
- Auto-promotes patterns to 'known' after catalog.auto_promote_after hits
- ShadowLog with atomic open/close and Record() for safe concurrent writes

Data-model simplification:
- Drop severity from regex rules (AgentRegexRule: name + pattern only)
- Rename Pattern.Severity -> Verdict, Pattern.Label -> RuleName
- Drop Severity from ShadowEvent and MatchResult
- Admin endpoint POST /api/agent/patterns/:id accepts {verdict, tags}
- Verdict is Phase-2 AI responsibility, not a regex-rule input

File source improvements:
- Add max_lines_per_pull config (per-tick line cap, defaults to batch_max)
- Large backlogs consumed across multiple ticks instead of truncated

Catalog changes:
- Remove backup rotation (.1-.5) from Persist — atomic tmp+rename only
- Remove backup fallback from LoadCatalog
- MarkKnown sets Verdict='known' (no more hardcoded 'low')

Other:
- Miner deduplication: skip re-clustering when patternID already seen in tick
- New admin endpoints: GET /api/agent/status, POST /api/agent/flush
- Agent controller auth via X-Gateway-Secret header
- Comprehensive docs: shadow-mode.md, updated configuration.md, getting-started.md