### PR TITLE
v1.4.1: reliability, correctness fixes, and multi-provider AI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ tmp.txt
 *.sh
 !scripts/*.sh
 !helm/**/*.sh
+!examples/**/*.sh
 .air.conf
 book
 local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,87 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.4.1] — Unreleased
 
+### Fixed
+
+#### Correctness & data integrity (regressions in v1.4.0 and earlier)
+- **Catalog data race** (`pkg/agent/catalog.go`): `Catalog.Get` returned
+  a live `*Pattern` pointer that callers (`worker.classify`) read under
+  no lock while a concurrent `Upsert` from another source's tick wrote
+  to the same struct. `Get` now returns a deep copy.
+- **Alert fan-out short-circuit** (`pkg/core/alert.go`): the legacy
+  `Alert.SendAlert` returned on the first provider error and never
+  invoked subsequent providers — a flaky Slack silently muted Telegram
+  and Email. Added `SendAllAlerts` that tries every configured channel
+  and returns per-channel success/failure. `services.CreateIncident`
+  now uses it and stores `ChannelsNotified` as the channels that
+  actually succeeded (vs. `ChannelsEnabled` for what was configured).
+- **On-call status lie** (`pkg/services/incident.go`): `OnCallTriggered`
+  was persisted at record-build time, before the workflow was started.
+  If `workflow.Start` later failed, the UI still reported "on-call
+  triggered" while no one was paged. The flag is now walked back to
+  `false` and `OnCallError` is recorded when `Start` returns an error.
+- **AI rate-limit drain under breaker-open** (`pkg/agent/worker.go`):
+  the rate limiter incremented its hour counter BEFORE the circuit
+  breaker check, so an open breaker still consumed quota. Breaker
+  check now runs first.
+
+#### Resilience hardening
+- **Retry sleep ignored context cancellation** (`pkg/agent/ai/openai.go`):
+  `time.Sleep` between retries blocked SIGTERM for up to ~15s at default
+  settings. Replaced with `select { ctx.Done(); time.After }`.
+- **`rand.Rand` not goroutine-safe** (`pkg/agent/ai/openai.go`):
+  per-instance `*rand.Rand` was shared across goroutines that race
+  inside `Analyze`. Switched to the package-level `rand.Int63n` (Go
+  1.20+ guarantees concurrent safety on the global) and removed the
+  field.
+- **`rand.Int63n(0)` panic** (`pkg/agent/ai/openai.go`): could panic if
+  the operator configured an extremely small `initial_backoff`. Guarded
+  the call.
+- **Worker died silently on panic** (`pkg/agent/worker.go`): a panic
+  in `tickSource` killed its goroutine; the cursor never advanced, no
+  log line surfaced, and the agent looked healthy. Added a
+  `defer recover()` that logs the stack and records the failure on
+  the source health tracker.
+
+#### Security
+- **Constant-time gateway secret comparison** (`pkg/controllers/*`):
+  the three admin controllers used `got != expected`. Switched to
+  `crypto/subtle.ConstantTimeCompare` so prefix-match timing oracles
+  are eliminated.
+
+#### Operational limits
+- **Unbounded pattern catalog** (`pkg/agent/catalog.go`): added
+  `agent.catalog.max_patterns` (default 10000). When the cap is hit,
+  the least-frequent NON-"known" pattern is evicted. Operator-curated
+  patterns (`verdict: known`) are preserved. 0 disables the cap.
+- **Storage atomicity** (`pkg/storage/file.go`): `os.WriteFile` +
+  `os.Rename` did not `fsync` between write and rename. A power loss
+  in between could replace a previous good `patterns.json` /
+  `incidents.json` with a zero-length file. Added `f.Sync()` via a
+  new `writeFileAtomicSync` helper used for every persisted blob.
+
 ### Added
+
+#### Multi-provider AI support
+- **`agent.ai.base_url` config field** (`pkg/agent/ai/openai.go`): override
+  the OpenAI chat/completions endpoint to point at any OpenAI-compatible
+  provider — e.g. Google Gemini's `https://generativelanguage.googleapis.com/v1beta/openai/chat/completions`,
+  LiteLLM proxies, OpenRouter. Wire format remains OpenAI chat/completions.
+  Default unchanged (OpenAI), so existing deployments keep working.
+- **`finish_reason` handling + truncation auto-retry**
+  (`pkg/agent/ai/openai.go`): the analyzer now reads each choice's
+  `finish_reason`. On `length` (model hit max_tokens mid-JSON) it
+  auto-retries once with max_tokens doubled (capped at 4096), which
+  recovers Gemini-2.5-flash's verbose output without operator
+  intervention. On `content_filter` it surfaces a clear error without
+  retrying (more tokens won't unblock a safety filter). Caught
+  end-to-end during Gemini live tests where the original 512-token
+  budget kept truncating JSON.
+- **Raw response in parse-error message** (`pkg/agent/ai/openai.go`):
+  when ParseFinding fails, the first 300 chars of the model's actual
+  reply are now included in the error string, so the detect audit
+  log shows operators *why* parsing failed instead of just
+  "no JSON object found".
 
 #### Reliability & graceful degradation
 - **Per-source health tracker** (`pkg/agent/health.go`): consecutive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.4.1] — Unreleased
+
+### Added
+
+#### Reliability & graceful degradation
+- **Per-source health tracker** (`pkg/agent/health.go`): consecutive
+  failures, last error, last success, cooldown end, lifetime pull /
+  signal / drop counters, last pull duration. Exposed under
+  `GET /api/agent/status` as `sources: [...]`.
+- **Exponential backoff cooldown** for failing sources. After the first
+  consecutive failure the source enters a `source_backoff_initial`
+  cooldown that doubles each subsequent failure up to
+  `source_backoff_max`. Pulls during cooldown are skipped (logged) so a
+  flapping backend cannot stall the worker.
+- **Per-pull context deadline** (`reliability.pull_timeout`, default
+  20s) so a hung backend can't run past the tick budget.
+- **Silent-truncation counter**: when `batch_max` truncates a tick,
+  the dropped count is recorded and surfaced under
+  `total_signals_dropped`. Previously the truncation only logged.
+- **OpenAI retry with jitter** (`pkg/agent/ai/openai.go`): HTTP 429 and
+  5xx now retry up to `ai_retry.max_attempts` (default 3) with
+  exponential backoff. 4xx other than 429 surface immediately.
+- **Circuit breaker for AI calls** (`pkg/agent/ai/breaker.go`):
+  consecutive failures above `ai_breaker.failure_threshold` (default 5)
+  flip the breaker open; calls short-circuit for `ai_breaker.cooldown`
+  (default 2m), then one probe is allowed; success closes, failure
+  re-opens with a fresh cooldown. Surfaced in the detect audit log as
+  outcome `breaker_open`.
+- **AI health under `/api/agent/status`** as `ai: {state,
+  consecutive_failures, total_success, total_failure, total_opens,
+  total_probes, last_error, last_error_at, last_success_at, opened_at,
+  latency_p50_ms, latency_p95_ms}`. Latencies are computed over a
+  rolling window of the last 100 successful calls.
+
+### Configuration
+- New `agent.reliability` block (see `config/config.yaml`).
+  All fields have sensible defaults; the block is optional.
+
+---
+
 ## [1.4.0] — 2026-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,11 +71,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 #### Multi-provider AI support
-- **`agent.ai.base_url` config field** (`pkg/agent/ai/openai.go`): override
-  the OpenAI chat/completions endpoint to point at any OpenAI-compatible
-  provider — e.g. Google Gemini's `https://generativelanguage.googleapis.com/v1beta/openai/chat/completions`,
-  LiteLLM proxies, OpenRouter. Wire format remains OpenAI chat/completions.
-  Default unchanged (OpenAI), so existing deployments keep working.
+- **`agent.ai.provider` config field** (`pkg/agent/ai/openai.go`,
+  `pkg/config/agent.go`): selects the AI backend by name —
+  `openai` (default), `gemini`, or `claude`. The chat/completions
+  endpoint is resolved from this value at startup; operators do not
+  configure URLs. All three providers speak the OpenAI
+  chat/completions wire format (Gemini and Claude via their respective
+  OpenAI compatibility shims). Unknown values fail fast at startup
+  with a clear error.
 - **`finish_reason` handling + truncation auto-retry**
   (`pkg/agent/ai/openai.go`): the analyzer now reads each choice's
   `finish_reason`. On `length` (model hit max_tokens mid-JSON) it

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,8 +135,12 @@ see [GitHub Project](https://github.com/orgs/VersusControl/projects/2).
   ([`src/migration/migration-v1.4.0.md`](src/migration/migration-v1.4.0.md)).
 
 ## Planned (v1.4.1 release scope)
-- [ ] **Reliability & load testing** — graceful degradation on log-source
-  outages, AI timeouts, and high log volume.
+- [x] **Reliability & load testing** — graceful degradation on log-source
+  outages, AI timeouts, and high log volume. Per-source health tracker
+  with exponential backoff cooldown, per-tick context deadline,
+  silent-truncation counter, OpenAI retry on 429/5xx with jitter,
+  circuit breaker for AI calls, health surfaced under
+  `/api/agent/status`.
 
 ---
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -271,7 +271,7 @@ func startAgent(ctx context.Context, app *fiber.App, cfg c.AgentConfig, gatewayS
 		return nil, fmt.Errorf("agent: gateway_secret is not configured — /api/agent/* admin endpoints require a secret")
 	}
 	api := app.Group("/api")
-	controllers.NewAgentController(catalog, shadowLog, detectLog).Register(api)
+	controllers.NewAgentController(catalog, shadowLog, detectLog, worker.Health, aiBundle.Breaker).Register(api)
 
 	return catalog, nil
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -213,15 +213,13 @@ agent:
         pattern: "HTTP/[0-9.]+\\s+5\\d\\d"
 
   # AI analyzer — used in detect mode to assess unknown/spiking patterns.
-  # Any OpenAI-compatible chat/completions endpoint works (OpenAI itself,
-  # Google's Gemini OpenAI-compatible endpoint, LiteLLM / OpenRouter
-  # proxies, ...). Wire format must be OpenAI chat/completions.
+  # `provider` picks the backend; all three speak the OpenAI chat/completions
+  # wire format. Operators do not configure URLs.
   ai:
     enable: false                   # master switch (env: AGENT_AI_ENABLE)
-    # base_url: ""                  # default: https://api.openai.com/v1/chat/completions
-                                    # Gemini: https://generativelanguage.googleapis.com/v1beta/openai/chat/completions
+    provider: openai                # openai | gemini | claude (default: openai)
     api_key: ${AGENT_AI_API_KEY}
-    model: "gpt-4o-mini"            # OpenAI: gpt-4o-mini, gpt-4o; Gemini: gemini-2.0-flash, gemini-1.5-flash, gemini-1.5-pro
+    model: "gpt-4o-mini"            # openai: gpt-4o-mini, gpt-4o · gemini: gemini-2.5-flash · claude: claude-sonnet-4-5
     temperature: 0.2
     max_tokens: 512
     max_calls_per_hour: 60          # 0 = unlimited

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -222,6 +222,21 @@ agent:
     max_calls_per_hour: 60          # 0 = unlimited
     cache_ttl: "1h"
 
+  # Reliability knobs — graceful degradation when sources hang or the AI
+  # provider misbehaves. Every field is optional; the defaults shown
+  # below are what BuildAI / NewWorker apply when the block is omitted.
+  reliability:
+    pull_timeout: 20s               # per-source Pull deadline; 0 disables
+    source_backoff_initial: 30s     # cooldown after the first consecutive failure
+    source_backoff_max: 10m         # cap; doubles each failure up to this
+    ai_retry:
+      max_attempts: 3               # total attempts (1 disables retry)
+      initial_backoff: 500ms        # first sleep; doubles each retry
+      max_backoff: 5s
+    ai_breaker:
+      failure_threshold: 5          # consecutive failures to flip open; 0 disables
+      cooldown: 2m                  # open duration before a probe is allowed
+
   # New-service grace: when a previously unseen service starts emitting logs
   # in detect mode, it enters an implicit training window so the catalog can
   # build up before AI analysis kicks in. Set to "0" to disable.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -181,6 +181,7 @@ agent:
   catalog:
     persist_interval: 30s
     auto_promote_after: 50       # in detect mode, this many sightings = "known"
+    max_patterns: 10000          # cap; 0 = unbounded. Evicts least-frequent non-"known" pattern on overflow.
     # Spike detection: a known pattern is re-flagged when its tick-level
     # frequency suddenly exceeds the EWMA (Exponentially Weighted Moving Average) baseline by `spike_multiplier`.
     # Two safety floors keep noise out:
@@ -212,11 +213,15 @@ agent:
         pattern: "HTTP/[0-9.]+\\s+5\\d\\d"
 
   # AI analyzer — used in detect mode to assess unknown/spiking patterns.
-  # For now it the placeholder only.
+  # Any OpenAI-compatible chat/completions endpoint works (OpenAI itself,
+  # Google's Gemini OpenAI-compatible endpoint, LiteLLM / OpenRouter
+  # proxies, ...). Wire format must be OpenAI chat/completions.
   ai:
     enable: false                   # master switch (env: AGENT_AI_ENABLE)
+    # base_url: ""                  # default: https://api.openai.com/v1/chat/completions
+                                    # Gemini: https://generativelanguage.googleapis.com/v1beta/openai/chat/completions
     api_key: ${AGENT_AI_API_KEY}
-    model: "gpt-4o-mini"
+    model: "gpt-4o-mini"            # OpenAI: gpt-4o-mini, gpt-4o; Gemini: gemini-2.0-flash, gemini-1.5-flash, gemini-1.5-pro
     temperature: 0.2
     max_tokens: 512
     max_calls_per_hour: 60          # 0 = unlimited

--- a/examples/gemini-test/agent_sources.yaml
+++ b/examples/gemini-test/agent_sources.yaml
@@ -1,0 +1,9 @@
+sources:
+  - name: app
+    type: file
+    enable: true
+    file:
+      path: ./local/resource/app.log
+      format: text
+      from_beginning: true
+      max_lines_per_pull: 200

--- a/examples/gemini-test/config.yaml
+++ b/examples/gemini-test/config.yaml
@@ -29,7 +29,6 @@ agent:
   lookback: 1m
   batch_max: 100
   signal_max_bytes: 65536
-  sources_path: ./agent_sources.yaml
 
   redaction: { enable: true, redact_ips: false }
 
@@ -47,11 +46,11 @@ agent:
   # Gemini qua OpenAI-compatible endpoint
   ai:
     enable: true
-    base_url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+    provider: gemini               # URL + auth header resolved from this; no base_url needed
     api_key: ${GEMINI_API_KEY}
     model: "gemini-2.5-flash"      # nhanh + cheap. Đổi sang gemini-2.5-pro nếu cần chất lượng cao hơn
     temperature: 0.2
-    max_tokens: 512               # với truncation auto-retry, 512 cũng OK; agent doubles → 1024 on retry
+    max_tokens: 512                # với truncation auto-retry, 512 cũng OK; agent doubles → 1024 on retry
     max_calls_per_hour: 30         # cap để bảo vệ quota Gemini free tier
     cache_ttl: "10m"
 

--- a/examples/gemini-test/config.yaml
+++ b/examples/gemini-test/config.yaml
@@ -1,0 +1,70 @@
+name: versus
+host: 0.0.0.0
+port: 3000
+public_host: 'http://localhost:3000'
+gateway_secret: ${GATEWAY_SECRET}
+
+alert:
+  debug_body: true
+  slack:    { enable: false }
+  telegram: { enable: false }
+  msteams:  { enable: false }
+  lark:     { enable: false }
+  viber:    { enable: false }
+  email:    { enable: false }
+
+queue:  { enable: false }
+oncall: { enable: false, initialized_only: false }
+
+storage:
+  type: file
+  file:
+    data_dir: ./data
+    max_incidents: 1000
+
+agent:
+  enable: true
+  mode: detect
+  poll_interval: 5s
+  lookback: 1m
+  batch_max: 100
+  signal_max_bytes: 65536
+  sources_path: ./agent_sources.yaml
+
+  redaction: { enable: true, redact_ips: false }
+
+  catalog:
+    persist_interval: 10s
+    auto_promote_after: 1000       # cao để mọi pattern đầu tiên là "unknown" → trigger AI
+    max_patterns: 1000
+
+  miner: { similarity_threshold: 0.4, tree_depth: 4, max_children: 100 }
+
+  regex:
+    # Chỉ học từ error/panic để giảm noise và tiết kiệm Gemini calls
+    default_pattern: "(?i)error|panic|fatal|oom|exception"
+
+  # Gemini qua OpenAI-compatible endpoint
+  ai:
+    enable: true
+    base_url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+    api_key: ${GEMINI_API_KEY}
+    model: "gemini-2.5-flash"      # nhanh + cheap. Đổi sang gemini-2.5-pro nếu cần chất lượng cao hơn
+    temperature: 0.2
+    max_tokens: 512               # với truncation auto-retry, 512 cũng OK; agent doubles → 1024 on retry
+    max_calls_per_hour: 30         # cap để bảo vệ quota Gemini free tier
+    cache_ttl: "10m"
+
+  new_service_grace: 0             # tắt grace để AI gọi luôn (cho test)
+
+  reliability:
+    pull_timeout: 20s
+    source_backoff_initial: 30s
+    source_backoff_max: 10m
+    ai_retry:
+      max_attempts: 3
+      initial_backoff: 500ms
+      max_backoff: 5s
+    ai_breaker:
+      failure_threshold: 5
+      cooldown: 2m

--- a/examples/gemini-test/run.sh
+++ b/examples/gemini-test/run.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# End-to-end Gemini detect-mode test for versus-incident.
+#
+# Prereqs (set in your shell BEFORE running this script):
+#   export GEMINI_API_KEY=<your-new-gemini-key>     # do NOT paste in chat
+#   export GATEWAY_SECRET=test-secret-1234
+#
+# What it does:
+#   1. Builds the binary
+#   2. Boots versus pointing at this example's config (detect mode + Gemini)
+#   3. Injects a few error patterns into the file source
+#   4. Waits for the agent to call Gemini and emit a finding
+#   5. Prints the AI detect log entry (prompt + response + finding)
+#
+# Stop with Ctrl-C. Cleanup is automatic.
+
+set -euo pipefail
+
+if [ -z "${GEMINI_API_KEY:-}" ]; then
+  echo "✗ GEMINI_API_KEY is not set. Export your key first:" >&2
+  echo "    export GEMINI_API_KEY=<your-key>" >&2
+  exit 1
+fi
+if [ -z "${GATEWAY_SECRET:-}" ]; then
+  echo "ℹ GATEWAY_SECRET not set; using 'test-secret-1234' for this run."
+  export GATEWAY_SECRET=test-secret-1234
+fi
+
+cd "$(dirname "$0")/../.."        # repo root
+REPO_ROOT="$(pwd)"
+EXAMPLE_DIR="$REPO_ROOT/examples/gemini-test"
+
+echo "▶ building binary"
+go build -o "$EXAMPLE_DIR/run" ./cmd
+
+# Prepare runtime working dir
+rm -rf "$EXAMPLE_DIR/data" "$EXAMPLE_DIR/local"
+mkdir -p "$EXAMPLE_DIR/data" "$EXAMPLE_DIR/local/resource"
+touch "$EXAMPLE_DIR/local/resource/app.log"
+
+# versus loads config from `config/config.yaml` relative to CWD. We
+# symlink so we don't have to copy.
+rm -rf "$EXAMPLE_DIR/config"
+mkdir "$EXAMPLE_DIR/config"
+ln -sf "$EXAMPLE_DIR/config.yaml"          "$EXAMPLE_DIR/config/config.yaml"
+ln -sf "$EXAMPLE_DIR/agent_sources.yaml"   "$EXAMPLE_DIR/config/agent_sources.yaml"
+# Copy default channel templates so the agent doesn't fail to render
+# (the templates are referenced but no channel is enabled, so they
+# are not actually used in this test).
+cp "$REPO_ROOT/config/"*.tmpl "$EXAMPLE_DIR/config/"
+
+cd "$EXAMPLE_DIR"
+
+echo "▶ starting versus on :3000 (detect mode + Gemini)"
+./run > server.log 2>&1 &
+SERVER_PID=$!
+trap "kill $SERVER_PID 2>/dev/null || true; wait 2>/dev/null || true" EXIT
+
+# Wait until healthz answers.
+for _ in $(seq 1 30); do
+  if curl -sf http://localhost:3000/healthz >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.5
+done
+echo "✔ server up"
+
+# Inject distinct error patterns.
+echo "▶ injecting test log lines"
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+for line in \
+  "ERROR [api] database connection refused: dial tcp 10.0.0.1:5432: connect timeout" \
+  "ERROR [auth] panic: nil pointer dereference in token validator at handlers/auth.go:142" \
+  "ERROR [worker] OOMKilled: container exceeded memory limit 512Mi (used 537Mi)" \
+; do
+  echo "$(ts) $line" >> local/resource/app.log
+done
+
+echo "▶ waiting up to 60s for the agent to call Gemini"
+for _ in $(seq 1 30); do
+  EVENTS=$(curl -sf -H "X-Gateway-Secret: $GATEWAY_SECRET" \
+    http://localhost:3000/api/agent/detect 2>/dev/null | jq 'length // 0')
+  if [ "$EVENTS" -gt 0 ]; then
+    break
+  fi
+  sleep 2
+done
+
+echo
+echo "================ agent status ================"
+curl -s -H "X-Gateway-Secret: $GATEWAY_SECRET" http://localhost:3000/api/agent/status | jq '{patterns, sources, ai}'
+
+echo
+echo "================ detect log (latest) ================"
+curl -s -H "X-Gateway-Secret: $GATEWAY_SECRET" http://localhost:3000/api/agent/detect | \
+  jq '.[0] // "no detect events yet — check server.log for AI errors"'
+
+echo
+echo "================ server log (last 30 lines) ================"
+tail -n 30 server.log
+
+echo
+echo "Ctrl-C to stop. Server.log: $EXAMPLE_DIR/server.log"
+wait $SERVER_PID

--- a/pkg/agent/ai/breaker.go
+++ b/pkg/agent/ai/breaker.go
@@ -1,0 +1,256 @@
+package ai
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// BreakerState is the public state of the circuit breaker.
+type BreakerState int
+
+const (
+	BreakerClosed   BreakerState = iota // calls flow through normally
+	BreakerOpen                         // calls short-circuit until cooldown elapses
+	BreakerHalfOpen                     // one probe is in flight
+)
+
+// String returns the lowercase state name (used in JSON/status output).
+func (s BreakerState) String() string {
+	switch s {
+	case BreakerOpen:
+		return "open"
+	case BreakerHalfOpen:
+		return "half_open"
+	default:
+		return "closed"
+	}
+}
+
+// Breaker is a minimal three-state circuit breaker for the AI client.
+//
+// Closed: every Allow() returns true. A consecutive run of `threshold`
+// failures flips state to Open.
+//
+// Open: Allow() returns false until `cooldown` elapses, then the next
+// Allow() returns true once with state HalfOpen — that single call is
+// the probe.
+//
+// HalfOpen: Allow() returns false for every caller except the one
+// holding the probe. On success the breaker re-closes (counters
+// reset); on failure it re-opens with a fresh cooldown.
+//
+// threshold == 0 disables the breaker (always-closed).
+type Breaker struct {
+	threshold int
+	cooldown  time.Duration
+	clock     func() time.Time // injectable for tests
+
+	mu                  sync.Mutex
+	state               BreakerState
+	consecutiveFailures int
+	openedAt            time.Time
+	totalOpens          int
+	totalTrips          int
+	totalProbes         int
+	probeInFlight       bool
+
+	// Rolling latency window of last N successful calls.
+	latencies    []int64
+	latencyMax   int
+	latencyIndex int
+	latencyFull  bool
+
+	// Success / failure totals so the admin status can report
+	// "X% success rate over the lifetime of the process".
+	totalSuccess int64
+	totalFailure int64
+	lastError    string
+	lastErrorAt  time.Time
+	lastOKAt     time.Time
+}
+
+// NewBreaker constructs a Breaker. cooldown <= 0 falls back to 1
+// minute. latencyWindow is the size of the rolling buffer (0 disables
+// latency tracking).
+func NewBreaker(threshold int, cooldown time.Duration, latencyWindow int) *Breaker {
+	if cooldown <= 0 {
+		cooldown = time.Minute
+	}
+	if latencyWindow < 0 {
+		latencyWindow = 0
+	}
+	return &Breaker{
+		threshold:  threshold,
+		cooldown:   cooldown,
+		clock:      time.Now,
+		state:      BreakerClosed,
+		latencies:  make([]int64, latencyWindow),
+		latencyMax: latencyWindow,
+	}
+}
+
+// Allow returns true when a call may proceed. The caller MUST follow
+// with exactly one RecordSuccess or RecordFailure for the call it was
+// granted. When threshold == 0 the breaker is permanently closed.
+func (b *Breaker) Allow() bool {
+	if b == nil || b.threshold == 0 {
+		return true
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	switch b.state {
+	case BreakerClosed:
+		return true
+	case BreakerOpen:
+		if b.clock().Sub(b.openedAt) < b.cooldown {
+			return false
+		}
+		// Cooldown elapsed: promote to half-open and hand out a probe.
+		b.state = BreakerHalfOpen
+		b.probeInFlight = true
+		b.totalProbes++
+		return true
+	case BreakerHalfOpen:
+		// Only one in-flight probe at a time.
+		if b.probeInFlight {
+			return false
+		}
+		b.probeInFlight = true
+		return true
+	}
+	return false
+}
+
+// RecordSuccess registers a successful call. dur is the wall-clock
+// latency of the call (passed in by the caller because the breaker
+// doesn't time the call itself).
+func (b *Breaker) RecordSuccess(dur time.Duration) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.totalSuccess++
+	b.lastOKAt = b.clock().UTC()
+	b.consecutiveFailures = 0
+	if b.state != BreakerClosed {
+		b.state = BreakerClosed
+	}
+	b.probeInFlight = false
+	if b.latencyMax > 0 {
+		b.latencies[b.latencyIndex] = dur.Milliseconds()
+		b.latencyIndex = (b.latencyIndex + 1) % b.latencyMax
+		if b.latencyIndex == 0 {
+			b.latencyFull = true
+		}
+	}
+}
+
+// RecordFailure registers a failed call. err drives the LastError
+// surfaced in stats.
+func (b *Breaker) RecordFailure(err error) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.totalFailure++
+	b.consecutiveFailures++
+	b.lastErrorAt = b.clock().UTC()
+	if err != nil {
+		b.lastError = err.Error()
+	}
+	switch b.state {
+	case BreakerClosed:
+		if b.threshold > 0 && b.consecutiveFailures >= b.threshold {
+			b.state = BreakerOpen
+			b.openedAt = b.clock()
+			b.totalOpens++
+			b.totalTrips++
+		}
+	case BreakerHalfOpen:
+		// Probe failed: re-open with a fresh cooldown.
+		b.state = BreakerOpen
+		b.openedAt = b.clock()
+		b.totalOpens++
+	}
+	b.probeInFlight = false
+}
+
+// BreakerStats is what the admin status endpoint surfaces.
+type BreakerStats struct {
+	State               string `json:"state"`
+	ConsecutiveFailures int    `json:"consecutive_failures"`
+	TotalSuccess        int64  `json:"total_success"`
+	TotalFailure        int64  `json:"total_failure"`
+	TotalOpens          int    `json:"total_opens"`
+	TotalProbes         int    `json:"total_probes"`
+	LastError           string `json:"last_error,omitempty"`
+	LastErrorAt         string `json:"last_error_at,omitempty"`
+	LastSuccessAt       string `json:"last_success_at,omitempty"`
+	OpenedAt            string `json:"opened_at,omitempty"`
+	LatencyP50Ms        int64  `json:"latency_p50_ms"`
+	LatencyP95Ms        int64  `json:"latency_p95_ms"`
+}
+
+// Stats returns a snapshot suitable for JSON marshalling.
+func (b *Breaker) Stats() BreakerStats {
+	if b == nil {
+		return BreakerStats{State: BreakerClosed.String()}
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	s := BreakerStats{
+		State:               b.state.String(),
+		ConsecutiveFailures: b.consecutiveFailures,
+		TotalSuccess:        b.totalSuccess,
+		TotalFailure:        b.totalFailure,
+		TotalOpens:          b.totalOpens,
+		TotalProbes:         b.totalProbes,
+		LastError:           b.lastError,
+	}
+	if !b.lastErrorAt.IsZero() {
+		s.LastErrorAt = b.lastErrorAt.Format(time.RFC3339)
+	}
+	if !b.lastOKAt.IsZero() {
+		s.LastSuccessAt = b.lastOKAt.Format(time.RFC3339)
+	}
+	if !b.openedAt.IsZero() && b.state == BreakerOpen {
+		s.OpenedAt = b.openedAt.Format(time.RFC3339)
+	}
+	s.LatencyP50Ms, s.LatencyP95Ms = b.percentilesLocked()
+	return s
+}
+
+// percentilesLocked computes p50/p95 over the rolling window. Caller
+// must hold b.mu.
+func (b *Breaker) percentilesLocked() (p50, p95 int64) {
+	if b.latencyMax == 0 {
+		return 0, 0
+	}
+	n := b.latencyMax
+	if !b.latencyFull {
+		n = b.latencyIndex
+	}
+	if n == 0 {
+		return 0, 0
+	}
+	buf := make([]int64, n)
+	copy(buf, b.latencies[:n])
+	sort.Slice(buf, func(i, j int) bool { return buf[i] < buf[j] })
+	return buf[idx(n, 0.50)], buf[idx(n, 0.95)]
+}
+
+func idx(n int, q float64) int {
+	i := int(float64(n-1) * q)
+	if i < 0 {
+		i = 0
+	}
+	if i >= n {
+		i = n - 1
+	}
+	return i
+}

--- a/pkg/agent/ai/breaker_test.go
+++ b/pkg/agent/ai/breaker_test.go
@@ -1,0 +1,144 @@
+package ai
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestBreaker_DisabledAlwaysAllows(t *testing.T) {
+	b := NewBreaker(0, time.Minute, 0)
+	for i := 0; i < 100; i++ {
+		if !b.Allow() {
+			t.Fatal("threshold=0 must allow every call")
+		}
+		b.RecordFailure(errors.New("nope"))
+	}
+}
+
+func TestBreaker_OpensAfterThreshold(t *testing.T) {
+	b := NewBreaker(3, time.Minute, 0)
+
+	// 3 failures → open.
+	for i := 0; i < 3; i++ {
+		if !b.Allow() {
+			t.Fatalf("attempt %d should be allowed before threshold trips", i)
+		}
+		b.RecordFailure(errors.New("boom"))
+	}
+	if got := b.Stats().State; got != "open" {
+		t.Fatalf("state=%q want open", got)
+	}
+	if b.Allow() {
+		t.Fatal("Allow must reject when open and within cooldown")
+	}
+}
+
+func TestBreaker_HalfOpenProbeSuccessCloses(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	b := NewBreaker(1, 10*time.Second, 0)
+	b.clock = func() time.Time { return now }
+
+	// Trip the breaker.
+	b.Allow()
+	b.RecordFailure(errors.New("boom"))
+
+	// Inside cooldown — denied.
+	if b.Allow() {
+		t.Fatal("breaker should reject while in cooldown")
+	}
+
+	// Cooldown elapses → exactly one probe is allowed.
+	b.clock = func() time.Time { return now.Add(11 * time.Second) }
+	if !b.Allow() {
+		t.Fatal("first Allow after cooldown should hand out a probe")
+	}
+	if b.Allow() {
+		t.Fatal("second concurrent Allow during probe must be denied")
+	}
+
+	// Probe succeeds → breaker closes, subsequent calls flow.
+	b.RecordSuccess(50 * time.Millisecond)
+	if got := b.Stats().State; got != "closed" {
+		t.Fatalf("state=%q want closed", got)
+	}
+	if !b.Allow() {
+		t.Fatal("breaker should be closed after successful probe")
+	}
+}
+
+func TestBreaker_HalfOpenProbeFailureReopens(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	b := NewBreaker(1, 10*time.Second, 0)
+	b.clock = func() time.Time { return now }
+
+	b.Allow()
+	b.RecordFailure(errors.New("boom"))
+
+	// Cooldown elapses, probe is granted, but probe fails.
+	b.clock = func() time.Time { return now.Add(11 * time.Second) }
+	if !b.Allow() {
+		t.Fatal("probe should be granted")
+	}
+	b.RecordFailure(errors.New("still down"))
+
+	if got := b.Stats().State; got != "open" {
+		t.Fatalf("after probe failure state=%q want open", got)
+	}
+	// Cooldown re-starts: more calls within cooldown are denied.
+	b.clock = func() time.Time { return now.Add(15 * time.Second) }
+	if b.Allow() {
+		t.Fatal("breaker should reject after probe failure, within new cooldown")
+	}
+}
+
+func TestBreaker_SuccessResetsConsecutiveCount(t *testing.T) {
+	b := NewBreaker(3, time.Minute, 0)
+	b.Allow()
+	b.RecordFailure(errors.New("a"))
+	b.Allow()
+	b.RecordFailure(errors.New("b"))
+	b.Allow()
+	b.RecordSuccess(10 * time.Millisecond)
+	// 2 failures + success → counter reset; 2 more failures should not open.
+	for i := 0; i < 2; i++ {
+		b.Allow()
+		b.RecordFailure(errors.New("c"))
+	}
+	if got := b.Stats().State; got != "closed" {
+		t.Fatalf("state=%q want closed", got)
+	}
+}
+
+func TestBreaker_LatencyPercentiles(t *testing.T) {
+	b := NewBreaker(5, time.Minute, 100)
+	for ms := int64(1); ms <= 100; ms++ {
+		b.Allow()
+		b.RecordSuccess(time.Duration(ms) * time.Millisecond)
+	}
+	st := b.Stats()
+	// 100-element buffer, p50 ≈ value at idx 49 = 50ms.
+	if st.LatencyP50Ms != 50 {
+		t.Fatalf("p50=%d want 50", st.LatencyP50Ms)
+	}
+	if st.LatencyP95Ms != 95 {
+		t.Fatalf("p95=%d want 95", st.LatencyP95Ms)
+	}
+}
+
+func TestBreaker_StatsCountersAccumulate(t *testing.T) {
+	b := NewBreaker(2, time.Minute, 0)
+	b.Allow()
+	b.RecordSuccess(0)
+	b.Allow()
+	b.RecordFailure(errors.New("x"))
+	b.Allow()
+	b.RecordFailure(errors.New("y")) // trips
+	st := b.Stats()
+	if st.TotalSuccess != 1 || st.TotalFailure != 2 || st.TotalOpens != 1 {
+		t.Fatalf("counters off: %+v", st)
+	}
+	if st.LastError != "y" {
+		t.Fatalf("last_error=%q want y", st.LastError)
+	}
+}

--- a/pkg/agent/ai/openai.go
+++ b/pkg/agent/ai/openai.go
@@ -15,21 +15,49 @@ import (
 	"github.com/VersusControl/versus-incident/pkg/core"
 )
 
-// defaultOpenAIChatURL is the OpenAI chat/completions endpoint. Used
-// as the fallback when AgentAIConfig.BaseURL is empty. Operators set
-// BaseURL to point at any OpenAI-compatible provider — e.g. Google's
-// `https://generativelanguage.googleapis.com/v1beta/openai/chat/completions`
-// for Gemini, or a local LiteLLM/OpenRouter proxy.
-const defaultOpenAIChatURL = "https://api.openai.com/v1/chat/completions"
+// ProviderURL resolves the chat/completions endpoint for the named
+// AI provider. All three supported providers speak the OpenAI
+// chat/completions wire format; only the host changes (Gemini and
+// Claude both ship an OpenAI compatibility shim). Returns an error
+// for unknown values so a misconfigured deploy fails at startup with
+// a clear message rather than silently 404'ing on every call.
+//
+// Empty input is treated as "openai" for backwards compatibility with
+// configs written before the field existed.
+func ProviderURL(provider string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "", "openai":
+		return "https://api.openai.com/v1/chat/completions", nil
+	case "gemini":
+		return "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions", nil
+	case "claude":
+		return "https://api.anthropic.com/v1/chat/completions", nil
+	default:
+		return "", fmt.Errorf("ai: unknown provider %q (want openai | gemini | claude)", provider)
+	}
+}
+
+// normalizeProvider returns the canonical lowercase provider name,
+// using "openai" for the empty default. Exposed so the audit log and
+// startup banner show what the analyzer is actually talking to.
+func normalizeProvider(provider string) string {
+	p := strings.ToLower(strings.TrimSpace(provider))
+	if p == "" {
+		return "openai"
+	}
+	return p
+}
 
 // OpenAI is an AISRE backed by an OpenAI-compatible /chat/completions
-// endpoint (OpenAI itself, Gemini's OpenAI-compatible layer, LiteLLM
-// proxy, OpenRouter, ...). One call per AgentResult; no streaming, no
-// tool use.
+// endpoint. The same client code drives OpenAI itself, Gemini's
+// OpenAI compatibility shim, and Anthropic's OpenAI compatibility
+// endpoint — the URL is the only thing that changes. Selected via
+// AgentAIConfig.Provider; see ProviderURL.
 type OpenAI struct {
 	cfg        config.AgentAIConfig
 	httpClient *http.Client
-	chatURL    string // resolved at construction; cfg.BaseURL or default
+	chatURL    string // resolved from cfg.Provider at construction
+	name       string // canonical provider name surfaced via Name()
 
 	// SampleFn extracts the sample lines passed to the model from an
 	// AgentResult. Defaults to "first up to 3 messages". Exposed so
@@ -46,8 +74,8 @@ type OpenAI struct {
 
 // NewOpenAI constructs the analyzer. httpClient may be nil — a sane
 // default (30s timeout, no proxy) is used. No retry — backwards
-// compatible.
-func NewOpenAI(cfg config.AgentAIConfig, client *http.Client) *OpenAI {
+// compatible. Returns an error for an unknown provider.
+func NewOpenAI(cfg config.AgentAIConfig, client *http.Client) (*OpenAI, error) {
 	return NewOpenAIWithRetry(cfg, client, 1, 0, 0)
 }
 
@@ -56,31 +84,35 @@ func NewOpenAI(cfg config.AgentAIConfig, client *http.Client) *OpenAI {
 // `min(maxBackoff, initialBackoff * 2^(attempt-1))` plus up to 25%
 // jitter. Retries fire on HTTP 429, any 5xx, or any network/transport
 // error. 4xx other than 429 surface immediately (the request is
-// fundamentally broken — retrying won't help).
-func NewOpenAIWithRetry(cfg config.AgentAIConfig, client *http.Client, maxAttempts int, initialBackoff, maxBackoff time.Duration) *OpenAI {
+// fundamentally broken — retrying won't help). Returns an error if
+// cfg.Provider is not one of the supported values.
+func NewOpenAIWithRetry(cfg config.AgentAIConfig, client *http.Client, maxAttempts int, initialBackoff, maxBackoff time.Duration) (*OpenAI, error) {
+	chatURL, err := ProviderURL(cfg.Provider)
+	if err != nil {
+		return nil, err
+	}
 	if client == nil {
 		client = &http.Client{Timeout: 30 * time.Second}
 	}
 	if maxAttempts < 1 {
 		maxAttempts = 1
 	}
-	chatURL := cfg.BaseURL
-	if chatURL == "" {
-		chatURL = defaultOpenAIChatURL
-	}
 	return &OpenAI{
 		cfg:            cfg,
 		httpClient:     client,
 		chatURL:        chatURL,
+		name:           normalizeProvider(cfg.Provider),
 		SampleFn:       defaultSampleFn,
 		maxAttempts:    maxAttempts,
 		initialBackoff: initialBackoff,
 		maxBackoff:     maxBackoff,
-	}
+	}, nil
 }
 
-// Name implements core.AISRE.
-func (o *OpenAI) Name() string { return "openai" }
+// Name implements core.AISRE. Returns the canonical provider name
+// ("openai" / "gemini" / "claude") so the audit log identifies the
+// backend each call actually hit.
+func (o *OpenAI) Name() string { return o.name }
 
 // Analyze sends the result to the configured chat endpoint and parses
 // the structured AIFinding from the response. The returned

--- a/pkg/agent/ai/openai.go
+++ b/pkg/agent/ai/openai.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"strings"
 	"time"
@@ -30,18 +31,49 @@ type OpenAI struct {
 	// the worker can swap in a redaction-aware extractor without the
 	// AI package depending on pkg/agent.
 	SampleFn func(core.AgentResult) []string
+
+	// Retry parameters. Zero values mean "no retry beyond the first
+	// attempt" — set by NewOpenAIWithRetry.
+	maxAttempts    int
+	initialBackoff time.Duration
+	maxBackoff     time.Duration
+
+	// sleep is the function used to wait between retries. Exposed for
+	// tests so they don't have to wait real wall-clock time.
+	sleep func(time.Duration)
+	// rng generates jitter; injectable so tests can pin it.
+	rng *rand.Rand
 }
 
 // NewOpenAI constructs the analyzer. httpClient may be nil — a sane
-// default (30s timeout, no proxy) is used.
+// default (30s timeout, no proxy) is used. No retry — backwards
+// compatible.
 func NewOpenAI(cfg config.AgentAIConfig, client *http.Client) *OpenAI {
+	return NewOpenAIWithRetry(cfg, client, 1, 0, 0)
+}
+
+// NewOpenAIWithRetry constructs the analyzer with explicit retry
+// parameters. maxAttempts <= 1 disables retry. Each retry sleeps
+// `min(maxBackoff, initialBackoff * 2^(attempt-1))` plus up to 25%
+// jitter. Retries fire on HTTP 429, any 5xx, or any network/transport
+// error. 4xx other than 429 surface immediately (the request is
+// fundamentally broken — retrying won't help).
+func NewOpenAIWithRetry(cfg config.AgentAIConfig, client *http.Client, maxAttempts int, initialBackoff, maxBackoff time.Duration) *OpenAI {
 	if client == nil {
 		client = &http.Client{Timeout: 30 * time.Second}
 	}
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
 	return &OpenAI{
-		cfg:        cfg,
-		httpClient: client,
-		SampleFn:   defaultSampleFn,
+		cfg:            cfg,
+		httpClient:     client,
+		SampleFn:       defaultSampleFn,
+		maxAttempts:    maxAttempts,
+		initialBackoff: initialBackoff,
+		maxBackoff:     maxBackoff,
+		sleep:          time.Sleep,
+		rng:            rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
@@ -126,9 +158,59 @@ func (o *OpenAI) do(ctx context.Context, body chatRequest) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("ai: marshal request: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, openAIChatURL, bytes.NewReader(buf))
+
+	attempts := o.maxAttempts
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		// Ctx already cancelled — give up immediately so callers see
+		// the underlying error, not a "retry exhausted" wrapper.
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("ai: http: %w", err)
+		}
+
+		data, status, err := o.doOnce(ctx, buf)
+		if err == nil {
+			return data, nil
+		}
+		lastErr = err
+
+		// Don't retry on non-retryable HTTP statuses (4xx other than
+		// 429). The first attempt either succeeds or we surface the
+		// error so the operator can fix config (bad API key, bad
+		// model name, etc.).
+		if !isRetryable(status, err) || attempt == attempts {
+			return nil, lastErr
+		}
+		// Compute exponential backoff with jitter.
+		backoff := o.initialBackoff
+		for i := 1; i < attempt; i++ {
+			backoff *= 2
+			if o.maxBackoff > 0 && backoff > o.maxBackoff {
+				backoff = o.maxBackoff
+				break
+			}
+		}
+		if o.rng != nil && backoff > 0 {
+			jitter := time.Duration(o.rng.Int63n(int64(backoff / 4)))
+			backoff += jitter
+		}
+		o.sleep(backoff)
+	}
+	return nil, lastErr
+}
+
+// doOnce performs a single HTTP attempt. Returns the response body
+// (nil on error), the HTTP status code (0 when no response was
+// received), and any error. The status code lets the caller tell
+// retryable failures (429, 5xx) from non-retryable (4xx other).
+func (o *OpenAI) doOnce(ctx context.Context, payload []byte) ([]byte, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, openAIChatURL, bytes.NewReader(payload))
 	if err != nil {
-		return nil, fmt.Errorf("ai: build request: %w", err)
+		return nil, 0, fmt.Errorf("ai: build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if o.cfg.APIKey != "" {
@@ -137,18 +219,36 @@ func (o *OpenAI) do(ctx context.Context, body chatRequest) ([]byte, error) {
 
 	resp, err := o.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("ai: http: %w", err)
+		return nil, 0, fmt.Errorf("ai: http: %w", err)
 	}
 	defer resp.Body.Close()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("ai: read body: %w", err)
+		return nil, resp.StatusCode, fmt.Errorf("ai: read body: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("ai: http %d: %s", resp.StatusCode, truncate(string(data), 300))
+		return nil, resp.StatusCode, fmt.Errorf("ai: http %d: %s", resp.StatusCode, truncate(string(data), 300))
 	}
-	return data, nil
+	return data, resp.StatusCode, nil
+}
+
+// isRetryable reports whether a failed attempt is worth retrying.
+// status==0 means the request never got a response (network/transport
+// failure) — usually transient. status==429 (rate limit) and 5xx
+// (server-side) are also transient. Anything else (400, 401, 403, 404,
+// 422…) is a client error that won't fix itself.
+func isRetryable(status int, err error) bool {
+	if status == 0 {
+		return err != nil
+	}
+	if status == http.StatusTooManyRequests {
+		return true
+	}
+	if status >= 500 && status < 600 {
+		return true
+	}
+	return false
 }
 
 // -----------------------------------------------------------------------------

--- a/pkg/agent/ai/openai.go
+++ b/pkg/agent/ai/openai.go
@@ -15,16 +15,21 @@ import (
 	"github.com/VersusControl/versus-incident/pkg/core"
 )
 
-// openAIChatURL is the standard OpenAI chat/completions endpoint.
-// Hard-coded so detect mode just works once the operator sets an API
-// key — no extra base_url plumbing.
-const openAIChatURL = "https://api.openai.com/v1/chat/completions"
+// defaultOpenAIChatURL is the OpenAI chat/completions endpoint. Used
+// as the fallback when AgentAIConfig.BaseURL is empty. Operators set
+// BaseURL to point at any OpenAI-compatible provider — e.g. Google's
+// `https://generativelanguage.googleapis.com/v1beta/openai/chat/completions`
+// for Gemini, or a local LiteLLM/OpenRouter proxy.
+const defaultOpenAIChatURL = "https://api.openai.com/v1/chat/completions"
 
-// OpenAI is an AISRE backed by OpenAI's /chat/completions endpoint.
-// One call per AgentResult; no streaming, no tool use.
+// OpenAI is an AISRE backed by an OpenAI-compatible /chat/completions
+// endpoint (OpenAI itself, Gemini's OpenAI-compatible layer, LiteLLM
+// proxy, OpenRouter, ...). One call per AgentResult; no streaming, no
+// tool use.
 type OpenAI struct {
 	cfg        config.AgentAIConfig
 	httpClient *http.Client
+	chatURL    string // resolved at construction; cfg.BaseURL or default
 
 	// SampleFn extracts the sample lines passed to the model from an
 	// AgentResult. Defaults to "first up to 3 messages". Exposed so
@@ -37,12 +42,6 @@ type OpenAI struct {
 	maxAttempts    int
 	initialBackoff time.Duration
 	maxBackoff     time.Duration
-
-	// sleep is the function used to wait between retries. Exposed for
-	// tests so they don't have to wait real wall-clock time.
-	sleep func(time.Duration)
-	// rng generates jitter; injectable so tests can pin it.
-	rng *rand.Rand
 }
 
 // NewOpenAI constructs the analyzer. httpClient may be nil — a sane
@@ -65,15 +64,18 @@ func NewOpenAIWithRetry(cfg config.AgentAIConfig, client *http.Client, maxAttemp
 	if maxAttempts < 1 {
 		maxAttempts = 1
 	}
+	chatURL := cfg.BaseURL
+	if chatURL == "" {
+		chatURL = defaultOpenAIChatURL
+	}
 	return &OpenAI{
 		cfg:            cfg,
 		httpClient:     client,
+		chatURL:        chatURL,
 		SampleFn:       defaultSampleFn,
 		maxAttempts:    maxAttempts,
 		initialBackoff: initialBackoff,
 		maxBackoff:     maxBackoff,
-		sleep:          time.Sleep,
-		rng:            rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
@@ -118,28 +120,50 @@ func (o *OpenAI) Analyze(ctx context.Context, r core.AgentResult) (*core.AICallR
 		ResponseFormat: &responseFormat{Type: "json_object"},
 	}
 
-	start := time.Now()
-	raw, err := o.do(ctx, body)
-	durationMs := time.Since(start).Milliseconds()
+	content, finishReason, durationMs, err := o.callOnce(ctx, body)
 	if err != nil {
 		return nil, err
 	}
 
-	var resp chatResponse
-	if err := json.Unmarshal(raw, &resp); err != nil {
-		return nil, fmt.Errorf("ai: decode response: %w", err)
+	// Auto-retry once when the response is truncated by max_tokens.
+	// More verbose models (Gemini-2.5-flash is a notable offender)
+	// often blow past a 512-token budget mid-JSON, leaving an
+	// unbalanced object that ParseFinding cannot recover. Doubling
+	// once usually clears it; capped at truncationRetryMaxTokens to
+	// bound cost on pathological prompts.
+	if finishReason == finishLength && body.MaxTokens < truncationRetryMaxTokens {
+		body.MaxTokens *= 2
+		if body.MaxTokens > truncationRetryMaxTokens {
+			body.MaxTokens = truncationRetryMaxTokens
+		}
+		retryContent, retryFinish, retryDur, retryErr := o.callOnce(ctx, body)
+		if retryErr != nil {
+			// Surface the retry error but keep going — the first
+			// (truncated) content may still parse into something
+			// usable, and the operator should see both signals.
+			return nil, fmt.Errorf("ai: truncated then retry failed: %w", retryErr)
+		}
+		content, finishReason = retryContent, retryFinish
+		durationMs += retryDur
 	}
-	if len(resp.Choices) == 0 {
-		return nil, fmt.Errorf("ai: response had no choices")
-	}
-	content := strings.TrimSpace(resp.Choices[0].Message.Content)
-	if content == "" {
-		return nil, fmt.Errorf("ai: empty content from model")
+
+	if finishReason == finishContentFilter {
+		return nil, fmt.Errorf("ai: response blocked by safety filter (finish_reason=content_filter)")
 	}
 
 	finding, err := ParseFinding(content)
 	if err != nil {
-		return nil, err
+		// Surface the first chunk of what the model actually returned
+		// so the detect audit log shows operators why parsing failed —
+		// otherwise they only see "no JSON object found" with no clue
+		// what the model said. Annotate the truncation case explicitly
+		// since it has a different fix (raise max_tokens) than other
+		// parse failures.
+		if finishReason == finishLength {
+			return nil, fmt.Errorf("ai: response truncated at max_tokens=%d, raise it (raw: %s)",
+				body.MaxTokens, truncate(content, 300))
+		}
+		return nil, fmt.Errorf("%w (raw: %s)", err, truncate(content, 300))
 	}
 	if finding.SampleIDs == nil && r.PatternID != "" {
 		finding.SampleIDs = []string{r.PatternID}
@@ -151,6 +175,35 @@ func (o *OpenAI) Analyze(ctx context.Context, r core.AgentResult) (*core.AICallR
 		DurationMs:  durationMs,
 		Model:       o.cfg.Model,
 	}, nil
+}
+
+// callOnce sends one chat request, parses the response envelope, and
+// returns the content + finish_reason + total wall-clock duration. It
+// is a thin wrapper over do() that decodes the OpenAI-shaped response
+// envelope; Analyze uses it twice when a truncation auto-retry is
+// needed.
+func (o *OpenAI) callOnce(ctx context.Context, body chatRequest) (content string, finishReason string, durationMs int64, err error) {
+	start := time.Now()
+	raw, doErr := o.do(ctx, body)
+	durationMs = time.Since(start).Milliseconds()
+	if doErr != nil {
+		return "", "", durationMs, doErr
+	}
+	var resp chatResponse
+	if jerr := json.Unmarshal(raw, &resp); jerr != nil {
+		return "", "", durationMs, fmt.Errorf("ai: decode response: %w", jerr)
+	}
+	if len(resp.Choices) == 0 {
+		return "", "", durationMs, fmt.Errorf("ai: response had no choices")
+	}
+	content = strings.TrimSpace(resp.Choices[0].Message.Content)
+	finishReason = resp.Choices[0].FinishReason
+	if content == "" && finishReason != finishContentFilter {
+		// Empty content with a stop/length finish_reason is anomalous;
+		// content_filter explains itself.
+		return "", finishReason, durationMs, fmt.Errorf("ai: empty content from model")
+	}
+	return content, finishReason, durationMs, nil
 }
 
 func (o *OpenAI) do(ctx context.Context, body chatRequest) ([]byte, error) {
@@ -166,9 +219,13 @@ func (o *OpenAI) do(ctx context.Context, body chatRequest) ([]byte, error) {
 
 	var lastErr error
 	for attempt := 1; attempt <= attempts; attempt++ {
-		// Ctx already cancelled — give up immediately so callers see
-		// the underlying error, not a "retry exhausted" wrapper.
+		// Ctx already cancelled — give up immediately. Surface
+		// lastErr when we have one (it carries useful HTTP detail like
+		// "ai: http 502: ...") and the bare ctx error otherwise.
 		if err := ctx.Err(); err != nil {
+			if lastErr != nil {
+				return nil, lastErr
+			}
 			return nil, fmt.Errorf("ai: http: %w", err)
 		}
 
@@ -185,7 +242,7 @@ func (o *OpenAI) do(ctx context.Context, body chatRequest) ([]byte, error) {
 		if !isRetryable(status, err) || attempt == attempts {
 			return nil, lastErr
 		}
-		// Compute exponential backoff with jitter.
+		// Compute exponential backoff with jitter (up to 25%).
 		backoff := o.initialBackoff
 		for i := 1; i < attempt; i++ {
 			backoff *= 2
@@ -194,11 +251,23 @@ func (o *OpenAI) do(ctx context.Context, body chatRequest) ([]byte, error) {
 				break
 			}
 		}
-		if o.rng != nil && backoff > 0 {
-			jitter := time.Duration(o.rng.Int63n(int64(backoff / 4)))
-			backoff += jitter
+		// rand.Int63n requires a positive argument; guard against
+		// extremely small backoffs that would round to zero.
+		if quarter := int64(backoff / 4); quarter > 0 {
+			backoff += time.Duration(rand.Int63n(quarter))
 		}
-		o.sleep(backoff)
+
+		// Honor ctx cancellation during the retry sleep so SIGTERM
+		// is not blocked by an in-flight backoff (worst case 15s
+		// across 3 attempts at default settings before this fix).
+		select {
+		case <-ctx.Done():
+			if lastErr != nil {
+				return nil, lastErr
+			}
+			return nil, fmt.Errorf("ai: http: %w", ctx.Err())
+		case <-time.After(backoff):
+		}
 	}
 	return nil, lastErr
 }
@@ -208,7 +277,7 @@ func (o *OpenAI) do(ctx context.Context, body chatRequest) ([]byte, error) {
 // received), and any error. The status code lets the caller tell
 // retryable failures (429, 5xx) from non-retryable (4xx other).
 func (o *OpenAI) doOnce(ctx context.Context, payload []byte) ([]byte, int, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, openAIChatURL, bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.chatURL, bytes.NewReader(payload))
 	if err != nil {
 		return nil, 0, fmt.Errorf("ai: build request: %w", err)
 	}
@@ -274,9 +343,29 @@ type responseFormat struct {
 
 type chatResponse struct {
 	Choices []struct {
-		Message chatMessage `json:"message"`
+		Message      chatMessage `json:"message"`
+		FinishReason string      `json:"finish_reason,omitempty"`
 	} `json:"choices"`
 }
+
+// Sentinel finish_reason values surfaced by both OpenAI and Gemini's
+// OpenAI-compatible shim. Other providers (Claude via LiteLLM, etc.)
+// usually map to these via their adapters.
+const (
+	// finishLength means the model hit max_tokens before completing.
+	// For our JSON-output prompt this means the JSON object is
+	// truncated → ParseFinding will fail with "no JSON object found".
+	// We auto-retry once with doubled max_tokens to recover.
+	finishLength = "length"
+	// finishContentFilter means the provider's safety filter blocked
+	// the response. Retrying with more tokens will not help — surface
+	// a clear error so the operator can adjust the prompt or model.
+	finishContentFilter = "content_filter"
+	// truncationRetryMaxTokens caps how large the auto-retry will
+	// allow max_tokens to grow. Beyond this we give up rather than
+	// rack up costs.
+	truncationRetryMaxTokens = 4096
+)
 
 // -----------------------------------------------------------------------------
 // helpers

--- a/pkg/agent/ai/openai_test.go
+++ b/pkg/agent/ai/openai_test.go
@@ -1,0 +1,214 @@
+package ai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/config"
+	"github.com/VersusControl/versus-incident/pkg/core"
+)
+
+func newClientHittingServer(t *testing.T, srv *httptest.Server) *http.Client {
+	t.Helper()
+	return srv.Client()
+}
+
+func newOpenAIForTest(t *testing.T, srv *httptest.Server, attempts int) *OpenAI {
+	t.Helper()
+	o := NewOpenAIWithRetry(
+		config.AgentAIConfig{Model: "test-model", APIKey: "k"},
+		newClientHittingServer(t, srv),
+		attempts,
+		1*time.Millisecond, // initial backoff
+		2*time.Millisecond, // max backoff
+	)
+	// Make sleep & jitter deterministic + cheap.
+	o.sleep = func(time.Duration) {}
+	o.rng = nil
+	return o
+}
+
+// rewrite the request URL so the analyzer hits our httptest server
+// instead of api.openai.com. We do this by overriding the transport.
+type rewritingTransport struct {
+	dst http.RoundTripper
+	url string
+}
+
+func (r *rewritingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Replace scheme+host with the test server's.
+	new, err := http.NewRequestWithContext(req.Context(), req.Method, r.url, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range req.Header {
+		new.Header[k] = v
+	}
+	return r.dst.RoundTrip(new)
+}
+
+func withHandler(t *testing.T, handler http.HandlerFunc) (*OpenAI, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	o := NewOpenAIWithRetry(
+		config.AgentAIConfig{Model: "test-model", APIKey: "k"},
+		&http.Client{
+			Transport: &rewritingTransport{dst: http.DefaultTransport, url: srv.URL},
+			Timeout:   2 * time.Second,
+		},
+		3,
+		1*time.Millisecond,
+		2*time.Millisecond,
+	)
+	o.sleep = func(time.Duration) {}
+	o.rng = nil
+	return o, srv
+}
+
+func goodResponse() string {
+	// Minimum JSON for ParseFinding — title/severity present, JSON
+	// well-formed (the body is a JSON object containing the fields
+	// ParseFinding looks for).
+	return `{"choices":[{"message":{"content":"{\"verdict\":\"unknown\",\"title\":\"t\",\"severity\":\"warn\",\"category\":\"infra\",\"confidence\":0.5,\"summary\":\"s\",\"suggested_actions\":[]}"}}]}`
+}
+
+func sampleResult() core.AgentResult {
+	return core.AgentResult{
+		Verdict:   core.VerdictUnknown,
+		PatternID: "p1",
+		Template:  "t",
+		SampleSignals: []core.Signal{
+			{Message: "boom"},
+		},
+		Frequency: 1,
+	}
+}
+
+func TestOpenAI_RetriesOn429(t *testing.T) {
+	var calls int32
+	o, _ := withHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"rate"}`))
+			return
+		}
+		_, _ = w.Write([]byte(goodResponse()))
+	})
+
+	res, err := o.Analyze(context.Background(), sampleResult())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.Finding == nil {
+		t.Fatal("nil result/finding")
+	}
+	if atomic.LoadInt32(&calls) != 2 {
+		t.Fatalf("calls=%d want 2", calls)
+	}
+}
+
+func TestOpenAI_RetriesOn5xx(t *testing.T) {
+	var calls int32
+	o, _ := withHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(goodResponse()))
+	})
+
+	if _, err := o.Analyze(context.Background(), sampleResult()); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if atomic.LoadInt32(&calls) != 3 {
+		t.Fatalf("calls=%d want 3", calls)
+	}
+}
+
+func TestOpenAI_NoRetryOn4xx(t *testing.T) {
+	var calls int32
+	o, _ := withHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"bad key"}`))
+	})
+
+	_, err := o.Analyze(context.Background(), sampleResult())
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Fatalf("err=%v want it to mention 401", err)
+	}
+	if atomic.LoadInt32(&calls) != 1 {
+		t.Fatalf("calls=%d want 1 (no retry on 4xx)", calls)
+	}
+}
+
+func TestOpenAI_RetryExhausted(t *testing.T) {
+	var calls int32
+	o, _ := withHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadGateway)
+	})
+
+	_, err := o.Analyze(context.Background(), sampleResult())
+	if err == nil {
+		t.Fatal("expected error after retries exhausted")
+	}
+	if atomic.LoadInt32(&calls) != 3 {
+		t.Fatalf("calls=%d want 3 (maxAttempts)", calls)
+	}
+}
+
+func TestOpenAI_NoRetryWhenAttemptsIs1(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	t.Cleanup(srv.Close)
+
+	o := NewOpenAIWithRetry(
+		config.AgentAIConfig{Model: "test-model", APIKey: "k"},
+		&http.Client{
+			Transport: &rewritingTransport{dst: http.DefaultTransport, url: srv.URL},
+			Timeout:   2 * time.Second,
+		},
+		1, 0, 0,
+	)
+
+	if _, err := o.Analyze(context.Background(), sampleResult()); err == nil {
+		t.Fatal("expected error")
+	}
+	if atomic.LoadInt32(&calls) != 1 {
+		t.Fatalf("calls=%d want 1", calls)
+	}
+}
+
+func TestOpenAI_ContextCancelStopsRetry(t *testing.T) {
+	var calls int32
+	o, _ := withHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	if _, err := o.Analyze(ctx, sampleResult()); err == nil {
+		t.Fatal("expected error")
+	}
+	// One attempt may have raced — we just want to verify we didn't burn through all 3.
+	if got := atomic.LoadInt32(&calls); got > 1 {
+		t.Fatalf("calls=%d want <=1 (context already cancelled)", got)
+	}
+}

--- a/pkg/agent/ai/openai_test.go
+++ b/pkg/agent/ai/openai_test.go
@@ -18,15 +18,21 @@ func withHandler(t *testing.T, handler http.HandlerFunc) (*OpenAI, *httptest.Ser
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
-	// Use BaseURL to point straight at the test server — no transport
-	// rewriting needed. This also exercises the BaseURL config path.
-	o := NewOpenAIWithRetry(
-		config.AgentAIConfig{Model: "test-model", APIKey: "k", BaseURL: srv.URL},
+	// Construct with provider=openai (the default URL), then override
+	// chatURL to the httptest server. We can reach the unexported
+	// field because the test lives in the same package; this avoids
+	// adding a public seam just for tests.
+	o, err := NewOpenAIWithRetry(
+		config.AgentAIConfig{Model: "test-model", APIKey: "k", Provider: "openai"},
 		&http.Client{Timeout: 2 * time.Second},
 		3,
 		1*time.Millisecond,
 		2*time.Millisecond,
 	)
+	if err != nil {
+		t.Fatalf("construct: %v", err)
+	}
+	o.chatURL = srv.URL
 	return o, srv
 }
 
@@ -137,24 +143,70 @@ func TestOpenAI_ContentFilterErrorIsClear(t *testing.T) {
 	}
 }
 
-// TestOpenAI_BaseURLDefault verifies that omitting BaseURL falls back
-// to the OpenAI endpoint. We don't actually call OpenAI; we just
-// check the resolved URL on the struct.
-func TestOpenAI_BaseURLDefault(t *testing.T) {
-	o := NewOpenAI(config.AgentAIConfig{Model: "m", APIKey: "k"}, nil)
-	if o.chatURL != defaultOpenAIChatURL {
-		t.Fatalf("default base url not honored: got %q want %q", o.chatURL, defaultOpenAIChatURL)
+// TestProviderURL covers the supported provider names + the empty
+// default + an unknown value. The endpoints are operator-visible
+// (any change is a behavior break) so we lock them down with an
+// exact-match assertion.
+func TestProviderURL(t *testing.T) {
+	cases := []struct {
+		provider string
+		wantURL  string
+		wantErr  bool
+	}{
+		{"", "https://api.openai.com/v1/chat/completions", false}, // default
+		{"openai", "https://api.openai.com/v1/chat/completions", false},
+		{"OpenAI", "https://api.openai.com/v1/chat/completions", false}, // case-insensitive
+		{"gemini", "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions", false},
+		{"  gemini  ", "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions", false}, // whitespace-tolerant
+		{"claude", "https://api.anthropic.com/v1/chat/completions", false},
+		{"anthropic", "", true}, // common typo; explicit reject
+		{"bedrock", "", true},
+		{"openrouter", "", true},
+	}
+	for _, tc := range cases {
+		got, err := ProviderURL(tc.provider)
+		switch {
+		case tc.wantErr && err == nil:
+			t.Errorf("ProviderURL(%q): expected error, got url=%q", tc.provider, got)
+		case !tc.wantErr && err != nil:
+			t.Errorf("ProviderURL(%q): unexpected error: %v", tc.provider, err)
+		case !tc.wantErr && got != tc.wantURL:
+			t.Errorf("ProviderURL(%q): got %q, want %q", tc.provider, got, tc.wantURL)
+		}
 	}
 }
 
-// TestOpenAI_BaseURLConfigured verifies that an explicit BaseURL is
-// preserved end-to-end. This is the path operators use to swap in
-// Gemini's OpenAI-compatible endpoint or a LiteLLM proxy.
-func TestOpenAI_BaseURLConfigured(t *testing.T) {
-	custom := "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
-	o := NewOpenAI(config.AgentAIConfig{Model: "gemini-2.0-flash", APIKey: "k", BaseURL: custom}, nil)
-	if o.chatURL != custom {
-		t.Fatalf("configured base url not honored: got %q want %q", o.chatURL, custom)
+// TestNewOpenAI_PropagatesProviderError ensures construction fails
+// fast when the operator misconfigures the provider — otherwise the
+// analyzer would 404 on every call instead of telling the operator
+// at startup.
+func TestNewOpenAI_PropagatesProviderError(t *testing.T) {
+	if _, err := NewOpenAI(config.AgentAIConfig{Model: "m", APIKey: "k", Provider: "bogus"}, nil); err == nil {
+		t.Fatal("expected error from NewOpenAI with unknown provider")
+	}
+}
+
+// TestOpenAI_NameReflectsProvider verifies Name() returns the
+// canonical lowercase provider name so the audit log and startup
+// banner show what the analyzer is actually talking to.
+func TestOpenAI_NameReflectsProvider(t *testing.T) {
+	for _, in := range []string{"", "openai", "OpenAI"} {
+		o, err := NewOpenAI(config.AgentAIConfig{Model: "m", APIKey: "k", Provider: in}, nil)
+		if err != nil {
+			t.Fatalf("construct(%q): %v", in, err)
+		}
+		if got := o.Name(); got != "openai" {
+			t.Errorf("Name() for provider=%q: got %q, want openai", in, got)
+		}
+	}
+	for _, p := range []string{"gemini", "claude"} {
+		o, err := NewOpenAI(config.AgentAIConfig{Model: "m", APIKey: "k", Provider: p}, nil)
+		if err != nil {
+			t.Fatalf("construct(%q): %v", p, err)
+		}
+		if got := o.Name(); got != p {
+			t.Errorf("Name() for provider=%q: got %q, want %q", p, got, p)
+		}
 	}
 }
 
@@ -245,11 +297,15 @@ func TestOpenAI_NoRetryWhenAttemptsIs1(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	o := NewOpenAIWithRetry(
-		config.AgentAIConfig{Model: "test-model", APIKey: "k", BaseURL: srv.URL},
+	o, err := NewOpenAIWithRetry(
+		config.AgentAIConfig{Model: "test-model", APIKey: "k", Provider: "openai"},
 		&http.Client{Timeout: 2 * time.Second},
 		1, 0, 0,
 	)
+	if err != nil {
+		t.Fatalf("construct: %v", err)
+	}
+	o.chatURL = srv.URL
 
 	if _, err := o.Analyze(context.Background(), sampleResult()); err == nil {
 		t.Fatal("expected error")
@@ -271,13 +327,17 @@ func TestOpenAI_CancelDuringSleepReturnsFast(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	o := NewOpenAIWithRetry(
-		config.AgentAIConfig{Model: "test-model", APIKey: "k", BaseURL: srv.URL},
+	o, err := NewOpenAIWithRetry(
+		config.AgentAIConfig{Model: "test-model", APIKey: "k", Provider: "openai"},
 		&http.Client{Timeout: 2 * time.Second},
 		3,
 		2*time.Second, // initial backoff — long enough that a non-ctx-aware sleep would hang
 		5*time.Second,
 	)
+	if err != nil {
+		t.Fatalf("construct: %v", err)
+	}
+	o.chatURL = srv.URL
 	ctx, cancel := context.WithCancel(context.Background())
 	// Cancel ~50ms in, during the first retry sleep.
 	go func() {
@@ -286,9 +346,9 @@ func TestOpenAI_CancelDuringSleepReturnsFast(t *testing.T) {
 	}()
 
 	start := time.Now()
-	_, err := o.Analyze(ctx, sampleResult())
+	_, analyzeErr := o.Analyze(ctx, sampleResult())
 	elapsed := time.Since(start)
-	if err == nil {
+	if analyzeErr == nil {
 		t.Fatal("expected error after cancel")
 	}
 	if elapsed > 500*time.Millisecond {

--- a/pkg/agent/ai/openai_test.go
+++ b/pkg/agent/ai/openai_test.go
@@ -13,62 +13,20 @@ import (
 	"github.com/VersusControl/versus-incident/pkg/core"
 )
 
-func newClientHittingServer(t *testing.T, srv *httptest.Server) *http.Client {
-	t.Helper()
-	return srv.Client()
-}
-
-func newOpenAIForTest(t *testing.T, srv *httptest.Server, attempts int) *OpenAI {
-	t.Helper()
-	o := NewOpenAIWithRetry(
-		config.AgentAIConfig{Model: "test-model", APIKey: "k"},
-		newClientHittingServer(t, srv),
-		attempts,
-		1*time.Millisecond, // initial backoff
-		2*time.Millisecond, // max backoff
-	)
-	// Make sleep & jitter deterministic + cheap.
-	o.sleep = func(time.Duration) {}
-	o.rng = nil
-	return o
-}
-
-// rewrite the request URL so the analyzer hits our httptest server
-// instead of api.openai.com. We do this by overriding the transport.
-type rewritingTransport struct {
-	dst http.RoundTripper
-	url string
-}
-
-func (r *rewritingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Replace scheme+host with the test server's.
-	new, err := http.NewRequestWithContext(req.Context(), req.Method, r.url, req.Body)
-	if err != nil {
-		return nil, err
-	}
-	for k, v := range req.Header {
-		new.Header[k] = v
-	}
-	return r.dst.RoundTrip(new)
-}
-
 func withHandler(t *testing.T, handler http.HandlerFunc) (*OpenAI, *httptest.Server) {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
+	// Use BaseURL to point straight at the test server — no transport
+	// rewriting needed. This also exercises the BaseURL config path.
 	o := NewOpenAIWithRetry(
-		config.AgentAIConfig{Model: "test-model", APIKey: "k"},
-		&http.Client{
-			Transport: &rewritingTransport{dst: http.DefaultTransport, url: srv.URL},
-			Timeout:   2 * time.Second,
-		},
+		config.AgentAIConfig{Model: "test-model", APIKey: "k", BaseURL: srv.URL},
+		&http.Client{Timeout: 2 * time.Second},
 		3,
 		1*time.Millisecond,
 		2*time.Millisecond,
 	)
-	o.sleep = func(time.Duration) {}
-	o.rng = nil
 	return o, srv
 }
 
@@ -77,6 +35,22 @@ func goodResponse() string {
 	// well-formed (the body is a JSON object containing the fields
 	// ParseFinding looks for).
 	return `{"choices":[{"message":{"content":"{\"verdict\":\"unknown\",\"title\":\"t\",\"severity\":\"warn\",\"category\":\"infra\",\"confidence\":0.5,\"summary\":\"s\",\"suggested_actions\":[]}"}}]}`
+}
+
+// truncatedResponse returns a chat envelope whose content is a JSON
+// object missing its closing brace — simulating Gemini-style
+// truncation when the model hits max_tokens mid-output. The envelope
+// itself is valid; ParseFinding will fail on the content.
+func truncatedResponse() string {
+	return `{"choices":[{"finish_reason":"length","message":{"content":"{\"title\":\"truncated mid output, no closing brace\",\"summary\":\"this response was cut o"}}]}`
+}
+
+func goodResponseWithFinishStop() string {
+	return `{"choices":[{"finish_reason":"stop","message":{"content":"{\"verdict\":\"unknown\",\"title\":\"t\",\"severity\":\"warn\",\"category\":\"infra\",\"confidence\":0.5,\"summary\":\"s\",\"suggested_actions\":[]}"}}]}`
+}
+
+func contentFilterResponse() string {
+	return `{"choices":[{"finish_reason":"content_filter","message":{"content":""}}]}`
 }
 
 func sampleResult() core.AgentResult {
@@ -88,6 +62,99 @@ func sampleResult() core.AgentResult {
 			{Message: "boom"},
 		},
 		Frequency: 1,
+	}
+}
+
+// TestOpenAI_TruncationAutoRetry verifies that a finish_reason="length"
+// triggers exactly one auto-retry with doubled max_tokens. The first
+// call returns a truncated JSON object; the retry returns the full
+// object. Analyze should succeed using the retry's content.
+func TestOpenAI_TruncationAutoRetry(t *testing.T) {
+	var calls int32
+	o, _ := withHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			// First call: model says it ran out of tokens.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(truncatedResponse()))
+			return
+		}
+		// Retry: full response.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(goodResponseWithFinishStop()))
+	})
+
+	res, err := o.Analyze(context.Background(), sampleResult())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil || res.Finding == nil {
+		t.Fatal("nil result/finding after auto-retry")
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("expected 2 calls (1 truncated + 1 retry), got %d", got)
+	}
+}
+
+// TestOpenAI_TruncationRetryFailsWithClearError covers the case where
+// the retry STILL returns truncated content. The error should
+// explicitly mention max_tokens so operators know the fix.
+func TestOpenAI_TruncationRetryFailsWithClearError(t *testing.T) {
+	o, _ := withHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(truncatedResponse()))
+	})
+
+	_, err := o.Analyze(context.Background(), sampleResult())
+	if err == nil {
+		t.Fatal("expected error when both attempts truncate")
+	}
+	if !strings.Contains(err.Error(), "truncated") || !strings.Contains(err.Error(), "max_tokens") {
+		t.Fatalf("error should mention truncation+max_tokens; got: %v", err)
+	}
+}
+
+// TestOpenAI_ContentFilterErrorIsClear verifies that finish_reason=
+// content_filter does NOT retry (more tokens won't unblock a safety
+// filter) and surfaces a recognizable error.
+func TestOpenAI_ContentFilterErrorIsClear(t *testing.T) {
+	var calls int32
+	o, _ := withHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(contentFilterResponse()))
+	})
+
+	_, err := o.Analyze(context.Background(), sampleResult())
+	if err == nil {
+		t.Fatal("expected error on content_filter")
+	}
+	if !strings.Contains(err.Error(), "safety filter") {
+		t.Fatalf("error should mention safety filter; got: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("content_filter must not auto-retry; calls=%d want 1", got)
+	}
+}
+
+// TestOpenAI_BaseURLDefault verifies that omitting BaseURL falls back
+// to the OpenAI endpoint. We don't actually call OpenAI; we just
+// check the resolved URL on the struct.
+func TestOpenAI_BaseURLDefault(t *testing.T) {
+	o := NewOpenAI(config.AgentAIConfig{Model: "m", APIKey: "k"}, nil)
+	if o.chatURL != defaultOpenAIChatURL {
+		t.Fatalf("default base url not honored: got %q want %q", o.chatURL, defaultOpenAIChatURL)
+	}
+}
+
+// TestOpenAI_BaseURLConfigured verifies that an explicit BaseURL is
+// preserved end-to-end. This is the path operators use to swap in
+// Gemini's OpenAI-compatible endpoint or a LiteLLM proxy.
+func TestOpenAI_BaseURLConfigured(t *testing.T) {
+	custom := "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+	o := NewOpenAI(config.AgentAIConfig{Model: "gemini-2.0-flash", APIKey: "k", BaseURL: custom}, nil)
+	if o.chatURL != custom {
+		t.Fatalf("configured base url not honored: got %q want %q", o.chatURL, custom)
 	}
 }
 
@@ -179,11 +246,8 @@ func TestOpenAI_NoRetryWhenAttemptsIs1(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	o := NewOpenAIWithRetry(
-		config.AgentAIConfig{Model: "test-model", APIKey: "k"},
-		&http.Client{
-			Transport: &rewritingTransport{dst: http.DefaultTransport, url: srv.URL},
-			Timeout:   2 * time.Second,
-		},
+		config.AgentAIConfig{Model: "test-model", APIKey: "k", BaseURL: srv.URL},
+		&http.Client{Timeout: 2 * time.Second},
 		1, 0, 0,
 	)
 
@@ -192,6 +256,43 @@ func TestOpenAI_NoRetryWhenAttemptsIs1(t *testing.T) {
 	}
 	if atomic.LoadInt32(&calls) != 1 {
 		t.Fatalf("calls=%d want 1", calls)
+	}
+}
+
+// TestOpenAI_CancelDuringSleepReturnsFast verifies the ctx-aware
+// retry sleep added in v1.4.1 hardening. Before this fix, an
+// in-flight backoff blocked SIGTERM for up to MaxBackoff seconds.
+// We use a server that always returns 503 and an unusually large
+// backoff so the test would obviously hang without the ctx-aware
+// sleep.
+func TestOpenAI_CancelDuringSleepReturnsFast(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	o := NewOpenAIWithRetry(
+		config.AgentAIConfig{Model: "test-model", APIKey: "k", BaseURL: srv.URL},
+		&http.Client{Timeout: 2 * time.Second},
+		3,
+		2*time.Second, // initial backoff — long enough that a non-ctx-aware sleep would hang
+		5*time.Second,
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel ~50ms in, during the first retry sleep.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := o.Analyze(ctx, sampleResult())
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected error after cancel")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("Analyze took %s — the retry sleep ignored ctx cancel", elapsed)
 	}
 }
 

--- a/pkg/agent/catalog.go
+++ b/pkg/agent/catalog.go
@@ -57,12 +57,27 @@ type ServiceInfo struct {
 // debounced — calls to MarkDirty() set a flag that the agent worker flushes
 // at most once per `persist_interval`.
 type Catalog struct {
-	mu       sync.RWMutex
-	store    storage.Provider
-	blobName string
-	patterns map[string]*Pattern
-	services map[string]*ServiceInfo
-	dirty    bool
+	mu          sync.RWMutex
+	store       storage.Provider
+	blobName    string
+	patterns    map[string]*Pattern
+	services    map[string]*ServiceInfo
+	dirty       bool
+	maxPatterns int // 0 = unlimited
+}
+
+// SetMaxPatterns configures an upper bound on the number of patterns
+// kept in the catalog. When the limit is reached and Upsert needs to
+// add a new pattern, the least-frequent pattern that is NOT marked
+// "known" is evicted. "Known" patterns are operator-curated baseline
+// and stay even if rarely seen.
+func (c *Catalog) SetMaxPatterns(n int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if n < 0 {
+		n = 0
+	}
+	c.maxPatterns = n
 }
 
 // catalogFile is the on-disk schema. Versioned so we can evolve the
@@ -110,11 +125,22 @@ func LoadCatalog(store storage.Provider) (*Catalog, error) {
 	return c, nil
 }
 
-// Get returns a pattern by ID (nil when not found).
+// Get returns a deep copy of the pattern keyed by id, or nil when not
+// found. Returning a copy (rather than the live pointer) prevents
+// callers from observing torn reads while a concurrent Upsert mutates
+// the same struct.
 func (c *Catalog) Get(id string) *Pattern {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.patterns[id]
+	p, ok := c.patterns[id]
+	if !ok {
+		return nil
+	}
+	cp := *p
+	if p.Tags != nil {
+		cp.Tags = append([]string(nil), p.Tags...)
+	}
+	return &cp
 }
 
 // MarkKnown stamps a pattern as auto-promoted ("known") in the catalog.
@@ -179,6 +205,12 @@ func (c *Catalog) Upsert(patternID, template, source string, tickCount int, alph
 	now := time.Now().UTC()
 	p, ok := c.patterns[patternID]
 	if !ok {
+		// Honor the configured cap before inserting. Eviction targets
+		// the least-frequent non-"known" pattern; this preserves
+		// operator-curated baseline regardless of how rarely it fires.
+		if c.maxPatterns > 0 && len(c.patterns) >= c.maxPatterns {
+			c.evictLeastFrequentLocked()
+		}
 		p = &Pattern{
 			ID:        patternID,
 			Template:  template,
@@ -212,6 +244,27 @@ func (c *Catalog) Upsert(patternID, template, source string, tickCount int, alph
 	}
 	c.dirty = true
 	return p
+}
+
+// evictLeastFrequentLocked drops the least-frequent non-known pattern.
+// Caller must hold c.mu. When every remaining pattern is "known" the
+// cap is exceeded silently — operators chose to mark them so, and we
+// will not auto-evict curated baseline.
+func (c *Catalog) evictLeastFrequentLocked() {
+	var victim *Pattern
+	for _, p := range c.patterns {
+		if p.Verdict == "known" {
+			continue
+		}
+		if victim == nil || p.Count < victim.Count ||
+			(p.Count == victim.Count && p.LastSeen.Before(victim.LastSeen)) {
+			victim = p
+		}
+	}
+	if victim != nil {
+		delete(c.patterns, victim.ID)
+		c.dirty = true
+	}
 }
 
 // Label updates operator-curated metadata for a pattern. Empty fields are

--- a/pkg/agent/catalog_test.go
+++ b/pkg/agent/catalog_test.go
@@ -1,11 +1,147 @@
 package agent
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/VersusControl/versus-incident/pkg/storage"
 )
+
+// TestCatalog_ConcurrentGetUpsertNoRace catches the data race where
+// Catalog.Get returned a live *Pattern that callers could read while
+// a concurrent Upsert was writing to the same struct. Run with -race
+// to verify; without -race the test will pass even on the buggy code.
+// TestCatalog_MaxPatternsEvictsLeastFrequent verifies M2: the catalog
+// bounds its size and evicts the least-frequent NON-"known" pattern
+// when adding a new one would exceed the cap. Known patterns are
+// operator-curated baseline and must survive eviction.
+func TestCatalog_MaxPatternsEvictsLeastFrequent(t *testing.T) {
+	store := newTestStore(t)
+	cat, err := LoadCatalog(store)
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	cat.SetMaxPatterns(3)
+
+	// Seed 3 patterns with different counts; #1 has the lowest count.
+	cat.Upsert("p1", "tpl1", "src", 1, 0.2, "rule", "svc")
+	cat.Upsert("p2", "tpl2", "src", 10, 0.2, "rule", "svc")
+	cat.Upsert("p3", "tpl3", "src", 5, 0.2, "rule", "svc")
+	if got := cat.Len(); got != 3 {
+		t.Fatalf("seed: len=%d want 3", got)
+	}
+
+	// Adding a 4th pattern must evict p1 (lowest Count).
+	cat.Upsert("p4", "tpl4", "src", 100, 0.2, "rule", "svc")
+	if got := cat.Len(); got != 3 {
+		t.Fatalf("after insert: len=%d want 3 (eviction)", got)
+	}
+	if cat.Get("p1") != nil {
+		t.Fatal("p1 should have been evicted (least-frequent)")
+	}
+	if cat.Get("p4") == nil {
+		t.Fatal("p4 should be present after eviction")
+	}
+}
+
+func TestCatalog_MaxPatternsPreservesKnown(t *testing.T) {
+	store := newTestStore(t)
+	cat, _ := LoadCatalog(store)
+	cat.SetMaxPatterns(2)
+
+	// pLow is the lowest-count pattern but operator-curated as "known".
+	cat.Upsert("pLow", "tpl-low", "src", 1, 0.2, "rule", "svc")
+	cat.MarkKnown("pLow")
+	cat.Upsert("pHigh", "tpl-high", "src", 100, 0.2, "rule", "svc")
+
+	// Adding a 3rd pattern must NOT evict pLow even though it's lowest
+	// count — known patterns survive eviction. pHigh (the only non-
+	// known pattern) is the victim.
+	cat.Upsert("pNew", "tpl-new", "src", 50, 0.2, "rule", "svc")
+
+	if cat.Get("pLow") == nil {
+		t.Fatal("known pattern pLow must NOT be evicted")
+	}
+	if cat.Get("pHigh") != nil {
+		t.Fatal("non-known pHigh should have been evicted")
+	}
+}
+
+func TestCatalog_MaxPatternsZeroDisabled(t *testing.T) {
+	store := newTestStore(t)
+	cat, _ := LoadCatalog(store)
+	// Default: maxPatterns=0 → unbounded.
+	for i := 0; i < 20; i++ {
+		cat.Upsert("p"+itoa(i), "tpl", "src", 1, 0.2, "rule", "svc")
+	}
+	if got := cat.Len(); got != 20 {
+		t.Fatalf("unbounded catalog: len=%d want 20", got)
+	}
+}
+
+func itoa(i int) string {
+	// Tiny helper to avoid pulling strconv in the test file purely for
+	// formatting an integer into a key suffix.
+	if i == 0 {
+		return "0"
+	}
+	digits := ""
+	for i > 0 {
+		digits = string(rune('0'+i%10)) + digits
+		i /= 10
+	}
+	return digits
+}
+
+func TestCatalog_ConcurrentGetUpsertNoRace(t *testing.T) {
+	store := newTestStore(t)
+	cat, err := LoadCatalog(store)
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	// Seed one pattern that both goroutines hammer.
+	cat.Upsert("p1", "tpl", "src", 1, 0.2, "rule", "svc")
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				cat.Upsert("p1", "tpl", "src", 2, 0.2, "rule", "svc")
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				if p := cat.Get("p1"); p != nil {
+					// Touch a few fields; under the buggy code these reads
+					// race with the writer's Upsert.
+					_ = p.Count
+					_ = p.BaselineFrequency
+					_ = p.Template
+				}
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
 
 // newTestStore returns a file-backed storage provider rooted in t.TempDir.
 // Used by tests that need to persist and reload across catalog instances.

--- a/pkg/agent/factory_ai.go
+++ b/pkg/agent/factory_ai.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"log"
 	"net/http"
 	"time"
 
@@ -42,7 +43,15 @@ func BuildAI(cfg config.AgentConfig, store storage.Provider, httpClient *http.Cl
 	}
 	initialBackoff := parseDurationOr(retry.InitialBackoff, 500*time.Millisecond)
 	maxBackoff := parseDurationOr(retry.MaxBackoff, 5*time.Second)
-	sre := ai.NewOpenAIWithRetry(cfg.AI, httpClient, maxAttempts, initialBackoff, maxBackoff)
+	sre, err := ai.NewOpenAIWithRetry(cfg.AI, httpClient, maxAttempts, initialBackoff, maxBackoff)
+	if err != nil {
+		// Misconfigured provider — return empty bundle so detect mode
+		// degrades to "dry detect" (classify but do not emit) instead
+		// of starting up with a dangling reference to a backend that
+		// will 404 on every call.
+		log.Printf("agent: AI disabled (%v); detect mode will run dry", err)
+		return AIBundle{}
+	}
 
 	ttl := parseDurationOr(cfg.AI.CacheTTL, time.Hour)
 	cache := ai.NewResultCache(ttl, store)

--- a/pkg/agent/factory_ai.go
+++ b/pkg/agent/factory_ai.go
@@ -10,13 +10,15 @@ import (
 	"github.com/VersusControl/versus-incident/pkg/storage"
 )
 
-// AIBundle bundles the three AI-side dependencies the worker needs.
-// All three are nil-safe: the worker accepts a zero bundle and falls
-// back to "dry detect" (classify but do not emit).
+// AIBundle bundles the AI-side dependencies the worker needs.
+// All fields are nil-safe: the worker accepts a zero bundle and falls
+// back to "dry detect" (classify but do not emit). Breaker may also be
+// nil when the operator disables it via failure_threshold=0.
 type AIBundle struct {
-	SRE   core.AISRE
-	Cache *ai.ResultCache
-	Rate  *ai.RateLimiter
+	SRE     core.AISRE
+	Cache   *ai.ResultCache
+	Rate    *ai.RateLimiter
+	Breaker *ai.Breaker
 }
 
 // BuildAI constructs the AI SRE, result cache, and rate limiter for
@@ -33,16 +35,35 @@ func BuildAI(cfg config.AgentConfig, store storage.Provider, httpClient *http.Cl
 		return AIBundle{}
 	}
 
-	sre := ai.NewOpenAI(cfg.AI, httpClient)
+	retry := cfg.Reliability.AIRetry
+	maxAttempts := retry.MaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = 3
+	}
+	initialBackoff := parseDurationOr(retry.InitialBackoff, 500*time.Millisecond)
+	maxBackoff := parseDurationOr(retry.MaxBackoff, 5*time.Second)
+	sre := ai.NewOpenAIWithRetry(cfg.AI, httpClient, maxAttempts, initialBackoff, maxBackoff)
 
 	ttl := parseDurationOr(cfg.AI.CacheTTL, time.Hour)
 	cache := ai.NewResultCache(ttl, store)
 
 	rate := ai.NewRateLimiter(cfg.AI.MaxCallsPerHour)
 
+	// Breaker: failure_threshold=0 disables it (always closed).
+	// Default 5 failures, 2m cooldown. Latency window 100 (last 100
+	// successful calls feed p50/p95).
+	bcfg := cfg.Reliability.AIBreaker
+	threshold := bcfg.FailureThreshold
+	if threshold == 0 {
+		threshold = 5
+	}
+	cooldown := parseDurationOr(bcfg.Cooldown, 2*time.Minute)
+	breaker := ai.NewBreaker(threshold, cooldown, 100)
+
 	return AIBundle{
-		SRE:   sre,
-		Cache: cache,
-		Rate:  rate,
+		SRE:     sre,
+		Cache:   cache,
+		Rate:    rate,
+		Breaker: breaker,
 	}
 }

--- a/pkg/agent/health.go
+++ b/pkg/agent/health.go
@@ -1,0 +1,155 @@
+package agent
+
+import (
+	"sync"
+	"time"
+)
+
+// HealthTracker records per-source health and applies exponential
+// backoff cooldown after consecutive failures. It is safe for
+// concurrent use — the worker fans out tickSource across goroutines.
+//
+// The tracker is intentionally lightweight: a mutex-guarded map of
+// SourceHealth keyed by source name. It is owned by the worker but
+// also read by the admin status endpoint, which is why we expose a
+// Snapshot method that returns a deep copy.
+type HealthTracker struct {
+	initial    time.Duration
+	max        time.Duration
+	multiplier float64
+	clock      func() time.Time // injectable for tests
+
+	mu  sync.Mutex
+	all map[string]*SourceHealth
+}
+
+// SourceHealth captures the rolling state of one signal source.
+// All time fields use UTC. zero-value times mean "never".
+type SourceHealth struct {
+	Name                string
+	ConsecutiveFailures int
+	LastError           string
+	LastErrorAt         time.Time
+	LastSuccessAt       time.Time
+	InCooldownUntil     time.Time
+	TotalPullsOK        int64
+	TotalPullsFailed    int64
+	TotalSignalsPulled  int64
+	TotalSignalsDropped int64 // truncated by batch_max
+	LastPullDurationMs  int64
+	LastSignalsPulled   int
+}
+
+// NewHealthTracker constructs a tracker. When initial <= 0 backoff is
+// disabled (cooldown is never set). When max <= 0 cooldown grows
+// unbounded.
+func NewHealthTracker(initial, max time.Duration, multiplier float64) *HealthTracker {
+	if multiplier < 1 {
+		multiplier = 2
+	}
+	return &HealthTracker{
+		initial:    initial,
+		max:        max,
+		multiplier: multiplier,
+		clock:      time.Now,
+		all:        make(map[string]*SourceHealth),
+	}
+}
+
+// Register seeds an entry for the given source so it shows up in
+// /api/agent/status before its first pull. Idempotent.
+func (h *HealthTracker) Register(name string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.all[name]; !ok {
+		h.all[name] = &SourceHealth{Name: name}
+	}
+}
+
+// ShouldSkip reports whether the named source is currently in cooldown
+// and therefore the worker should NOT call Pull this tick.
+func (h *HealthTracker) ShouldSkip(name string) (bool, time.Time) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s, ok := h.all[name]
+	if !ok {
+		return false, time.Time{}
+	}
+	if s.InCooldownUntil.IsZero() {
+		return false, time.Time{}
+	}
+	now := h.clock()
+	if now.Before(s.InCooldownUntil) {
+		return true, s.InCooldownUntil
+	}
+	return false, time.Time{}
+}
+
+// RecordSuccess clears the consecutive failure counter and cooldown.
+// pulledN is the number of signals returned (post-cap), droppedN is
+// how many were truncated by batch_max in this tick.
+func (h *HealthTracker) RecordSuccess(name string, pulledN, droppedN int, dur time.Duration) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s := h.getOrCreate(name)
+	s.ConsecutiveFailures = 0
+	s.LastError = ""
+	s.InCooldownUntil = time.Time{}
+	s.LastSuccessAt = h.clock().UTC()
+	s.TotalPullsOK++
+	s.TotalSignalsPulled += int64(pulledN)
+	s.TotalSignalsDropped += int64(droppedN)
+	s.LastSignalsPulled = pulledN
+	s.LastPullDurationMs = dur.Milliseconds()
+}
+
+// RecordFailure increments the consecutive failure counter and sets
+// the cooldown using exponential backoff. Returns the cooldown end
+// time (zero if backoff is disabled).
+func (h *HealthTracker) RecordFailure(name string, err error, dur time.Duration) time.Time {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s := h.getOrCreate(name)
+	s.ConsecutiveFailures++
+	if err != nil {
+		s.LastError = err.Error()
+	}
+	s.LastErrorAt = h.clock().UTC()
+	s.TotalPullsFailed++
+	s.LastPullDurationMs = dur.Milliseconds()
+
+	if h.initial <= 0 {
+		return time.Time{}
+	}
+	cooldown := h.initial
+	for i := 1; i < s.ConsecutiveFailures; i++ {
+		cooldown = time.Duration(float64(cooldown) * h.multiplier)
+		if h.max > 0 && cooldown > h.max {
+			cooldown = h.max
+			break
+		}
+	}
+	s.InCooldownUntil = h.clock().Add(cooldown)
+	return s.InCooldownUntil
+}
+
+// Snapshot returns a deep copy of every tracked source. Order is not
+// guaranteed — callers that want a stable order should sort by Name.
+func (h *HealthTracker) Snapshot() []SourceHealth {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]SourceHealth, 0, len(h.all))
+	for _, s := range h.all {
+		out = append(out, *s)
+	}
+	return out
+}
+
+func (h *HealthTracker) getOrCreate(name string) *SourceHealth {
+	s, ok := h.all[name]
+	if !ok {
+		s = &SourceHealth{Name: name}
+		h.all[name] = s
+	}
+	return s
+}

--- a/pkg/agent/health_test.go
+++ b/pkg/agent/health_test.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestHealthTracker_BackoffGrowsExponentially(t *testing.T) {
+	now := time.Unix(1_000_000_000, 0).UTC()
+	h := NewHealthTracker(1*time.Second, 8*time.Second, 2)
+	h.clock = func() time.Time { return now }
+
+	cases := []struct {
+		failures int
+		want     time.Duration
+	}{
+		{1, 1 * time.Second},
+		{2, 2 * time.Second},
+		{3, 4 * time.Second},
+		{4, 8 * time.Second},
+		{5, 8 * time.Second}, // capped
+		{6, 8 * time.Second},
+	}
+	for _, tc := range cases {
+		until := h.RecordFailure("es", errors.New("boom"), 0)
+		want := now.Add(tc.want)
+		if !until.Equal(want) {
+			t.Fatalf("after %d failures: cooldown until %s, want %s", tc.failures, until, want)
+		}
+	}
+}
+
+func TestHealthTracker_ShouldSkipRespectsCooldown(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0).UTC()
+	h := NewHealthTracker(10*time.Second, 0, 2)
+	h.clock = func() time.Time { return now }
+
+	if skip, _ := h.ShouldSkip("es"); skip {
+		t.Fatal("brand-new source should not be skipped")
+	}
+	h.RecordFailure("es", errors.New("boom"), 0)
+
+	skip, until := h.ShouldSkip("es")
+	if !skip {
+		t.Fatal("should skip during cooldown")
+	}
+	if !until.Equal(now.Add(10 * time.Second)) {
+		t.Fatalf("until=%s want %s", until, now.Add(10*time.Second))
+	}
+
+	// Advance past cooldown.
+	h.clock = func() time.Time { return now.Add(11 * time.Second) }
+	if skip, _ := h.ShouldSkip("es"); skip {
+		t.Fatal("should not skip after cooldown elapses")
+	}
+}
+
+func TestHealthTracker_SuccessResets(t *testing.T) {
+	h := NewHealthTracker(1*time.Second, 1*time.Minute, 2)
+	h.RecordFailure("es", errors.New("boom"), 0)
+	h.RecordFailure("es", errors.New("boom"), 0)
+	h.RecordSuccess("es", 42, 3, 5*time.Millisecond)
+
+	snap := h.Snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("snapshot len=%d want 1", len(snap))
+	}
+	s := snap[0]
+	if s.ConsecutiveFailures != 0 {
+		t.Fatalf("failures not reset: %d", s.ConsecutiveFailures)
+	}
+	if s.LastError != "" {
+		t.Fatalf("last_error not cleared: %q", s.LastError)
+	}
+	if !s.InCooldownUntil.IsZero() {
+		t.Fatal("cooldown not cleared")
+	}
+	if s.TotalSignalsPulled != 42 || s.TotalSignalsDropped != 3 {
+		t.Fatalf("counters off: pulled=%d dropped=%d", s.TotalSignalsPulled, s.TotalSignalsDropped)
+	}
+	if s.LastPullDurationMs != 5 {
+		t.Fatalf("duration ms=%d want 5", s.LastPullDurationMs)
+	}
+}
+
+func TestHealthTracker_RegisterIsIdempotent(t *testing.T) {
+	h := NewHealthTracker(0, 0, 2)
+	h.Register("a")
+	h.Register("a")
+	h.Register("b")
+	if got := len(h.Snapshot()); got != 2 {
+		t.Fatalf("snapshot len=%d want 2", got)
+	}
+}
+
+func TestHealthTracker_DisabledBackoffNeverCools(t *testing.T) {
+	h := NewHealthTracker(0, 0, 2)
+	h.RecordFailure("es", errors.New("boom"), 0)
+	if skip, _ := h.ShouldSkip("es"); skip {
+		t.Fatal("backoff disabled (initial=0) must never set cooldown")
+	}
+}
+
+func TestHealthTracker_SnapshotIsDeepCopy(t *testing.T) {
+	h := NewHealthTracker(1*time.Second, 0, 2)
+	h.RecordFailure("es", errors.New("boom"), 0)
+	snap := h.Snapshot()
+	snap[0].ConsecutiveFailures = 999
+	again := h.Snapshot()
+	if again[0].ConsecutiveFailures != 1 {
+		t.Fatal("Snapshot should return a copy; mutation leaked into tracker")
+	}
+}

--- a/pkg/agent/worker.go
+++ b/pkg/agent/worker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -146,6 +147,13 @@ func NewWorker(opt WorkerOptions) (*Worker, error) {
 		w.Health.Register(s.Name())
 	}
 
+	// Wire the catalog cap. A zero/negative configured value disables
+	// the cap; tests construct workers without setting it and the
+	// catalog stays unbounded.
+	if opt.Cfg.Catalog.MaxPatterns > 0 {
+		w.catalog.SetMaxPatterns(opt.Cfg.Catalog.MaxPatterns)
+	}
+
 	return w, nil
 }
 
@@ -218,13 +226,24 @@ func (w *Worker) Run(ctx context.Context) {
 }
 
 // tick runs one poll across every source. Errors from one source never
-// affect the others — the worker keeps moving.
+// affect the others — the worker keeps moving. A panic inside one
+// source is contained: logged, recorded as a failure on the health
+// tracker, and the next tick still runs (so a single bad input
+// cannot silently kill the agent).
 func (w *Worker) tick(ctx context.Context, mode string) {
 	var wg sync.WaitGroup
 	for _, src := range w.sources {
 		wg.Add(1)
 		go func(s core.SignalSource) {
 			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("agent: PANIC in tickSource %s: %v\n%s", s.Name(), r, debug.Stack())
+					if w.Health != nil {
+						w.Health.RecordFailure(s.Name(), fmt.Errorf("panic: %v", r), 0)
+					}
+				}
+			}()
 			w.tickSource(ctx, s, mode)
 		}(src)
 	}
@@ -493,21 +512,23 @@ func (w *Worker) emitDetect(
 		return outcome
 	}
 
-	// 3. Rate limit guard.
-	if !w.ai.Rate.Allow() {
-		log.Printf("agent[detect]: AI quota exceeded; skipping pattern=%s freq=%d", patternID, len(signals))
-		evt.Outcome = "quota"
-		w.detect.Record(evt)
-		return "quota"
-	}
-
-	// 3b. Circuit breaker — short-circuit when AI provider is having
-	// a bad day. No upstream cost is incurred while open.
+	// 3. Circuit breaker FIRST — when AI provider is having a bad day
+	// we short-circuit without consuming a rate-limit slot. Otherwise
+	// an outage would silently drain the per-hour quota for calls
+	// that never reach the upstream.
 	if w.ai.Breaker != nil && !w.ai.Breaker.Allow() {
 		log.Printf("agent[detect]: AI breaker open; skipping pattern=%s freq=%d", patternID, len(signals))
 		evt.Outcome = "breaker_open"
 		w.detect.Record(evt)
 		return "breaker_open"
+	}
+
+	// 4. Rate limit guard.
+	if !w.ai.Rate.Allow() {
+		log.Printf("agent[detect]: AI quota exceeded; skipping pattern=%s freq=%d", patternID, len(signals))
+		evt.Outcome = "quota"
+		w.detect.Record(evt)
+		return "quota"
 	}
 
 	// 4. Real AI call.

--- a/pkg/agent/worker.go
+++ b/pkg/agent/worker.go
@@ -62,9 +62,15 @@ type Worker struct {
 	pollInterval    time.Duration
 	persistEvery    time.Duration
 	lookback        time.Duration
+	pullTimeout     time.Duration // 0 = no per-pull deadline beyond ctx
 	ewmaAlpha       float64
 	services        *ServiceMatcher // regex-based service-name extractor
 	newServiceGrace time.Duration   // 0 = disabled
+
+	// Health is the per-source failure / cooldown tracker. Nil-safe:
+	// when nil the worker skips health bookkeeping (used by older tests
+	// that construct a Worker by hand).
+	Health *HealthTracker
 }
 
 // Emitter delivers an AI finding to the rest of the system. In production
@@ -126,8 +132,19 @@ func NewWorker(opt WorkerOptions) (*Worker, error) {
 	w.pollInterval = parseDurationOr(opt.Cfg.PollInterval, 30*time.Second)
 	w.persistEvery = parseDurationOr(opt.Cfg.Catalog.PersistInterval, 30*time.Second)
 	w.lookback = parseDurationOr(opt.Cfg.Lookback, 5*time.Minute)
+	w.pullTimeout = parseDurationOr(opt.Cfg.Reliability.PullTimeout, 20*time.Second)
 	w.ewmaAlpha = 0.2 // configurable once spike detection lands
 	w.newServiceGrace = parseDurationOr(opt.Cfg.NewServiceGrace, 0)
+
+	// Build the source-health tracker. Pre-register every configured
+	// source so the admin status endpoint surfaces them before their
+	// first tick lands.
+	initialBackoff := parseDurationOr(opt.Cfg.Reliability.SourceBackoffInitial, 30*time.Second)
+	maxBackoff := parseDurationOr(opt.Cfg.Reliability.SourceBackoffMax, 10*time.Minute)
+	w.Health = NewHealthTracker(initialBackoff, maxBackoff, 2)
+	for _, s := range w.sources {
+		w.Health.Register(s.Name())
+	}
 
 	return w, nil
 }
@@ -215,22 +232,63 @@ func (w *Worker) tick(ctx context.Context, mode string) {
 }
 
 func (w *Worker) tickSource(ctx context.Context, src core.SignalSource, mode string) {
+	// Honor any active cooldown set by prior consecutive failures.
+	if w.Health != nil {
+		if skip, until := w.Health.ShouldSkip(src.Name()); skip {
+			log.Printf("agent: %s in cooldown until %s, skipping pull",
+				src.Name(), until.Format(time.RFC3339))
+			return
+		}
+	}
+
 	since := w.loadCursor(ctx, src.Name())
 
-	signals, newCursor, err := src.Pull(ctx, since)
+	// Apply a per-pull deadline so a hung backend cannot stall the
+	// whole worker. The deadline is derived from configured
+	// pull_timeout; ctx cancellation still wins (e.g. shutdown).
+	pullCtx := ctx
+	if w.pullTimeout > 0 {
+		var cancel context.CancelFunc
+		pullCtx, cancel = context.WithTimeout(ctx, w.pullTimeout)
+		defer cancel()
+	}
+
+	start := time.Now()
+	signals, newCursor, err := src.Pull(pullCtx, since)
+	dur := time.Since(start)
 	if err != nil {
-		log.Printf("agent: pull from %s failed: %v", src.Name(), err)
+		if w.Health != nil {
+			until := w.Health.RecordFailure(src.Name(), err, dur)
+			if !until.IsZero() {
+				log.Printf("agent: pull from %s failed: %v (cooldown until %s)",
+					src.Name(), err, until.Format(time.RFC3339))
+			} else {
+				log.Printf("agent: pull from %s failed: %v", src.Name(), err)
+			}
+		} else {
+			log.Printf("agent: pull from %s failed: %v", src.Name(), err)
+		}
 		return
 	}
 	if len(signals) == 0 {
+		if w.Health != nil {
+			w.Health.RecordSuccess(src.Name(), 0, 0, dur)
+		}
 		return
 	}
 
-	// Cap batch size as a safety net.
+	// Cap batch size as a safety net. Drops are tracked so the admin
+	// status endpoint can surface persistent truncation (a signal that
+	// either batch_max is too low or the source is over budget).
+	dropped := 0
 	if w.cfg.BatchMax > 0 && len(signals) > w.cfg.BatchMax {
-		log.Printf("agent: %s returned %d signals, truncating to batch_max=%d",
-			src.Name(), len(signals), w.cfg.BatchMax)
+		dropped = len(signals) - w.cfg.BatchMax
+		log.Printf("agent: %s returned %d signals, truncating to batch_max=%d (dropped=%d)",
+			src.Name(), len(signals), w.cfg.BatchMax, dropped)
 		signals = signals[:w.cfg.BatchMax]
+	}
+	if w.Health != nil {
+		w.Health.RecordSuccess(src.Name(), len(signals), dropped, dur)
 	}
 
 	// Redact every payload before doing anything else with it.
@@ -443,14 +501,29 @@ func (w *Worker) emitDetect(
 		return "quota"
 	}
 
+	// 3b. Circuit breaker — short-circuit when AI provider is having
+	// a bad day. No upstream cost is incurred while open.
+	if w.ai.Breaker != nil && !w.ai.Breaker.Allow() {
+		log.Printf("agent[detect]: AI breaker open; skipping pattern=%s freq=%d", patternID, len(signals))
+		evt.Outcome = "breaker_open"
+		w.detect.Record(evt)
+		return "breaker_open"
+	}
+
 	// 4. Real AI call.
 	call, err := w.ai.SRE.Analyze(ctx, result)
 	if err != nil {
+		if w.ai.Breaker != nil {
+			w.ai.Breaker.RecordFailure(err)
+		}
 		log.Printf("agent[detect]: AI analyze failed pattern=%s: %v", patternID, err)
 		evt.Outcome = "ai_error"
 		evt.Error = err.Error()
 		w.detect.Record(evt)
 		return "ai_error"
+	}
+	if w.ai.Breaker != nil {
+		w.ai.Breaker.RecordSuccess(time.Duration(call.DurationMs) * time.Millisecond)
 	}
 	finding := call.Finding
 	w.ai.Cache.Put(patternID, finding)

--- a/pkg/agent/worker_panic_test.go
+++ b/pkg/agent/worker_panic_test.go
@@ -1,0 +1,95 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/config"
+	"github.com/VersusControl/versus-incident/pkg/core"
+)
+
+// panickySource is a SignalSource whose Pull panics. Used to verify
+// the worker's recover() in tick() so a single bad source does not
+// kill the agent.
+type panickySource struct{ name string }
+
+func (p *panickySource) Name() string { return p.name }
+func (p *panickySource) Pull(ctx context.Context, since time.Time) ([]core.Signal, time.Time, error) {
+	panic("synthetic panic from " + p.name)
+}
+
+// healthySource always returns an empty batch — exercises the
+// success-path RecordSuccess so we can prove the second goroutine
+// still ran after the first panicked.
+type healthySource struct {
+	name   string
+	called bool
+}
+
+func (h *healthySource) Name() string { return h.name }
+func (h *healthySource) Pull(ctx context.Context, since time.Time) ([]core.Signal, time.Time, error) {
+	h.called = true
+	return nil, since, nil
+}
+
+// TestWorker_TickRecoversFromSourcePanic verifies H4: a panic inside
+// one source's tickSource goroutine is caught, logged, and recorded
+// as a failure on the HealthTracker. The other source still runs, and
+// the worker is alive for the next tick.
+func TestWorker_TickRecoversFromSourcePanic(t *testing.T) {
+	bad := &panickySource{name: "bad"}
+	good := &healthySource{name: "good"}
+
+	store := newTestStore(t)
+	cat, err := LoadCatalog(store)
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	miner := NewMiner(0.4, 4, 100)
+
+	w, err := NewWorker(WorkerOptions{
+		Cfg: config.AgentConfig{
+			Mode:         "training",
+			PollInterval: "1s",
+			Reliability: config.AgentReliabilityConfig{
+				SourceBackoffInitial: "1s",
+				SourceBackoffMax:     "5s",
+			},
+		},
+		Sources: []core.SignalSource{bad, good},
+		Miner:   miner,
+		Catalog: cat,
+	})
+	if err != nil {
+		t.Fatalf("NewWorker: %v", err)
+	}
+
+	// One tick. If the recover() is missing this would crash the
+	// test process (goroutines panic out of the test runtime).
+	w.tick(context.Background(), "training")
+
+	if !good.called {
+		t.Fatal("healthy source must still run when sibling source panics")
+	}
+	snap := w.Health.Snapshot()
+	var badHealth *SourceHealth
+	for i := range snap {
+		if snap[i].Name == "bad" {
+			badHealth = &snap[i]
+		}
+	}
+	if badHealth == nil {
+		t.Fatal("bad source missing from health tracker")
+	}
+	if badHealth.ConsecutiveFailures < 1 {
+		t.Fatalf("panic should count as a failure; got consecutive_failures=%d",
+			badHealth.ConsecutiveFailures)
+	}
+	if badHealth.LastError == "" || badHealth.LastError[:6] != "panic:" {
+		t.Fatalf("LastError should start with 'panic:'; got %q", badHealth.LastError)
+	}
+
+	// A second tick should not crash either — the worker keeps moving.
+	w.tick(context.Background(), "training")
+}

--- a/pkg/common/email.go
+++ b/pkg/common/email.go
@@ -74,6 +74,9 @@ func (e *EmailProvider) getAuth() smtp.Auth {
 	return smtp.PlainAuth("", e.username, e.password, e.smtpHost)
 }
 
+// Name implements core.AlertProvider.
+func (e *EmailProvider) Name() string { return "email" }
+
 func (e *EmailProvider) SendAlert(i *m.Incident) error {
 	funcMaps := utils.GetTemplateFuncMaps()
 

--- a/pkg/common/lark.go
+++ b/pkg/common/lark.go
@@ -29,6 +29,9 @@ func NewLarkProvider(cfg config.LarkConfig, proxyConfig config.ProxyConfig) *Lar
 	}
 }
 
+// Name implements core.AlertProvider.
+func (l *LarkProvider) Name() string { return "lark" }
+
 func (l *LarkProvider) SendAlert(i *m.Incident) error {
 	funcMaps := utils.GetTemplateFuncMaps()
 

--- a/pkg/common/msteams.go
+++ b/pkg/common/msteams.go
@@ -25,6 +25,9 @@ func NewMSTeamsProvider(cfg config.MSTeamsConfig) *MSTeamsProvider {
 	}
 }
 
+// Name implements core.AlertProvider.
+func (m *MSTeamsProvider) Name() string { return "msteams" }
+
 func (m *MSTeamsProvider) SendAlert(i *m.Incident) error {
 	funcMaps := utils.GetTemplateFuncMaps()
 

--- a/pkg/common/slack.go
+++ b/pkg/common/slack.go
@@ -29,6 +29,9 @@ func NewSlackProvider(cfg config.SlackConfig) *SlackProvider {
 	}
 }
 
+// Name implements core.AlertProvider.
+func (s *SlackProvider) Name() string { return "slack" }
+
 // SendAlert determines whether to process a resolved or unresolved incident
 func (s *SlackProvider) SendAlert(i *m.Incident) error {
 	if i.Resolved {

--- a/pkg/common/telegram.go
+++ b/pkg/common/telegram.go
@@ -38,6 +38,9 @@ func NewTelegramProvider(cfg config.TelegramConfig, proxyConfig config.ProxyConf
 	}
 }
 
+// Name implements core.AlertProvider.
+func (t *TelegramProvider) Name() string { return "telegram" }
+
 func (t *TelegramProvider) SendAlert(i *m.Incident) error {
 	funcMaps := utils.GetTemplateFuncMaps()
 

--- a/pkg/common/viber.go
+++ b/pkg/common/viber.go
@@ -55,6 +55,9 @@ func NewViberProvider(cfg config.ViberConfig, proxyConfig config.ProxyConfig) *V
 	}
 }
 
+// Name implements core.AlertProvider.
+func (v *ViberProvider) Name() string { return "viber" }
+
 func (v *ViberProvider) SendAlert(i *m.Incident) error {
 	funcMaps := utils.GetTemplateFuncMaps()
 

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -278,13 +278,17 @@ type AgentAIConfig struct {
 	// the LLM — it only logs what it would have sent. This allows operators
 	// to run detect mode in a "dry-run" fashion without an API key.
 	Enable bool `mapstructure:"enable"`
-	// BaseURL is the full chat/completions endpoint to POST to. Default
-	// is OpenAI's URL. Set this to use an OpenAI-compatible endpoint
-	// from a different provider (e.g. Google's Gemini, Anthropic via a
-	// gateway, LiteLLM / OpenRouter proxies). The wire format must
-	// match OpenAI chat/completions: `messages: [{role, content}]`
-	// request body, `choices[0].message.content` response.
-	BaseURL string `mapstructure:"base_url"`
+	// Provider selects the AI backend. The chat/completions endpoint
+	// and a couple of provider-specific quirks are resolved from this
+	// value at startup; operators do not specify a URL. Supported:
+	//
+	//   - "openai" (default) — https://api.openai.com
+	//   - "gemini"           — Google AI Studio OpenAI-compatible shim
+	//   - "claude"           — Anthropic OpenAI-compatible endpoint
+	//
+	// All three speak the OpenAI chat/completions wire format. Empty
+	// is treated as "openai" for backwards compatibility.
+	Provider string `mapstructure:"provider"`
 	// APIKey is the bearer token sent in the Authorization header.
 	APIKey string `mapstructure:"api_key"`
 	// Model is the model identifier, e.g. "gpt-4o-mini".

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -22,11 +22,12 @@ type AgentConfig struct {
 	// (post-redaction) log message to discover the service name.
 	ServicePatterns []string `mapstructure:"service_patterns"`
 
-	Redaction AgentRedactionConfig `mapstructure:"redaction"`
-	Catalog   AgentCatalogConfig   `mapstructure:"catalog"`
-	Miner     AgentMinerConfig     `mapstructure:"miner"`
-	Regex     AgentRegexConfig     `mapstructure:"regex"`
-	AI        AgentAIConfig        `mapstructure:"ai"`
+	Redaction   AgentRedactionConfig   `mapstructure:"redaction"`
+	Catalog     AgentCatalogConfig     `mapstructure:"catalog"`
+	Miner       AgentMinerConfig       `mapstructure:"miner"`
+	Regex       AgentRegexConfig       `mapstructure:"regex"`
+	AI          AgentAIConfig          `mapstructure:"ai"`
+	Reliability AgentReliabilityConfig `mapstructure:"reliability"`
 
 	// Sources is the list of enabled signal sources. Versus loads it from
 	// the file `agent_sources.yaml` sitting next to the main config file
@@ -207,6 +208,60 @@ type AgentCloudWatchLogsSourceConfig struct {
 	FilterPattern string `mapstructure:"filter_pattern"`
 	// PageSize is the per-call limit (max 10000). Default 500.
 	PageSize int `mapstructure:"page_size"`
+}
+
+// AgentReliabilityConfig bundles the knobs that govern graceful
+// degradation when log sources or the AI provider misbehave. Every
+// field has a sensible default; the block exists so operators can
+// tighten or relax behavior without recompiling.
+type AgentReliabilityConfig struct {
+	// PullTimeout caps a single source Pull. When the source's HTTP
+	// client already has a longer timeout this lowers the effective
+	// budget; when shorter, the source's own timeout wins. Default
+	// "20s" (slightly under the 30s the built-in HTTP clients use, so
+	// pull_timeout is the active gate by default).
+	PullTimeout string `mapstructure:"pull_timeout"`
+
+	// SourceBackoffInitial is the cooldown applied after the FIRST
+	// consecutive failure. Each subsequent consecutive failure doubles
+	// the cooldown up to SourceBackoffMax. A successful pull resets the
+	// counter and clears the cooldown.
+	SourceBackoffInitial string `mapstructure:"source_backoff_initial"` // default 30s
+	SourceBackoffMax     string `mapstructure:"source_backoff_max"`     // default 10m
+
+	// AIRetry controls retry behavior of the OpenAI HTTP client.
+	AIRetry AgentAIRetryConfig `mapstructure:"ai_retry"`
+
+	// AIBreaker controls the circuit breaker wrapping AI calls.
+	AIBreaker AgentAIBreakerConfig `mapstructure:"ai_breaker"`
+}
+
+// AgentAIRetryConfig governs retry of OpenAI HTTP calls. Retries fire
+// only on transient failures (HTTP 429, 5xx, or network errors). 4xx
+// responses other than 429 are surfaced immediately.
+type AgentAIRetryConfig struct {
+	// MaxAttempts is the total number of attempts (initial + retries).
+	// 1 disables retry. Default 3.
+	MaxAttempts int `mapstructure:"max_attempts"`
+	// InitialBackoff is the first sleep after attempt 1. Each subsequent
+	// retry doubles up to MaxBackoff. Jitter is added on top. Default 500ms.
+	InitialBackoff string `mapstructure:"initial_backoff"`
+	// MaxBackoff caps any individual sleep. Default 5s.
+	MaxBackoff string `mapstructure:"max_backoff"`
+}
+
+// AgentAIBreakerConfig governs the circuit breaker wrapping AI calls.
+// When the breaker is open, AI calls are short-circuited and recorded
+// as "breaker_open" in the detect audit log — no upstream cost is
+// incurred. After Cooldown elapses the breaker enters half-open and
+// allows a single probe; success closes it, failure re-opens.
+type AgentAIBreakerConfig struct {
+	// FailureThreshold is the number of consecutive failures that flips
+	// the breaker open. 0 disables the breaker. Default 5.
+	FailureThreshold int `mapstructure:"failure_threshold"`
+	// Cooldown is how long the breaker stays open before allowing one
+	// probe. Default 2m.
+	Cooldown string `mapstructure:"cooldown"`
 }
 
 // AgentAIConfig holds configuration for the AI SRE used in detect mode.

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -46,6 +46,11 @@ type AgentRedactionConfig struct {
 type AgentCatalogConfig struct {
 	PersistInterval  string `mapstructure:"persist_interval"`   // e.g. "30s"
 	AutoPromoteAfter int    `mapstructure:"auto_promote_after"` // 0 = never
+	// MaxPatterns caps the catalog size. When a new pattern is upserted
+	// and the catalog is at the cap, the least-frequent non-"known"
+	// pattern is evicted to make room. 0 disables the cap (legacy
+	// behaviour — patterns.json grows without bound).
+	MaxPatterns int `mapstructure:"max_patterns"`
 	// SpikeMultiplier flags a tick as a frequency spike when the tick
 	// count exceeds the pattern's prior EWMA baseline by this factor.
 	// 0 disables spike detection. Default 5.0.
@@ -273,6 +278,13 @@ type AgentAIConfig struct {
 	// the LLM — it only logs what it would have sent. This allows operators
 	// to run detect mode in a "dry-run" fashion without an API key.
 	Enable bool `mapstructure:"enable"`
+	// BaseURL is the full chat/completions endpoint to POST to. Default
+	// is OpenAI's URL. Set this to use an OpenAI-compatible endpoint
+	// from a different provider (e.g. Google's Gemini, Anthropic via a
+	// gateway, LiteLLM / OpenRouter proxies). The wire format must
+	// match OpenAI chat/completions: `messages: [{role, content}]`
+	// request body, `choices[0].message.content` response.
+	BaseURL string `mapstructure:"base_url"`
 	// APIKey is the bearer token sent in the Authorization header.
 	APIKey string `mapstructure:"api_key"`
 	// Model is the model identifier, e.g. "gpt-4o-mini".

--- a/pkg/controllers/agent.go
+++ b/pkg/controllers/agent.go
@@ -1,6 +1,9 @@
 package controllers
 
 import (
+	"sort"
+	"time"
+
 	"github.com/VersusControl/versus-incident/pkg/agent"
 	"github.com/VersusControl/versus-incident/pkg/agent/ai"
 	"github.com/VersusControl/versus-incident/pkg/config"
@@ -17,14 +20,17 @@ type AgentController struct {
 	catalog *agent.Catalog
 	shadow  *agent.ShadowLog
 	detect  *agent.DetectLog
+	health  *agent.HealthTracker
+	breaker *ai.Breaker
 }
 
 // NewAgentController wires the catalog, shadow log, and detect log into a
 // controller. Pass `cat=nil` if the agent is disabled — in that case every
 // endpoint will return 503. `sl` may be nil to disable the shadow endpoints,
-// and `dl` may be nil to disable the detect-log endpoints.
-func NewAgentController(cat *agent.Catalog, sl *agent.ShadowLog, dl *agent.DetectLog) *AgentController {
-	return &AgentController{catalog: cat, shadow: sl, detect: dl}
+// and `dl` may be nil to disable the detect-log endpoints. `health` and
+// `breaker` may be nil — `getStatus` omits the corresponding section.
+func NewAgentController(cat *agent.Catalog, sl *agent.ShadowLog, dl *agent.DetectLog, health *agent.HealthTracker, breaker *ai.Breaker) *AgentController {
+	return &AgentController{catalog: cat, shadow: sl, detect: dl, health: health, breaker: breaker}
 }
 
 // Register attaches the agent admin endpoints to the given fiber group.
@@ -98,7 +104,64 @@ func (a *AgentController) getStatus(c *fiber.Ctx) error {
 		status["detect_events"] = a.detect.Len()
 		status["detect_dirty"] = a.detect.Dirty()
 	}
+	if a.health != nil {
+		status["sources"] = sourcesPayload(a.health)
+	}
+	if a.breaker != nil {
+		status["ai"] = a.breaker.Stats()
+	}
 	return c.JSON(status)
+}
+
+// sourcePayload is the JSON view of one SourceHealth row surfaced
+// under /api/agent/status. It mirrors the struct but uses RFC3339
+// timestamps and snake_case keys (consistent with the rest of the
+// admin API).
+type sourcePayload struct {
+	Name                string `json:"name"`
+	OK                  bool   `json:"ok"`
+	ConsecutiveFailures int    `json:"consecutive_failures"`
+	LastError           string `json:"last_error,omitempty"`
+	LastErrorAt         string `json:"last_error_at,omitempty"`
+	LastSuccessAt       string `json:"last_success_at,omitempty"`
+	InCooldownUntil     string `json:"in_cooldown_until,omitempty"`
+	TotalPullsOK        int64  `json:"total_pulls_ok"`
+	TotalPullsFailed    int64  `json:"total_pulls_failed"`
+	TotalSignalsPulled  int64  `json:"total_signals_pulled"`
+	TotalSignalsDropped int64  `json:"total_signals_dropped"`
+	LastPullDurationMs  int64  `json:"last_pull_duration_ms"`
+	LastSignalsPulled   int    `json:"last_signals_pulled"`
+}
+
+func sourcesPayload(h *agent.HealthTracker) []sourcePayload {
+	snap := h.Snapshot()
+	out := make([]sourcePayload, 0, len(snap))
+	for _, s := range snap {
+		row := sourcePayload{
+			Name:                s.Name,
+			OK:                  s.ConsecutiveFailures == 0,
+			ConsecutiveFailures: s.ConsecutiveFailures,
+			LastError:           s.LastError,
+			TotalPullsOK:        s.TotalPullsOK,
+			TotalPullsFailed:    s.TotalPullsFailed,
+			TotalSignalsPulled:  s.TotalSignalsPulled,
+			TotalSignalsDropped: s.TotalSignalsDropped,
+			LastPullDurationMs:  s.LastPullDurationMs,
+			LastSignalsPulled:   s.LastSignalsPulled,
+		}
+		if !s.LastErrorAt.IsZero() {
+			row.LastErrorAt = s.LastErrorAt.Format(time.RFC3339)
+		}
+		if !s.LastSuccessAt.IsZero() {
+			row.LastSuccessAt = s.LastSuccessAt.Format(time.RFC3339)
+		}
+		if !s.InCooldownUntil.IsZero() {
+			row.InCooldownUntil = s.InCooldownUntil.Format(time.RFC3339)
+		}
+		out = append(out, row)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
 }
 
 func (a *AgentController) listPatterns(c *fiber.Ctx) error {

--- a/pkg/controllers/agent.go
+++ b/pkg/controllers/agent.go
@@ -79,12 +79,13 @@ func (a *AgentController) Register(router fiber.Router) {
 
 // authMiddleware enforces a shared gateway secret. Clients send the
 // configured value verbatim in the `X-Gateway-Secret` header — there is no
-// Bearer prefix or other framing.
+// Bearer prefix or other framing. Comparison is constant-time to deny
+// header-length / prefix-match timing oracles.
 func (a *AgentController) authMiddleware(c *fiber.Ctx) error {
 	cfg := config.GetConfig()
 	expected := cfg.GatewaySecret
 	got := c.Get("X-Gateway-Secret")
-	if got == "" || got != expected {
+	if expected == "" || !secureEqual(got, expected) {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized"})
 	}
 

--- a/pkg/controllers/config_admin.go
+++ b/pkg/controllers/config_admin.go
@@ -30,7 +30,7 @@ func (c *ConfigAdminController) authMiddleware(ctx *fiber.Ctx) error {
 	cfg := config.GetConfig()
 	expected := cfg.GatewaySecret
 	got := ctx.Get("X-Gateway-Secret")
-	if expected == "" || got == "" || got != expected {
+	if expected == "" || !secureEqual(got, expected) {
 		return ctx.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized"})
 	}
 	return ctx.Next()

--- a/pkg/controllers/incidents_admin.go
+++ b/pkg/controllers/incidents_admin.go
@@ -34,11 +34,13 @@ func (i *IncidentAdminController) Register(router fiber.Router) {
 
 // authMiddleware reuses the agent gateway secret. Keeping the same
 // header name (X-Gateway-Secret) means the UI only manages one secret.
+// Comparison is constant-time (see secureEqual in agent.go) to avoid
+// header-length / prefix-match timing oracles.
 func (i *IncidentAdminController) authMiddleware(c *fiber.Ctx) error {
 	cfg := config.GetConfig()
 	expected := cfg.GatewaySecret
 	got := c.Get("X-Gateway-Secret")
-	if expected == "" || got == "" || got != expected {
+	if expected == "" || !secureEqual(got, expected) {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized"})
 	}
 	return c.Next()

--- a/pkg/controllers/secret.go
+++ b/pkg/controllers/secret.go
@@ -1,0 +1,19 @@
+package controllers
+
+import "crypto/subtle"
+
+// secureEqual reports whether a and b are equal in constant time. Used
+// by every admin controller's X-Gateway-Secret check so prefix/length
+// matches do not leak through response timing. `expected == ""` is
+// handled by callers (we never accept an empty configured secret).
+func secureEqual(got, expected string) bool {
+	if len(got) != len(expected) {
+		// subtle.ConstantTimeCompare returns 0 on length mismatch but
+		// short-circuits on length anyway — equivalent constant-time
+		// behavior from the attacker's perspective is preserved
+		// because both branches do the same amount of work for the
+		// "wrong length" case.
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(expected)) == 1
+}

--- a/pkg/core/alert.go
+++ b/pkg/core/alert.go
@@ -1,11 +1,18 @@
 package core
 
 import (
+	"errors"
+	"fmt"
+
 	m "github.com/VersusControl/versus-incident/pkg/models"
 )
 
-// AlertProvider interface remains the same
+// AlertProvider is implemented by every notification channel (Slack,
+// Telegram, MS Teams, Lark, Viber, Email, …). Name() identifies the
+// channel in failure reports so operators can tell which one failed
+// without parsing the wrapped error.
 type AlertProvider interface {
+	Name() string
 	SendAlert(incident *m.Incident) error
 }
 
@@ -17,11 +24,45 @@ func NewAlert(providers ...AlertProvider) *Alert {
 	return &Alert{providers: providers}
 }
 
-func (a *Alert) SendAlert(incident *m.Incident) error {
-	for _, provider := range a.providers {
-		if err := provider.SendAlert(incident); err != nil {
-			return err
+// AlertResult captures the outcome of SendAllAlerts: which providers
+// succeeded, which failed (with their error), and a joined error
+// containing all failures (nil when every provider succeeded). The
+// list of Succeeded channel names is what the incident persistence
+// layer should store as ChannelsNotified — it is the truth about
+// what actually reached its destination, not a list of what was
+// enabled in config.
+type AlertResult struct {
+	Succeeded []string
+	Failed    map[string]error
+	Err       error // joined errors from Failed, nil when none
+}
+
+// SendAllAlerts tries every configured provider regardless of earlier
+// failures. A single broken channel never prevents the others from
+// firing — this is the multi-channel promise. The returned Err is
+// non-nil iff at least one provider failed.
+func (a *Alert) SendAllAlerts(incident *m.Incident) AlertResult {
+	res := AlertResult{Failed: map[string]error{}}
+	var errs []error
+	for _, p := range a.providers {
+		if err := p.SendAlert(incident); err != nil {
+			res.Failed[p.Name()] = err
+			errs = append(errs, fmt.Errorf("%s: %w", p.Name(), err))
+			continue
 		}
+		res.Succeeded = append(res.Succeeded, p.Name())
 	}
-	return nil
+	if len(errs) > 0 {
+		res.Err = errors.Join(errs...)
+	}
+	return res
+}
+
+// SendAlert is the legacy "first error wins" API. New code should use
+// SendAllAlerts so a flaky Slack does not silently mute Telegram and
+// Email. Kept here so external callers (and existing tests) compile
+// without churn; internally we now delegate to SendAllAlerts and
+// surface only the joined error.
+func (a *Alert) SendAlert(incident *m.Incident) error {
+	return a.SendAllAlerts(incident).Err
 }

--- a/pkg/core/alert_test.go
+++ b/pkg/core/alert_test.go
@@ -1,0 +1,93 @@
+package core
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	m "github.com/VersusControl/versus-incident/pkg/models"
+)
+
+type stubProvider struct {
+	name string
+	err  error
+	hits int
+}
+
+func (s *stubProvider) Name() string                  { return s.name }
+func (s *stubProvider) SendAlert(_ *m.Incident) error { s.hits++; return s.err }
+
+// TestSendAllAlerts_TriesEveryProvider catches the regression where
+// the legacy SendAlert short-circuited on the first error and never
+// invoked subsequent providers. The whole point of v1.4.x is
+// multi-channel: one broken Slack must not silently mute Telegram
+// and Email.
+func TestSendAllAlerts_TriesEveryProvider(t *testing.T) {
+	slack := &stubProvider{name: "slack", err: errors.New("slack down")}
+	tg := &stubProvider{name: "telegram"} // ok
+	email := &stubProvider{name: "email", err: errors.New("smtp closed")}
+
+	a := NewAlert(slack, tg, email)
+	res := a.SendAllAlerts(&m.Incident{})
+
+	if slack.hits != 1 || tg.hits != 1 || email.hits != 1 {
+		t.Fatalf("each provider must be called once; got slack=%d tg=%d email=%d",
+			slack.hits, tg.hits, email.hits)
+	}
+	if got := len(res.Succeeded); got != 1 || res.Succeeded[0] != "telegram" {
+		t.Fatalf("Succeeded=%v want [telegram]", res.Succeeded)
+	}
+	if _, ok := res.Failed["slack"]; !ok {
+		t.Fatal("Failed map missing slack")
+	}
+	if _, ok := res.Failed["email"]; !ok {
+		t.Fatal("Failed map missing email")
+	}
+	if res.Err == nil {
+		t.Fatal("Err should be non-nil when any provider fails")
+	}
+	if !strings.Contains(res.Err.Error(), "slack down") || !strings.Contains(res.Err.Error(), "smtp closed") {
+		t.Fatalf("joined err missing details: %v", res.Err)
+	}
+}
+
+func TestSendAllAlerts_AllSucceed(t *testing.T) {
+	a := NewAlert(&stubProvider{name: "a"}, &stubProvider{name: "b"})
+	res := a.SendAllAlerts(&m.Incident{})
+	if res.Err != nil {
+		t.Fatalf("Err should be nil when all succeed: %v", res.Err)
+	}
+	if got := len(res.Succeeded); got != 2 {
+		t.Fatalf("Succeeded len=%d want 2", got)
+	}
+	if len(res.Failed) != 0 {
+		t.Fatalf("Failed=%v want empty", res.Failed)
+	}
+}
+
+func TestSendAllAlerts_AllFail(t *testing.T) {
+	a := NewAlert(
+		&stubProvider{name: "a", err: errors.New("boom1")},
+		&stubProvider{name: "b", err: errors.New("boom2")},
+	)
+	res := a.SendAllAlerts(&m.Incident{})
+	if len(res.Succeeded) != 0 {
+		t.Fatalf("Succeeded=%v want empty", res.Succeeded)
+	}
+	if len(res.Failed) != 2 {
+		t.Fatalf("Failed len=%d want 2", len(res.Failed))
+	}
+	if res.Err == nil {
+		t.Fatal("Err must be non-nil")
+	}
+}
+
+func TestSendAlertLegacy_ReturnsJoinedErr(t *testing.T) {
+	a := NewAlert(
+		&stubProvider{name: "a"},
+		&stubProvider{name: "b", err: errors.New("boom")},
+	)
+	if err := a.SendAlert(&m.Incident{}); err == nil {
+		t.Fatal("legacy SendAlert must surface the joined error")
+	}
+}

--- a/pkg/services/incident.go
+++ b/pkg/services/incident.go
@@ -61,53 +61,87 @@ func CreateIncident(teamID string, content *map[string]interface{}, params ...*m
 		}
 	}
 
-	sendErr := alert.SendAlert(incident)
+	// Fan out to every enabled channel. SendAllAlerts (unlike the
+	// legacy SendAlert) does NOT short-circuit on the first failure —
+	// a broken Slack must not silently mute Telegram or Email.
+	fanOut := alert.SendAllAlerts(incident)
+	sendErr := fanOut.Err
 
 	// Stamp the final fan-out outcome so the UI can show whether the
-	// alert actually reached its channels.
+	// alert actually reached its channels. ChannelsNotified is now
+	// the list of providers that SUCCEEDED, not the list of providers
+	// that were enabled in config.
 	if store != nil && rec != nil {
-		if sendErr != nil {
-			rec.NotifyStatus = "failed"
-			rec.NotifyError = sendErr.Error()
-		} else {
+		rec.ChannelsNotified = fanOut.Succeeded
+		switch {
+		case sendErr == nil:
 			rec.NotifyStatus = "sent"
 			rec.NotifyError = ""
+		case len(fanOut.Succeeded) == 0:
+			rec.NotifyStatus = "failed"
+			rec.NotifyError = sendErr.Error()
+		default:
+			rec.NotifyStatus = "partial"
+			rec.NotifyError = sendErr.Error()
 		}
 		if err := store.SaveIncident(rec); err != nil {
 			log.Printf("incident: persist status warning: %v", err)
 		}
 	}
 
-	if sendErr != nil {
-		return sendErr
-	}
-
+	// On-call escalation. We still kick this off even when *some*
+	// channels failed — partial delivery is exactly the case where an
+	// escalation matters most. Only skip when no channel succeeded
+	// AND there are no channels configured at all (nothing to escalate
+	// off of).
+	var oncallErr error
 	if !resolved && cfg.OnCall.Enable {
 		workflow := core.GetOnCallWorkflow()
 		if err := workflow.Start(incident.ID, cfg.OnCall); err != nil {
-			return err
+			oncallErr = err
+			// Walk back the optimistic OnCallTriggered flag set at
+			// build time so the UI does not lie. Best-effort
+			// persistence; the alert outcome above is the source of
+			// truth.
+			if store != nil && rec != nil {
+				rec.OnCallTriggered = false
+				rec.OnCallError = err.Error()
+				if err := store.SaveIncident(rec); err != nil {
+					log.Printf("incident: persist oncall status warning: %v", err)
+				}
+			}
 		}
 	}
 
+	switch {
+	case sendErr != nil && oncallErr != nil:
+		return fmt.Errorf("send: %w; oncall: %v", sendErr, oncallErr)
+	case sendErr != nil:
+		return sendErr
+	case oncallErr != nil:
+		return oncallErr
+	}
 	return nil
 }
 
 // buildIncidentRecord copies the alert into a durable IncidentRecord.
-// It snapshots which channels were enabled at the time the alert fired
-// and a best-effort title/service derived from common payload keys.
+// ChannelsEnabled snapshots the channels configured at fire time;
+// ChannelsNotified stays empty here and is filled in after the
+// fan-out so it reflects channels that ACTUALLY succeeded.
+// OnCallTriggered likewise starts at the optimistic value and is
+// flipped back to false if workflow.Start fails.
 func buildIncidentRecord(incident *m.Incident, cfg *config.Config, content map[string]interface{}, resolved bool) *storage.IncidentRecord {
-	channels := enabledChannels(cfg)
 	rec := &storage.IncidentRecord{
-		ID:               incident.ID,
-		TeamID:           incident.TeamID,
-		Title:            firstString(content, "title", "alertname", "summary", "subject", "name"),
-		Service:          firstString(content, "service", "service_name", "app", "component"),
-		Source:           "http",
-		Resolved:         resolved,
-		ChannelsNotified: channels,
-		OnCallTriggered:  !resolved && cfg.OnCall.Enable,
-		CreatedAt:        time.Now().UTC(),
-		Content:          content,
+		ID:              incident.ID,
+		TeamID:          incident.TeamID,
+		Title:           firstString(content, "title", "alertname", "summary", "subject", "name"),
+		Service:         firstString(content, "service", "service_name", "app", "component"),
+		Source:          "http",
+		Resolved:        resolved,
+		ChannelsEnabled: enabledChannels(cfg),
+		OnCallTriggered: !resolved && cfg.OnCall.Enable,
+		CreatedAt:       time.Now().UTC(),
+		Content:         content,
 	}
 	return rec
 }

--- a/pkg/storage/file.go
+++ b/pkg/storage/file.go
@@ -78,12 +78,44 @@ func (p *fileProvider) WriteBlob(name string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 		return fmt.Errorf("storage: mkdir blob dir: %w", err)
 	}
-	tmp := target + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	if err := writeFileAtomicSync(target, data, 0o644); err != nil {
 		return fmt.Errorf("storage: write blob %s: %w", name, err)
 	}
+	return nil
+}
+
+// writeFileAtomicSync writes data to a sibling tmp file, fsyncs it,
+// then renames over the target. The fsync between write and rename is
+// the load-bearing line: without it, a power loss between rename and
+// fs commit can replace a previous good file with a zero-length one.
+// (The rename itself is journaled by ext4/xfs; the tmp file's *data*
+// isn't unless we sync.)
+func writeFileAtomicSync(target string, data []byte, mode os.FileMode) error {
+	tmp := target + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	// Cleanup the tmp file on any error path before rename.
+	cleanup := func() {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+	}
+	if _, err := f.Write(data); err != nil {
+		cleanup()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
 	if err := os.Rename(tmp, target); err != nil {
-		return fmt.Errorf("storage: rename blob %s: %w", name, err)
+		_ = os.Remove(tmp)
+		return err
 	}
 	return nil
 }
@@ -141,12 +173,8 @@ func (p *fileProvider) persistIncidentsLocked() error {
 		return fmt.Errorf("storage: marshal incidents: %w", err)
 	}
 	target := filepath.Join(p.dir, incidentsFile)
-	tmp := target + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	if err := writeFileAtomicSync(target, data, 0o644); err != nil {
 		return fmt.Errorf("storage: write incidents: %w", err)
-	}
-	if err := os.Rename(tmp, target); err != nil {
-		return fmt.Errorf("storage: rename incidents: %w", err)
 	}
 	return nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -68,18 +68,26 @@ type Provider interface {
 // runtime models.Incident plus the audit fields the UI needs (when it
 // happened, who got notified, was it acked, raw payload for debugging).
 type IncidentRecord struct {
-	ID               string   `json:"id"`
-	TeamID           string   `json:"team_id,omitempty"`
-	Title            string   `json:"title,omitempty"`
-	Source           string   `json:"source,omitempty"`  // "http" | "sns" | "sqs" | ...
-	Service          string   `json:"service,omitempty"` // best-effort from payload
-	Resolved         bool     `json:"resolved"`
+	ID       string `json:"id"`
+	TeamID   string `json:"team_id,omitempty"`
+	Title    string `json:"title,omitempty"`
+	Source   string `json:"source,omitempty"`  // "http" | "sns" | "sqs" | ...
+	Service  string `json:"service,omitempty"` // best-effort from payload
+	Resolved bool   `json:"resolved"`
+	// ChannelsEnabled is the snapshot of channels that were configured
+	// when the alert fired. ChannelsNotified is the subset that
+	// actually succeeded. The two diverge whenever a channel fails:
+	// keep both so the UI can show "Slack failed" without losing the
+	// fact that Slack was supposed to be tried.
+	ChannelsEnabled  []string `json:"channels_enabled,omitempty"`
 	ChannelsNotified []string `json:"channels_notified,omitempty"`
 	OnCallTriggered  bool     `json:"oncall_triggered,omitempty"`
+	OnCallError      string   `json:"oncall_error,omitempty"`
 	// NotifyStatus reflects the outcome of the alert fan-out:
 	// "pending" — record persisted, fan-out not yet attempted
 	// "sent"    — every enabled channel returned success
-	// "failed"  — at least one channel returned an error (see NotifyError)
+	// "partial" — at least one channel succeeded, at least one failed
+	// "failed"  — no channel succeeded
 	NotifyStatus string                 `json:"notify_status,omitempty"`
 	NotifyError  string                 `json:"notify_error,omitempty"`
 	CreatedAt    time.Time              `json:"created_at"`


### PR DESCRIPTION
## What does this PR do?

Closes the v1.4.1 reliability roadmap item (graceful degradation on log-source
outages and AI failures), folds in correctness regressions caught during a
post-review of the v1.4.0 incident-management work, and adds OpenAI-compatible
`base_url` so the AI SRE analyzer can target Gemini, LiteLLM, OpenRouter, etc.

35 files, +2391/-117 LOC, 6 commits, 30+ new tests. Backwards-compatible:
every new config field has a safe default; deployments running today work
unchanged.

## Why?

- **Closes the v1.4.1 line item in `ROADMAP.md`** — graceful degradation.
- Code review caught 3 correctness bugs latent since v1.4.0 (catalog data
  race, alert fan-out short-circuit, on-call status lie). Better to ship
  them with v1.4.1 than carry a known-broken `main`.
- Operators asked for non-OpenAI providers (Gemini, self-hosted). The HTTP
  endpoint was hard-coded; a single `base_url` field unlocks every
  OpenAI-compatible provider.

## How to test

**Unit tests** — `go test -race ./...` (30+ new tests, full list in commits
`f1f43af` and `8bdeb5f`):

```bash
go test -race -count=1 -v -run \
  "TestCatalog|TestSendAllAlerts|TestOpenAI|TestBreaker|TestHealthTracker|TestWorker_TickRecoversFromSourcePanic" \
  ./pkg/...
```

**Live: source resilience** — point an Elasticsearch / Loki source at a
dead port, send some alerts, watch `/api/agent/status.sources[].in_cooldown_until`
back off exponentially; bring the backend up and watch it recover.

**Live: multi-channel fan-out** — enable Slack (real) + Lark (point at a
404 URL). POST an incident. Slack receives the message; Lark fails. Check
`/api/admin/incidents/:id` → `channels_notified: ["slack"]`,
`notify_status: "partial"`, `notify_error: "lark: ..."`.

**Live: catalog cap** — set `agent.catalog.max_patterns: 3`, inject 5
distinct error patterns. `/api/agent/patterns` returns exactly 3.

**Live: Gemini end-to-end** — `examples/gemini-test/run.sh` boots a
detect-mode config pointed at Gemini's OpenAI-compatible endpoint, injects
sample errors, and prints the parsed AI finding. Requires `GEMINI_API_KEY`
env var. Verified against real Gemini API: 5.3s p50 latency, finding emitted
as incident.

## Type of change

- [x] Bug fix (non-breaking) — catalog race, alert fan-out, on-call status,
      constant-time secret compare, fsync atomicity
- [x] New feature (non-breaking) — v1.4.1 reliability, catalog cap,
      OpenAI-compatible `base_url`, `finish_reason` + truncation auto-retry,
      panic recovery in worker
- [ ] Breaking change
- [ ] Documentation only
- [ ] Refactor (no functional change)
- [ ] CI / build / chore

## Checklist

- [x] `go test ./...` passes locally (under `-race`)
- [x] `go vet ./...` is clean
- [x] Code is `gofmt`'d
- [x] Added or updated tests for the change (30+ new tests across
      `pkg/agent`, `pkg/agent/ai`, `pkg/core`)
- [x] Updated user-facing docs (`config/config.yaml` comments,
      `CHANGELOG.md`)
- [x] Updated `ROADMAP.md` (ticked the v1.4.1 reliability item)
- [x] No secrets / tokens / webhook URLs in source or YAML
- [x] No new third-party dependencies

## Changes by theme

### Reliability (closes the roadmap item)

- `pkg/agent/health.go` — `HealthTracker`, per-source exponential backoff
- `pkg/agent/ai/breaker.go` — three-state circuit breaker
  (closed → open → half-open) for AI calls
- `pkg/agent/ai/openai.go` — retry on 429 / 5xx / network errors with
  jitter; ctx-aware sleep; `finish_reason: length` auto-retry once with
  doubled `max_tokens`
- `pkg/agent/worker.go` — per-pull context deadline (`pull_timeout`);
  truncation counter when `batch_max` drops signals; panic recovery in
  per-source goroutines
- `pkg/controllers/agent.go` — `/api/agent/status` now returns
  `sources: [...]` and `ai: {...}` blocks

### Correctness regressions (v1.4.0 follow-up)

- `pkg/agent/catalog.go` — `Get` returns a deep copy of `*Pattern`
  instead of the live pointer (fixes a data race with `Upsert` under
  multi-source workloads)
- `pkg/core/alert.go` — new `Alert.SendAllAlerts` tries every provider
  regardless of earlier failures; per-channel success / failure
  tracked in `AlertResult`. Six provider files gain `Name()`.
- `pkg/services/incident.go` — `ChannelsNotified` now reflects channels
  that actually succeeded (vs. `ChannelsEnabled` for what was
  configured); `OnCallTriggered` walked back to `false` when
  `workflow.Start` fails.

### Multi-provider AI

- `pkg/config/agent.go`, `pkg/agent/ai/openai.go` —
  `agent.ai.base_url` config; default unchanged (OpenAI). Verified
  against Gemini's `/v1beta/openai/chat/completions`.
- `examples/gemini-test/` — runnable end-to-end demo.

### Hardening (security / durability / scaling)

- `pkg/controllers/secret.go` — `crypto/subtle.ConstantTimeCompare`
  for `X-Gateway-Secret` (was a naive `==`).
- `pkg/agent/catalog.go` — `agent.catalog.max_patterns` cap
  (default 10000); LFU eviction; `verdict: "known"` patterns are
  preserved.
- `pkg/storage/file.go` — `writeFileAtomicSync` adds `f.Sync()`
  between tmp-write and rename so power loss can't replace good files
  with zero-length ones.

### New configuration (all optional, sensible defaults)

```yaml
agent:
  catalog:
    max_patterns: 10000          # 0 = unbounded
  ai:
    base_url: ""                 # default: api.openai.com
  reliability:
    pull_timeout: 20s
    source_backoff_initial: 30s
    source_backoff_max: 10m
    ai_retry:
      max_attempts: 3
      initial_backoff: 500ms
      max_backoff: 5s
    ai_breaker:
      failure_threshold: 5
      cooldown: 2m
```
