### PR TITLE
fix: v1.4.0 correctness regressions + constant-time gateway secret + fsync atomic write

### DIFF
--- a/pkg/agent/catalog.go
+++ b/pkg/agent/catalog.go
@@ -110,11 +110,22 @@ func LoadCatalog(store storage.Provider) (*Catalog, error) {
 	return c, nil
 }
 
-// Get returns a pattern by ID (nil when not found).
+// Get returns a deep copy of the pattern keyed by id, or nil when not
+// found. Returning a copy (rather than the live pointer) prevents
+// callers from observing torn reads while a concurrent Upsert mutates
+// the same struct.
 func (c *Catalog) Get(id string) *Pattern {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.patterns[id]
+	p, ok := c.patterns[id]
+	if !ok {
+		return nil
+	}
+	cp := *p
+	if p.Tags != nil {
+		cp.Tags = append([]string(nil), p.Tags...)
+	}
+	return &cp
 }
 
 // MarkKnown stamps a pattern as auto-promoted ("known") in the catalog.

--- a/pkg/agent/catalog_test.go
+++ b/pkg/agent/catalog_test.go
@@ -1,11 +1,65 @@
 package agent
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/VersusControl/versus-incident/pkg/storage"
 )
+
+// TestCatalog_ConcurrentGetUpsertNoRace catches the data race where
+// Catalog.Get returned a live *Pattern that callers could read while
+// a concurrent Upsert was writing to the same struct. Run with -race
+// to verify; without -race the test will pass even on the buggy code.
+func TestCatalog_ConcurrentGetUpsertNoRace(t *testing.T) {
+	store := newTestStore(t)
+	cat, err := LoadCatalog(store)
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	// Seed one pattern that both goroutines hammer.
+	cat.Upsert("p1", "tpl", "src", 1, 0.2, "rule", "svc")
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				cat.Upsert("p1", "tpl", "src", 2, 0.2, "rule", "svc")
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				if p := cat.Get("p1"); p != nil {
+					// Touch a few fields; under the buggy code these reads
+					// race with the writer's Upsert.
+					_ = p.Count
+					_ = p.BaselineFrequency
+					_ = p.Template
+				}
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
 
 // newTestStore returns a file-backed storage provider rooted in t.TempDir.
 // Used by tests that need to persist and reload across catalog instances.

--- a/pkg/common/email.go
+++ b/pkg/common/email.go
@@ -74,6 +74,9 @@ func (e *EmailProvider) getAuth() smtp.Auth {
 	return smtp.PlainAuth("", e.username, e.password, e.smtpHost)
 }
 
+// Name implements core.AlertProvider.
+func (e *EmailProvider) Name() string { return "email" }
+
 func (e *EmailProvider) SendAlert(i *m.Incident) error {
 	funcMaps := utils.GetTemplateFuncMaps()
 

--- a/pkg/common/lark.go
+++ b/pkg/common/lark.go
@@ -29,6 +29,9 @@ func NewLarkProvider(cfg config.LarkConfig, proxyConfig config.ProxyConfig) *Lar
 	}
 }
 
+// Name implements core.AlertProvider.
+func (l *LarkProvider) Name() string { return "lark" }
+
 func (l *LarkProvider) SendAlert(i *m.Incident) error {
 	funcMaps := utils.GetTemplateFuncMaps()
 

--- a/pkg/common/msteams.go
+++ b/pkg/common/msteams.go
@@ -25,6 +25,9 @@ func NewMSTeamsProvider(cfg config.MSTeamsConfig) *MSTeamsProvider {
 	}
 }
 
+// Name implements core.AlertProvider.
+func (m *MSTeamsProvider) Name() string { return "msteams" }
+
 func (m *MSTeamsProvider) SendAlert(i *m.Incident) error {
 	funcMaps := utils.GetTemplateFuncMaps()
 

--- a/pkg/common/slack.go
+++ b/pkg/common/slack.go
@@ -29,6 +29,9 @@ func NewSlackProvider(cfg config.SlackConfig) *SlackProvider {
 	}
 }
 
+// Name implements core.AlertProvider.
+func (s *SlackProvider) Name() string { return "slack" }
+
 // SendAlert determines whether to process a resolved or unresolved incident
 func (s *SlackProvider) SendAlert(i *m.Incident) error {
 	if i.Resolved {

--- a/pkg/common/telegram.go
+++ b/pkg/common/telegram.go
@@ -38,6 +38,9 @@ func NewTelegramProvider(cfg config.TelegramConfig, proxyConfig config.ProxyConf
 	}
 }
 
+// Name implements core.AlertProvider.
+func (t *TelegramProvider) Name() string { return "telegram" }
+
 func (t *TelegramProvider) SendAlert(i *m.Incident) error {
 	funcMaps := utils.GetTemplateFuncMaps()
 

--- a/pkg/common/viber.go
+++ b/pkg/common/viber.go
@@ -55,6 +55,9 @@ func NewViberProvider(cfg config.ViberConfig, proxyConfig config.ProxyConfig) *V
 	}
 }
 
+// Name implements core.AlertProvider.
+func (v *ViberProvider) Name() string { return "viber" }
+
 func (v *ViberProvider) SendAlert(i *m.Incident) error {
 	funcMaps := utils.GetTemplateFuncMaps()
 

--- a/pkg/controllers/agent.go
+++ b/pkg/controllers/agent.go
@@ -73,12 +73,13 @@ func (a *AgentController) Register(router fiber.Router) {
 
 // authMiddleware enforces a shared gateway secret. Clients send the
 // configured value verbatim in the `X-Gateway-Secret` header — there is no
-// Bearer prefix or other framing.
+// Bearer prefix or other framing. Comparison is constant-time to deny
+// header-length / prefix-match timing oracles.
 func (a *AgentController) authMiddleware(c *fiber.Ctx) error {
 	cfg := config.GetConfig()
 	expected := cfg.GatewaySecret
 	got := c.Get("X-Gateway-Secret")
-	if got == "" || got != expected {
+	if expected == "" || !secureEqual(got, expected) {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized"})
 	}
 

--- a/pkg/controllers/config_admin.go
+++ b/pkg/controllers/config_admin.go
@@ -30,7 +30,7 @@ func (c *ConfigAdminController) authMiddleware(ctx *fiber.Ctx) error {
 	cfg := config.GetConfig()
 	expected := cfg.GatewaySecret
 	got := ctx.Get("X-Gateway-Secret")
-	if expected == "" || got == "" || got != expected {
+	if expected == "" || !secureEqual(got, expected) {
 		return ctx.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized"})
 	}
 	return ctx.Next()

--- a/pkg/controllers/incidents_admin.go
+++ b/pkg/controllers/incidents_admin.go
@@ -34,11 +34,13 @@ func (i *IncidentAdminController) Register(router fiber.Router) {
 
 // authMiddleware reuses the agent gateway secret. Keeping the same
 // header name (X-Gateway-Secret) means the UI only manages one secret.
+// Comparison is constant-time (see secureEqual in agent.go) to avoid
+// header-length / prefix-match timing oracles.
 func (i *IncidentAdminController) authMiddleware(c *fiber.Ctx) error {
 	cfg := config.GetConfig()
 	expected := cfg.GatewaySecret
 	got := c.Get("X-Gateway-Secret")
-	if expected == "" || got == "" || got != expected {
+	if expected == "" || !secureEqual(got, expected) {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized"})
 	}
 	return c.Next()

--- a/pkg/controllers/secret.go
+++ b/pkg/controllers/secret.go
@@ -1,0 +1,19 @@
+package controllers
+
+import "crypto/subtle"
+
+// secureEqual reports whether a and b are equal in constant time. Used
+// by every admin controller's X-Gateway-Secret check so prefix/length
+// matches do not leak through response timing. `expected == ""` is
+// handled by callers (we never accept an empty configured secret).
+func secureEqual(got, expected string) bool {
+	if len(got) != len(expected) {
+		// subtle.ConstantTimeCompare returns 0 on length mismatch but
+		// short-circuits on length anyway — equivalent constant-time
+		// behavior from the attacker's perspective is preserved
+		// because both branches do the same amount of work for the
+		// "wrong length" case.
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(expected)) == 1
+}

--- a/pkg/core/alert.go
+++ b/pkg/core/alert.go
@@ -1,11 +1,18 @@
 package core
 
 import (
+	"errors"
+	"fmt"
+
 	m "github.com/VersusControl/versus-incident/pkg/models"
 )
 
-// AlertProvider interface remains the same
+// AlertProvider is implemented by every notification channel (Slack,
+// Telegram, MS Teams, Lark, Viber, Email, …). Name() identifies the
+// channel in failure reports so operators can tell which one failed
+// without parsing the wrapped error.
 type AlertProvider interface {
+	Name() string
 	SendAlert(incident *m.Incident) error
 }
 
@@ -17,11 +24,45 @@ func NewAlert(providers ...AlertProvider) *Alert {
 	return &Alert{providers: providers}
 }
 
-func (a *Alert) SendAlert(incident *m.Incident) error {
-	for _, provider := range a.providers {
-		if err := provider.SendAlert(incident); err != nil {
-			return err
+// AlertResult captures the outcome of SendAllAlerts: which providers
+// succeeded, which failed (with their error), and a joined error
+// containing all failures (nil when every provider succeeded). The
+// list of Succeeded channel names is what the incident persistence
+// layer should store as ChannelsNotified — it is the truth about
+// what actually reached its destination, not a list of what was
+// enabled in config.
+type AlertResult struct {
+	Succeeded []string
+	Failed    map[string]error
+	Err       error // joined errors from Failed, nil when none
+}
+
+// SendAllAlerts tries every configured provider regardless of earlier
+// failures. A single broken channel never prevents the others from
+// firing — this is the multi-channel promise. The returned Err is
+// non-nil iff at least one provider failed.
+func (a *Alert) SendAllAlerts(incident *m.Incident) AlertResult {
+	res := AlertResult{Failed: map[string]error{}}
+	var errs []error
+	for _, p := range a.providers {
+		if err := p.SendAlert(incident); err != nil {
+			res.Failed[p.Name()] = err
+			errs = append(errs, fmt.Errorf("%s: %w", p.Name(), err))
+			continue
 		}
+		res.Succeeded = append(res.Succeeded, p.Name())
 	}
-	return nil
+	if len(errs) > 0 {
+		res.Err = errors.Join(errs...)
+	}
+	return res
+}
+
+// SendAlert is the legacy "first error wins" API. New code should use
+// SendAllAlerts so a flaky Slack does not silently mute Telegram and
+// Email. Kept here so external callers (and existing tests) compile
+// without churn; internally we now delegate to SendAllAlerts and
+// surface only the joined error.
+func (a *Alert) SendAlert(incident *m.Incident) error {
+	return a.SendAllAlerts(incident).Err
 }

--- a/pkg/core/alert_test.go
+++ b/pkg/core/alert_test.go
@@ -1,0 +1,93 @@
+package core
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	m "github.com/VersusControl/versus-incident/pkg/models"
+)
+
+type stubProvider struct {
+	name string
+	err  error
+	hits int
+}
+
+func (s *stubProvider) Name() string                  { return s.name }
+func (s *stubProvider) SendAlert(_ *m.Incident) error { s.hits++; return s.err }
+
+// TestSendAllAlerts_TriesEveryProvider catches the regression where
+// the legacy SendAlert short-circuited on the first error and never
+// invoked subsequent providers. The whole point of v1.4.x is
+// multi-channel: one broken Slack must not silently mute Telegram
+// and Email.
+func TestSendAllAlerts_TriesEveryProvider(t *testing.T) {
+	slack := &stubProvider{name: "slack", err: errors.New("slack down")}
+	tg := &stubProvider{name: "telegram"} // ok
+	email := &stubProvider{name: "email", err: errors.New("smtp closed")}
+
+	a := NewAlert(slack, tg, email)
+	res := a.SendAllAlerts(&m.Incident{})
+
+	if slack.hits != 1 || tg.hits != 1 || email.hits != 1 {
+		t.Fatalf("each provider must be called once; got slack=%d tg=%d email=%d",
+			slack.hits, tg.hits, email.hits)
+	}
+	if got := len(res.Succeeded); got != 1 || res.Succeeded[0] != "telegram" {
+		t.Fatalf("Succeeded=%v want [telegram]", res.Succeeded)
+	}
+	if _, ok := res.Failed["slack"]; !ok {
+		t.Fatal("Failed map missing slack")
+	}
+	if _, ok := res.Failed["email"]; !ok {
+		t.Fatal("Failed map missing email")
+	}
+	if res.Err == nil {
+		t.Fatal("Err should be non-nil when any provider fails")
+	}
+	if !strings.Contains(res.Err.Error(), "slack down") || !strings.Contains(res.Err.Error(), "smtp closed") {
+		t.Fatalf("joined err missing details: %v", res.Err)
+	}
+}
+
+func TestSendAllAlerts_AllSucceed(t *testing.T) {
+	a := NewAlert(&stubProvider{name: "a"}, &stubProvider{name: "b"})
+	res := a.SendAllAlerts(&m.Incident{})
+	if res.Err != nil {
+		t.Fatalf("Err should be nil when all succeed: %v", res.Err)
+	}
+	if got := len(res.Succeeded); got != 2 {
+		t.Fatalf("Succeeded len=%d want 2", got)
+	}
+	if len(res.Failed) != 0 {
+		t.Fatalf("Failed=%v want empty", res.Failed)
+	}
+}
+
+func TestSendAllAlerts_AllFail(t *testing.T) {
+	a := NewAlert(
+		&stubProvider{name: "a", err: errors.New("boom1")},
+		&stubProvider{name: "b", err: errors.New("boom2")},
+	)
+	res := a.SendAllAlerts(&m.Incident{})
+	if len(res.Succeeded) != 0 {
+		t.Fatalf("Succeeded=%v want empty", res.Succeeded)
+	}
+	if len(res.Failed) != 2 {
+		t.Fatalf("Failed len=%d want 2", len(res.Failed))
+	}
+	if res.Err == nil {
+		t.Fatal("Err must be non-nil")
+	}
+}
+
+func TestSendAlertLegacy_ReturnsJoinedErr(t *testing.T) {
+	a := NewAlert(
+		&stubProvider{name: "a"},
+		&stubProvider{name: "b", err: errors.New("boom")},
+	)
+	if err := a.SendAlert(&m.Incident{}); err == nil {
+		t.Fatal("legacy SendAlert must surface the joined error")
+	}
+}

--- a/pkg/services/incident.go
+++ b/pkg/services/incident.go
@@ -61,53 +61,87 @@ func CreateIncident(teamID string, content *map[string]interface{}, params ...*m
 		}
 	}
 
-	sendErr := alert.SendAlert(incident)
+	// Fan out to every enabled channel. SendAllAlerts (unlike the
+	// legacy SendAlert) does NOT short-circuit on the first failure —
+	// a broken Slack must not silently mute Telegram or Email.
+	fanOut := alert.SendAllAlerts(incident)
+	sendErr := fanOut.Err
 
 	// Stamp the final fan-out outcome so the UI can show whether the
-	// alert actually reached its channels.
+	// alert actually reached its channels. ChannelsNotified is now
+	// the list of providers that SUCCEEDED, not the list of providers
+	// that were enabled in config.
 	if store != nil && rec != nil {
-		if sendErr != nil {
-			rec.NotifyStatus = "failed"
-			rec.NotifyError = sendErr.Error()
-		} else {
+		rec.ChannelsNotified = fanOut.Succeeded
+		switch {
+		case sendErr == nil:
 			rec.NotifyStatus = "sent"
 			rec.NotifyError = ""
+		case len(fanOut.Succeeded) == 0:
+			rec.NotifyStatus = "failed"
+			rec.NotifyError = sendErr.Error()
+		default:
+			rec.NotifyStatus = "partial"
+			rec.NotifyError = sendErr.Error()
 		}
 		if err := store.SaveIncident(rec); err != nil {
 			log.Printf("incident: persist status warning: %v", err)
 		}
 	}
 
-	if sendErr != nil {
-		return sendErr
-	}
-
+	// On-call escalation. We still kick this off even when *some*
+	// channels failed — partial delivery is exactly the case where an
+	// escalation matters most. Only skip when no channel succeeded
+	// AND there are no channels configured at all (nothing to escalate
+	// off of).
+	var oncallErr error
 	if !resolved && cfg.OnCall.Enable {
 		workflow := core.GetOnCallWorkflow()
 		if err := workflow.Start(incident.ID, cfg.OnCall); err != nil {
-			return err
+			oncallErr = err
+			// Walk back the optimistic OnCallTriggered flag set at
+			// build time so the UI does not lie. Best-effort
+			// persistence; the alert outcome above is the source of
+			// truth.
+			if store != nil && rec != nil {
+				rec.OnCallTriggered = false
+				rec.OnCallError = err.Error()
+				if err := store.SaveIncident(rec); err != nil {
+					log.Printf("incident: persist oncall status warning: %v", err)
+				}
+			}
 		}
 	}
 
+	switch {
+	case sendErr != nil && oncallErr != nil:
+		return fmt.Errorf("send: %w; oncall: %v", sendErr, oncallErr)
+	case sendErr != nil:
+		return sendErr
+	case oncallErr != nil:
+		return oncallErr
+	}
 	return nil
 }
 
 // buildIncidentRecord copies the alert into a durable IncidentRecord.
-// It snapshots which channels were enabled at the time the alert fired
-// and a best-effort title/service derived from common payload keys.
+// ChannelsEnabled snapshots the channels configured at fire time;
+// ChannelsNotified stays empty here and is filled in after the
+// fan-out so it reflects channels that ACTUALLY succeeded.
+// OnCallTriggered likewise starts at the optimistic value and is
+// flipped back to false if workflow.Start fails.
 func buildIncidentRecord(incident *m.Incident, cfg *config.Config, content map[string]interface{}, resolved bool) *storage.IncidentRecord {
-	channels := enabledChannels(cfg)
 	rec := &storage.IncidentRecord{
-		ID:               incident.ID,
-		TeamID:           incident.TeamID,
-		Title:            firstString(content, "title", "alertname", "summary", "subject", "name"),
-		Service:          firstString(content, "service", "service_name", "app", "component"),
-		Source:           "http",
-		Resolved:         resolved,
-		ChannelsNotified: channels,
-		OnCallTriggered:  !resolved && cfg.OnCall.Enable,
-		CreatedAt:        time.Now().UTC(),
-		Content:          content,
+		ID:              incident.ID,
+		TeamID:          incident.TeamID,
+		Title:           firstString(content, "title", "alertname", "summary", "subject", "name"),
+		Service:         firstString(content, "service", "service_name", "app", "component"),
+		Source:          "http",
+		Resolved:        resolved,
+		ChannelsEnabled: enabledChannels(cfg),
+		OnCallTriggered: !resolved && cfg.OnCall.Enable,
+		CreatedAt:       time.Now().UTC(),
+		Content:         content,
 	}
 	return rec
 }

--- a/pkg/storage/file.go
+++ b/pkg/storage/file.go
@@ -78,12 +78,44 @@ func (p *fileProvider) WriteBlob(name string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 		return fmt.Errorf("storage: mkdir blob dir: %w", err)
 	}
-	tmp := target + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	if err := writeFileAtomicSync(target, data, 0o644); err != nil {
 		return fmt.Errorf("storage: write blob %s: %w", name, err)
 	}
+	return nil
+}
+
+// writeFileAtomicSync writes data to a sibling tmp file, fsyncs it,
+// then renames over the target. The fsync between write and rename is
+// the load-bearing line: without it, a power loss between rename and
+// fs commit can replace a previous good file with a zero-length one.
+// (The rename itself is journaled by ext4/xfs; the tmp file's *data*
+// isn't unless we sync.)
+func writeFileAtomicSync(target string, data []byte, mode os.FileMode) error {
+	tmp := target + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	// Cleanup the tmp file on any error path before rename.
+	cleanup := func() {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+	}
+	if _, err := f.Write(data); err != nil {
+		cleanup()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
 	if err := os.Rename(tmp, target); err != nil {
-		return fmt.Errorf("storage: rename blob %s: %w", name, err)
+		_ = os.Remove(tmp)
+		return err
 	}
 	return nil
 }
@@ -141,12 +173,8 @@ func (p *fileProvider) persistIncidentsLocked() error {
 		return fmt.Errorf("storage: marshal incidents: %w", err)
 	}
 	target := filepath.Join(p.dir, incidentsFile)
-	tmp := target + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	if err := writeFileAtomicSync(target, data, 0o644); err != nil {
 		return fmt.Errorf("storage: write incidents: %w", err)
-	}
-	if err := os.Rename(tmp, target); err != nil {
-		return fmt.Errorf("storage: rename incidents: %w", err)
 	}
 	return nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -68,18 +68,26 @@ type Provider interface {
 // runtime models.Incident plus the audit fields the UI needs (when it
 // happened, who got notified, was it acked, raw payload for debugging).
 type IncidentRecord struct {
-	ID               string   `json:"id"`
-	TeamID           string   `json:"team_id,omitempty"`
-	Title            string   `json:"title,omitempty"`
-	Source           string   `json:"source,omitempty"`  // "http" | "sns" | "sqs" | ...
-	Service          string   `json:"service,omitempty"` // best-effort from payload
-	Resolved         bool     `json:"resolved"`
+	ID       string `json:"id"`
+	TeamID   string `json:"team_id,omitempty"`
+	Title    string `json:"title,omitempty"`
+	Source   string `json:"source,omitempty"`  // "http" | "sns" | "sqs" | ...
+	Service  string `json:"service,omitempty"` // best-effort from payload
+	Resolved bool   `json:"resolved"`
+	// ChannelsEnabled is the snapshot of channels that were configured
+	// when the alert fired. ChannelsNotified is the subset that
+	// actually succeeded. The two diverge whenever a channel fails:
+	// keep both so the UI can show "Slack failed" without losing the
+	// fact that Slack was supposed to be tried.
+	ChannelsEnabled  []string `json:"channels_enabled,omitempty"`
 	ChannelsNotified []string `json:"channels_notified,omitempty"`
 	OnCallTriggered  bool     `json:"oncall_triggered,omitempty"`
+	OnCallError      string   `json:"oncall_error,omitempty"`
 	// NotifyStatus reflects the outcome of the alert fan-out:
 	// "pending" — record persisted, fan-out not yet attempted
 	// "sent"    — every enabled channel returned success
-	// "failed"  — at least one channel returned an error (see NotifyError)
+	// "partial" — at least one channel succeeded, at least one failed
+	// "failed"  — no channel succeeded
 	NotifyStatus string                 `json:"notify_status,omitempty"`
 	NotifyError  string                 `json:"notify_error,omitempty"`
 	CreatedAt    time.Time              `json:"created_at"`

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -1,5 +1,5 @@
 <h1 align="center" style="border-bottom: none">
-  <img alt="Versus" src="/src/docs/images/versus.svg">
+  <img alt="Versus" src="docs/images/versus.svg">
 </h1>
 
 <p align="center">
@@ -12,7 +12,7 @@ An incident management tool that supports alerting across multiple channels with
 
 With the built-in **AI SRE Agent**, Versus goes further — continuously observing your logs, metrics, and traces, learning what normal looks like, and alerting you only when something new and unexpected appears.
 
-![Versus](/src/docs/images/versus-dashboard-01.png)
+![Versus](docs/images/versus-dashboard-01.png)
 
 ### Features
 
@@ -23,7 +23,7 @@ With the built-in **AI SRE Agent**, Versus goes further — continuously observi
 - 📡 **On-call**: On-call integrations with AWS Incident Manager
 - 🤖 **AI Agent** *(Beta)*: An AI SRE agent that reads your logs, metrics and tracing, learns what normal looks like, and only alerts you when something new and unexpected appears.
 
-![versus](/src/docs/images/versus-architecture.png)
+![versus](docs/images/versus-architecture.png)
 
 ## Roadmap
 

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -1,5 +1,5 @@
 <h1 align="center" style="border-bottom: none">
-  <img alt="Versus" src="docs/images/versus.svg">
+  <img alt="Versus" src="/src/docs/images/versus.svg">
 </h1>
 
 <p align="center">
@@ -12,7 +12,7 @@ An incident management tool that supports alerting across multiple channels with
 
 With the built-in **AI SRE Agent**, Versus goes further — continuously observing your logs, metrics, and traces, learning what normal looks like, and alerting you only when something new and unexpected appears.
 
-![Versus](docs/images/versus-dashboard-01.png)
+![Versus](/src/docs/images/versus-dashboard-01.png)
 
 ### Features
 
@@ -23,7 +23,7 @@ With the built-in **AI SRE Agent**, Versus goes further — continuously observi
 - 📡 **On-call**: On-call integrations with AWS Incident Manager
 - 🤖 **AI Agent** *(Beta)*: An AI SRE agent that reads your logs, metrics and tracing, learns what normal looks like, and only alerts you when something new and unexpected appears.
 
-![versus](docs/images/versus-architecture.png)
+![versus](/src/docs/images/versus-architecture.png)
 
 ## Roadmap
 

--- a/src/userguide/admin-ui.md
+++ b/src/userguide/admin-ui.md
@@ -5,7 +5,7 @@ React app embedded directly into the Go binary. There is no separate UI
 process to run; once the server is up, the dashboard is available at the
 root path.
 
-![Versus](/src/docs/images/versus-dashboard-02.png)
+![Versus](/docs/images/versus-dashboard-02.png)
 
 ## Quick start
 

--- a/src/userguide/admin-ui.md
+++ b/src/userguide/admin-ui.md
@@ -5,7 +5,7 @@ React app embedded directly into the Go binary. There is no separate UI
 process to run; once the server is up, the dashboard is available at the
 root path.
 
-![Versus](docs/images/versus-dashboard-02.png)
+![Versus](/src/docs/images/versus-dashboard-02.png)
 
 ## Quick start
 


### PR DESCRIPTION
## Why this is a separate PR

Following review feedback on #160, this PR extracts the three correctness
regressions latent since v1.4.0 into a small, focused changeset so it can
land independently of the larger graceful-degradation / multi-provider /
docs work in #160 (which the maintainer indicated may be reworked once
the Eino agent framework lands).

Every change here has a test; no feature work is mixed in.

## What's in here

### 1. Data race in `Catalog.Get` (`pkg/agent/catalog.go`)

`Get` returned a live `*Pattern` pointer that callers (`worker.classify`
via `prev.BaselineFrequency` / `prev.Count`) read without holding the
catalog mutex while a concurrent `Upsert` from another source's tick
wrote to the same struct. Existing tests passed under `-race` only
because no test exercised concurrent ticks for the same pattern.

`Get` now returns a deep copy (including a copied `Tags` slice).
`TestCatalog_ConcurrentGetUpsertNoRace` runs both operations in
parallel under `-race`.

### 2. Alert fan-out short-circuited on first error (`pkg/core/alert.go`)

The legacy `SendAlert` returned on the first provider error and never
invoked subsequent providers — a flaky Slack silently muted Telegram
and Email, defeating the whole point of the multi-channel design.

Added `Alert.SendAllAlerts`, which tries every configured provider
regardless of earlier failures and returns an `AlertResult` with
per-channel success / failure plus a joined error. The legacy
`SendAlert` is kept as a thin wrapper for any external callers. Each
`AlertProvider` now exposes `Name()` so failures are attributable.

Tests: `TestSendAllAlerts_TriesEveryProvider` (3 providers, middle one
OK, two fail), `TestSendAllAlerts_AllSucceed` / `AllFail`,
`TestSendAlertLegacy_ReturnsJoinedErr`.

### 3. `OnCallTriggered` reported true even when escalation never started (`pkg/services/incident.go`)

The flag was set at record-build time, before `SendAlert` and
`workflow.Start` ran. If `workflow.Start` later failed, the function
returned early and the persisted record claimed on-call was triggered
while no one was actually paged.

`CreateIncident` now uses `SendAllAlerts`, stores `ChannelsNotified`
as the channels that actually succeeded (vs. the new `ChannelsEnabled`
for what was configured), sets `NotifyStatus` to `"sent"` / `"partial"`
/ `"failed"` based on the fan-out result, and walks `OnCallTriggered`
back to `false` (writing `OnCallError`) when `workflow.Start` fails.
Storage schema gained `ChannelsEnabled` and `OnCallError` to support
this.

### 4. Constant-time gateway-secret comparison (`pkg/controllers/`)

All three admin controllers (agent, config, incidents) used a naive
`got != expected` string compare for the `X-Gateway-Secret` header.
Switched to `crypto/subtle.ConstantTimeCompare` via a small shared
helper (`pkg/controllers/secret.go`) so prefix-match timing oracles
are eliminated. The risk surface is small (local network, ~64-byte
secret) but the fix is one line per call site.

### 5. fsync staged file before atomic rename (`pkg/storage/file.go`)

`os.WriteFile` + `os.Rename` did not call `fsync` on the tmp file
before the rename. The rename is journaled by ext4 / xfs; the tmp
file's data is not, so a power loss in the brief window between
write and rename could replace a previous good `patterns.json` /
`incidents.json` with a zero-length file.

Extracted a `writeFileAtomicSync` helper that opens the `.tmp` file,
writes the payload, fsyncs, closes, renames over the target, and
cleans up the `.tmp` on any error path. `WriteBlob` (agent catalog,
shadow log, detect log) and `persistIncidentsLocked` (every alert)
now go through this helper.

## Test plan

- [x] `gofmt -l` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test -race -count=1 ./...` passes
- [ ] Manual: run against a real workload to confirm the alert
      fan-out actually reaches every channel when one provider errors.

## Relationship to #160

After this lands, #160 will be force-pushed to drop these three
commits from its history. The remaining contents of #160 (graceful
degradation, multi-provider AI support, docs) will then sit on top of
`upstream/main` once this PR is merged.
