### PR TITLE
feat(agent): add analyze tools — related logs, recent changes, dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ charts
 __pycache__
 coverage.out
 plans
+.github/copilot-instructions.md
+PROJECT_STRUCTURE.md
+EINO_PATTERNS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - New data-source pages: `src/agent/data-sources/graylog.md`,
   `src/agent/data-sources/splunk.md`.
 
+#### AI SRE Agent — analyze tools expansion (Phase 2.5)
+- **`get_related_logs` tool** — pulls a redacted raw-log slice from
+  configured signal sources around the incident window. Bridge via
+  `SignalReader` in `pkg/agent/analyze_adapter.go` (no import cycle).
+  Window default 15m (cap 1440m), limit default 50 (cap 200).
+- **`recent_changes` tool** — reads one or more remote git repositories'
+  commit histories to correlate incidents with recent deploys. Repos
+  configured in `tools.yaml` (`tools.recent_changes.git.repos[]`). Each
+  remote is mirror-cloned into a local cache on first use and fetched on
+  later lookups. Global + per-repo auth: HTTPS token via
+  `http.extraHeader` (never persisted to the mirror), SSH key via
+  `GIT_SSH_COMMAND`. Window default 120m (cap 1440m), newest first.
+- **`describe_dependencies` tool** — surfaces upstream/downstream
+  service neighbours from the service-dependency graph in `tools.yaml`
+  (`tools.describe_dependencies.services`), with a
+  `has_recent_incident` flag per neighbour. Reverse edges derived
+  automatically from `depends_on`.
+- **`tools.yaml` sibling config** — new optional per-tool DATA
+  configuration file (same directory as `config.yaml`). Supports
+  `${VAR}` expansion. Not a tool allow-list — tools are wired in code.
+- **`tool_timeout`** knob (root of `tools.yaml`, default `20s`) — caps
+  each tool dispatch; a timeout surfaces as a tool error, never a hard
+  failure.
+- **`parallel_tools`** knob (root of `tools.yaml`, default `false`) —
+  run multiple tool calls in one model turn concurrently while
+  preserving deterministic trace ordering.
+
 ### Changed
 - **Legacy `pkg/agent/ai/openai.go` deleted** — Eino is the only LLM
   path going forward. The `core.AISRE` adapter is removed; all callers
@@ -74,6 +101,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `AIBundle{Router, Detect, Analyze, Cache, Rate, AnalyzeRate}`.
 - `agent.ai.analyze` config block added; `analyze.enable` defaults to
   `true` when `ai.enable` is true (no separate opt-in flag).
+- `tool_timeout` and `parallel_tools` moved from `agent.ai.analyze`
+  to the root of `tools.yaml` — they apply to every tool dispatch.
+- `analyzetools.Default` signature extended to accept `SignalReader`,
+  `DependencyGraph`, and `ChangeFeed` dependencies.
 
 ### Fixed
 - Incident detail page no longer shows stale analysis status after

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -214,6 +214,18 @@ see [GitHub Project](https://github.com/orgs/VersusControl/projects/2).
   - **Shared prompt loader** — `pkg/agent/ai/prompt/loader.go`
   - **UI** — Run Analysis button, AnalysisCard, past analyses list
   - Legacy `pkg/agent/ai/openai.go` deleted
+- [x] **Analyze toolset expansion (Phase 2.5)** — grew the AnalyzeAgent
+  from 3 foundational tools to 6, plus tool-loop infrastructure:
+  - `get_related_logs` — redacted raw-log slice via `SignalReader` bridge
+  - `recent_changes` — remote git commit history feed with per-repo +
+    global auth (HTTPS token / SSH key); configured in `tools.yaml`
+  - `describe_dependencies` — upstream/downstream service graph from
+    `tools.yaml` with `has_recent_incident` flag
+  - `tools.yaml` sibling config file (per-tool DATA, not allow-list)
+  - `tool_timeout` (default 20s) + `parallel_tools` knobs at
+    `tools.yaml` root
+  - Docs: `ai-analyze-mode.md` per-tool YAML, `configuration.md`
+    worked examples
 
 ---
 
@@ -225,28 +237,6 @@ soak. Track Phase 2 work on the
 
 > The `Auto Post Mortem` UI card stays a `coming soon` stub until
 > Phase 3 lands.
-
-### AI SRE Agent — Phase 2.5: Analyze toolset expansion
-Grows the on-demand AnalyzeAgent from the three foundational read-only
-tools shipped in Phase 2 (`recent_incidents`, `pattern_history`,
-`describe_service`) into a deeper investigation set. Every tool stays
-read-only (import-graph guard), returns the `core.ToolResult` envelope,
-is allow-list filterable, and is recorded in the tool-call audit trail.
-Detailed plan + task board:
-[local plan](https://github.com/orgs/VersusControl/projects/2).
-- [ ] **E7 — Cross-source log retrieval** (`get_related_logs`) — pull a
-  redacted raw-log slice from the originating `SignalSource` around the
-  incident window (reuses `core.SignalSource`; no new config surface)
-- [ ] **E8 — Change / deploy correlation** (`recent_changes`) — line an
-  incident up against recent deploys/config changes from an optional
-  local NDJSON change feed (`agent.ai.analyze.changes_source`)
-- [ ] **E9 — Dependency awareness** (`describe_dependencies`) — surface
-  upstream/downstream neighbours from an optional `services.yaml`
-  dependency graph, flagging which neighbours are also firing
-- [ ] **E10 — Tool-runtime hardening & docs** — per-tool timeout
-  (`agent.ai.analyze.tool_timeout`), optional parallel tool dispatch
-  (`agent.ai.analyze.parallel_tools`), and doc updates to
-  `src/agent/ai-analyze-mode.md` + the agent config reference
 
 > Metrics & traces are **out of scope** for Phase 2.5 — Versus has no
 > metric ingestion path today. A metric-lookup analyze tool waits on

--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -1,0 +1,81 @@
+# tools.yaml — per-tool configuration for the AI SRE Agent's analyze tools.
+#
+# This file is loaded automatically when it sits next to the main config
+# file (config.yaml). It is OPTIONAL: with no file (or an empty section) a
+# tool that needs external data simply degrades to a clean "nothing found"
+# and the analysis proceeds without it.
+#
+# This file holds per-tool DATA configuration only. It is NOT a tool
+# allow-list: tools are registered in code (analyzetools.Default), and a
+# missing config block just means the tool has no data to read.
+
+
+tools:
+  # Shared tool-loop knobs (apply to every analyze tool dispatch).
+  tool_timeout: 20s     # cap per tool dispatch; empty/"0"/invalid = 20s default
+  parallel_tools: false # run tool calls in one model turn concurrently (off = sequential)
+
+  # ---------------------------------------------------------------------------
+  # recent_changes — correlate an incident with recent deploys / config changes
+  # ---------------------------------------------------------------------------
+  # The recent_changes tool reads one or more REMOTE git repositories' commit
+  # histories (the deploy/change record most teams already keep). Each repo is
+  # mirror-cloned into a local cache on first use and fetched on later lookups.
+  # It shells out to the `git` binary, which MUST be available on PATH. Private
+  # remotes authenticate via the optional `auth` block: a global default under
+  # `git.auth` applies to every repo, and each repo may override it with its own
+  # `auth`. With an empty `repos` list the tool is not registered.
+  #
+  # recent_changes:
+  #   git:
+  #     auth:                       # global default auth (optional)
+  #       token: ${GIT_TOKEN}       # HTTPS access token / PAT
+  #       ssh_key_path: ""          # path to a private SSH key
+  #     repos:
+  #       - url: https://github.com/acme/api.git  # remote clone URL (required)
+  #         branch: main                          # optional; empty = default HEAD
+  #         service: api                          # optional; empty = derived from URL
+  #         auth:                                 # optional; overrides git.auth
+  #           token: ${ACME_API_TOKEN}
+  recent_changes:
+    git:
+      auth:             # global default auth; empty = ambient git credentials
+        token: ""         # HTTPS access token / PAT (e.g. ${GIT_TOKEN})
+        ssh_key_path: ""  # path to a private SSH key for ssh/scp-like remotes
+      repos: []   # empty leaves recent_changes unregistered
+        # - url: https://github.com/acme/api.git
+        #   branch: main          # optional; empty = default HEAD
+        #   service: api          # optional; empty = auto-detected from repo name
+        # - url: git@github.com:acme/web.git   # service auto-detected as "web"
+        #   auth:                 # optional; per-repo override of git.auth
+        #     ssh_key_path: /home/versus/.ssh/web_deploy
+
+  # -------------------------------------------------------------------------
+  # describe_dependencies — surface a service's upstream/downstream neighbours
+  # -------------------------------------------------------------------------
+  # An optional service-dependency graph. With an empty `services` list the
+  # describe_dependencies tool is simply not registered and analyses proceed
+  # without dependency awareness.
+  #
+  # Schema (minimal):
+  #   services:
+  #     - name: <service-name>        # the service node
+  #       depends_on:                 # upstream services this one relies on
+  #         - <other-service-name>
+  #
+  # Only `depends_on` (upstream edges) is authored by hand. The reverse edges
+  # (`depended_on_by`, i.e. downstream consumers) are derived automatically.
+  describe_dependencies:
+    services: []
+    #  - name: web
+    #    depends_on:
+    #      - api
+    #  - name: api
+    #    depends_on:
+    #      - database
+    #      - cache
+    #  - name: worker
+    #    depends_on:
+    #      - database
+    #      - queue
+

--- a/pkg/agent/ai/analyze/agent.go
+++ b/pkg/agent/ai/analyze/agent.go
@@ -5,11 +5,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/cloudwego/eino/callbacks"
 	"github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/components/tool"
+	"github.com/cloudwego/eino/compose"
+	"github.com/cloudwego/eino/flow/agent"
+	"github.com/cloudwego/eino/flow/agent/react"
 	"github.com/cloudwego/eino/schema"
+	utilcb "github.com/cloudwego/eino/utils/callbacks"
 	"github.com/eino-contrib/jsonschema"
 
 	einowrap "github.com/VersusControl/versus-incident/pkg/agent/ai/eino"
@@ -18,21 +27,30 @@ import (
 )
 
 const (
-	defaultMaxToolIterations = 3
-	maxToolOutputBytes       = 4096
+	defaultMaxToolIterations = 8
+	maxToolOutputBytes       = 8192
+	// defaultToolTimeout caps a single tool dispatch when the operator
+	// does not configure analyze.tool_timeout. A slow tool surfaces as a
+	// tool error in the audit trace instead of consuming the whole
+	// analysis budget.
+	defaultToolTimeout = 20 * time.Second
 )
 
-// Agent is the analyze-kind AIAgent. It binds the resolved per-task
-// config, a tool-calling Eino chat model with the read-only tool
-// catalog already attached, and an in-memory tool registry the agent
-// dispatches to when the model issues a tool_call.
+// Agent is the analyze-kind AIAgent. The investigation loop, tool
+// fan-out, and per-call audit all run on Eino's pre-built ReAct agent
+// (flow/agent/react). The struct binds the resolved per-task config,
+// the ReAct agent (which already owns the tool-calling chat model plus
+// a compose.ToolsNode — sequential by default, concurrent when
+// analyze.parallel_tools is set), and an in-memory registry of the
+// read-only tools (kept for introspection / allow-list assertions).
 //
-// The struct deliberately has NO Emitter / Notifier field. The
-// import-graph guard test in agent_test.go asserts this so future
-// edits cannot silently turn analyze into a notification path.
+// The struct deliberately has NO Emitter / Notifier / Sender /
+// Dispatcher field. The import-graph guard test in agent_test.go
+// asserts this so future edits cannot silently turn analyze into a
+// notification path.
 type Agent struct {
 	cfg     config.AgentAIConfig
-	chat    model.ToolCallingChatModel
+	agent   *react.Agent
 	tools   map[string]core.AnalyzeTool
 	maxIter int
 }
@@ -43,27 +61,41 @@ type Options struct {
 	BaseURL    string
 	Timeout    time.Duration
 
-	// ChatModel overrides the Eino chat model. When non-nil the agent
-	// skips dialing OpenAI; tests pass a fake. The fake MUST already
-	// have tools bound (the constructor will not call WithTools on it).
+	// ChatModel overrides the Eino tool-calling chat model. When
+	// non-nil the agent skips dialing OpenAI; tests pass a fake. The
+	// ReAct agent binds tools onto it via WithTools.
 	ChatModel model.ToolCallingChatModel
+
+	// ToolTimeout caps a single tool dispatch. Zero applies the built-in
+	// defaultToolTimeout; a negative value disables the per-tool cap.
+	ToolTimeout time.Duration
+
+	// ParallelTools runs multiple tool calls emitted in one model turn
+	// concurrently. False (the default) dispatches them sequentially.
+	ParallelTools bool
 }
 
 // New constructs an analyze Agent. cfg must already be resolved for
 // the analyze task (see config.AgentAIConfig.Resolve). Every tool in
 // the supplied list is registered with the agent.
 func New(ctx context.Context, cfg config.AgentAIConfig, tools []core.AnalyzeTool, opts Options) (*Agent, error) {
+	toolTimeout := opts.ToolTimeout
+	if toolTimeout == 0 {
+		toolTimeout = defaultToolTimeout
+	}
+
 	reg := map[string]core.AnalyzeTool{}
+	einoTools := make([]tool.BaseTool, 0, len(tools))
 	for _, t := range tools {
 		if t == nil || t.Name() == "" {
 			continue
 		}
 		reg[t.Name()] = t
-	}
-
-	infos, err := buildToolInfos(reg)
-	if err != nil {
-		return nil, err
+		et, err := newEinoTool(t, toolTimeout)
+		if err != nil {
+			return nil, err
+		}
+		einoTools = append(einoTools, et)
 	}
 
 	chat := opts.ChatModel
@@ -76,18 +108,44 @@ func New(ctx context.Context, cfg config.AgentAIConfig, tools []core.AnalyzeTool
 		if err != nil {
 			return nil, err
 		}
-		bound, err := base.WithTools(infos)
-		if err != nil {
-			return nil, fmt.Errorf("analyze: WithTools: %w", err)
-		}
-		chat = bound
+		chat = base
+	}
+
+	maxIter := defaultMaxToolIterations
+
+	// MaxStep bounds the ReAct graph's pregel super-steps. The graph
+	// alternates chat -> tools -> chat ...; N chat calls interleaved
+	// with N-1 tool rounds take 2N-1 steps. Allowing maxIter tool
+	// rounds plus a final answer call (N = maxIter+1) gives the bound
+	// below — the framework-native equivalent of the old maxIter loop
+	// plus its "budget exhausted" guard.
+	reactAgent, err := react.NewAgent(ctx, &react.AgentConfig{
+		ToolCallingModel: chat,
+		ToolsConfig: compose.ToolsNodeConfig{
+			Tools: einoTools,
+			// Repair malformed tool calls from small models instead of
+			// aborting the turn: a hallucinated tool name is answered
+			// with a structured error the model can recover from.
+			UnknownToolsHandler: func(_ context.Context, name, _ string) (string, error) {
+				return fmt.Sprintf(`{"error":"unknown tool %q"}`, name), nil
+			},
+			// Tool dispatch is sequential by default; opts.ParallelTools
+			// flips ExecuteSequentially off so multiple tool calls in one
+			// turn fan out concurrently. The audit trace stays ordered
+			// either way (seq-stamped at OnStart, stable-sorted).
+			ExecuteSequentially: !opts.ParallelTools,
+		},
+		MaxStep: 2*maxIter + 1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("analyze: build react agent: %w", err)
 	}
 
 	return &Agent{
 		cfg:     cfg,
-		chat:    chat,
+		agent:   reactAgent,
 		tools:   reg,
-		maxIter: defaultMaxToolIterations,
+		maxIter: maxIter,
 	}, nil
 }
 
@@ -119,50 +177,35 @@ func (a *Agent) run(ctx context.Context, snap core.AnalyzeIncidentSnapshot) (*co
 		schema.UserMessage(user),
 	}
 
-	traces := make([]core.ToolCallTrace, 0)
+	// The audit trace is built from Eino tool callbacks rather than
+	// hand instrumentation, so it captures every tool the framework
+	// dispatches (including concurrent calls in one turn).
+	collector := &traceCollector{}
+	handler := utilcb.NewHandlerHelper().Tool(collector.toolHandler()).Handler()
+
 	start := time.Now()
-	rawFinal := ""
+	out, err := a.agent.Generate(ctx, messages, agent.WithComposeOptions(compose.WithCallbacks(handler)))
+	durationMs := time.Since(start).Milliseconds()
+	traces := collector.ordered()
 
-	for iter := 0; iter <= a.maxIter; iter++ {
-		out, err := a.chat.Generate(ctx, messages)
-		if err != nil {
-			return nil, fmt.Errorf("analyze: chat (iter %d): %w", iter, err)
-		}
-		if out == nil {
-			return nil, fmt.Errorf("analyze: empty response (iter %d)", iter)
-		}
-
-		// If the model produced tool calls, dispatch them and loop.
-		if len(out.ToolCalls) > 0 {
-			if iter == a.maxIter {
-				// Budget exhausted: force a final pass by appending a
-				// system nudge and breaking out on next turn.
-				messages = append(messages, out)
-				messages = append(messages, schema.SystemMessage(
-					"Tool iteration budget exhausted. Reply with the final JSON finding now."))
-				continue
-			}
-			messages = append(messages, out)
-			for _, tc := range out.ToolCalls {
-				trace := a.invokeTool(ctx, tc)
-				traces = append(traces, trace)
-				// Build the tool message regardless of error — the model
-				// needs a reply per tool_call_id or it will refuse next turn.
-				content := trace.Output
-				if trace.Error != "" {
-					content = fmt.Sprintf(`{"error":%q}`, trace.Error)
-				}
-				messages = append(messages, schema.ToolMessage(content, tc.ID))
-			}
-			continue
-		}
-
-		// No tool calls → this is the final assistant message.
-		rawFinal = strings.TrimSpace(out.Content)
-		break
+	if err != nil {
+		return &core.AICallResult{
+			UserPrompt: user,
+			DurationMs: durationMs,
+			Model:      a.cfg.Model,
+			ToolCalls:  traces,
+		}, fmt.Errorf("analyze: react agent: %w", err)
+	}
+	if out == nil {
+		return &core.AICallResult{
+			UserPrompt: user,
+			DurationMs: durationMs,
+			Model:      a.cfg.Model,
+			ToolCalls:  traces,
+		}, fmt.Errorf("analyze: react agent returned no message")
 	}
 
-	durationMs := time.Since(start).Milliseconds()
+	rawFinal := strings.TrimSpace(out.Content)
 	if rawFinal == "" {
 		return &core.AICallResult{
 			UserPrompt: user,
@@ -193,57 +236,165 @@ func (a *Agent) run(ctx context.Context, snap core.AnalyzeIncidentSnapshot) (*co
 	}, nil
 }
 
-func (a *Agent) invokeTool(ctx context.Context, tc schema.ToolCall) core.ToolCallTrace {
-	t := core.ToolCallTrace{
-		Name: tc.Function.Name,
-		Args: tc.Function.Arguments,
+// traceCollector turns Eino tool callbacks into ordered
+// core.ToolCallTrace entries. Tools may run concurrently, so the slice
+// is mutex-guarded and reassembled in start order (a monotonically
+// increasing sequence stamped at OnStart) before it lands in the
+// core.AICallResult.
+type traceCollector struct {
+	mu    sync.Mutex
+	seq   int64
+	items []*traceItem
+}
+
+type traceItem struct {
+	seq   int64
+	start time.Time
+	trace core.ToolCallTrace
+}
+
+type traceCtxKey struct{}
+
+func (c *traceCollector) toolHandler() *utilcb.ToolCallbackHandler {
+	return &utilcb.ToolCallbackHandler{
+		OnStart: func(ctx context.Context, info *callbacks.RunInfo, input *tool.CallbackInput) context.Context {
+			it := &traceItem{
+				seq:   atomic.AddInt64(&c.seq, 1),
+				start: time.Now(),
+			}
+			if info != nil {
+				it.trace.Name = info.Name
+			}
+			if input != nil {
+				it.trace.Args = input.ArgumentsInJSON
+			}
+			c.mu.Lock()
+			c.items = append(c.items, it)
+			c.mu.Unlock()
+			return context.WithValue(ctx, traceCtxKey{}, it)
+		},
+		OnEnd: func(ctx context.Context, _ *callbacks.RunInfo, output *tool.CallbackOutput) context.Context {
+			it, _ := ctx.Value(traceCtxKey{}).(*traceItem)
+			if it == nil {
+				return ctx
+			}
+			it.trace.DurationMs = time.Since(it.start).Milliseconds()
+			if output != nil {
+				it.trace.Output = capOutput(output.Response)
+			}
+			return ctx
+		},
+		OnError: func(ctx context.Context, _ *callbacks.RunInfo, err error) context.Context {
+			it, _ := ctx.Value(traceCtxKey{}).(*traceItem)
+			if it == nil {
+				return ctx
+			}
+			it.trace.DurationMs = time.Since(it.start).Milliseconds()
+			if err != nil {
+				it.trace.Error = err.Error()
+			}
+			return ctx
+		},
 	}
-	tool, ok := a.tools[tc.Function.Name]
-	if !ok {
-		t.Error = fmt.Sprintf("unknown tool %q", tc.Function.Name)
-		return t
+}
+
+func (c *traceCollector) ordered() []core.ToolCallTrace {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	sort.SliceStable(c.items, func(i, j int) bool { return c.items[i].seq < c.items[j].seq })
+	out := make([]core.ToolCallTrace, 0, len(c.items))
+	for _, it := range c.items {
+		out = append(out, it.trace)
 	}
-	start := time.Now()
-	result, err := tool.Invoke(ctx, json.RawMessage(tc.Function.Arguments))
-	t.DurationMs = time.Since(start).Milliseconds()
+	return out
+}
+
+func capOutput(s string) string {
+	if len(s) > maxToolOutputBytes {
+		return s[:maxToolOutputBytes] + `..."truncated"`
+	}
+	return s
+}
+
+// einoTool adapts a read-only core.AnalyzeTool onto Eino's
+// tool.InvokableTool so the ReAct agent's ToolsNode can dispatch it.
+// The single core.ToolResult envelope is preserved: Invoke still
+// returns core.ToolResult, which this adapter JSON-marshals (capped at
+// maxToolOutputBytes) into the string the model consumes.
+type einoTool struct {
+	impl    core.AnalyzeTool
+	info    *schema.ToolInfo
+	timeout time.Duration
+}
+
+func newEinoTool(t core.AnalyzeTool, timeout time.Duration) (*einoTool, error) {
+	info := &schema.ToolInfo{
+		Name: t.Name(),
+		Desc: t.Description(),
+	}
+	argsSchema := t.ArgsSchema()
+	if len(argsSchema) > 0 {
+		raw, err := json.Marshal(argsSchema)
+		if err != nil {
+			return nil, fmt.Errorf("analyze: marshal schema for tool %q: %w", t.Name(), err)
+		}
+		js := &jsonschema.Schema{}
+		if err := json.Unmarshal(raw, js); err != nil {
+			return nil, fmt.Errorf("analyze: parse schema for tool %q: %w", t.Name(), err)
+		}
+		info.ParamsOneOf = schema.NewParamsOneOfByJSONSchema(js)
+	}
+	return &einoTool{impl: t, info: info, timeout: timeout}, nil
+}
+
+// Info implements tool.BaseTool.
+func (e *einoTool) Info(_ context.Context) (*schema.ToolInfo, error) { return e.info, nil }
+
+// InvokableRun implements tool.InvokableTool. Tool errors (including a
+// per-tool timeout) are surfaced to the model as a structured error
+// message instead of aborting the ReAct graph, mirroring the prior
+// loop's resilience (the model can recover or pick another tool on the
+// next turn).
+func (e *einoTool) InvokableRun(ctx context.Context, argumentsInJSON string, _ ...tool.Option) (string, error) {
+	result, err := e.invoke(ctx, json.RawMessage(argumentsInJSON))
 	if err != nil {
-		t.Error = err.Error()
-		return t
+		return fmt.Sprintf(`{"error":%q}`, err.Error()), nil
 	}
 	b, mErr := json.Marshal(result)
 	if mErr != nil {
-		t.Error = fmt.Sprintf("marshal tool output: %v", mErr)
-		return t
+		return fmt.Sprintf(`{"error":%q}`, "marshal tool output: "+mErr.Error()), nil
 	}
-	if len(b) > maxToolOutputBytes {
-		b = append(b[:maxToolOutputBytes], []byte(`..."truncated"`)...)
-	}
-	t.Output = string(b)
-	return t
+	return capOutput(string(b)), nil
 }
 
-// buildToolInfos converts the registry into Eino ToolInfos. Each
-// AnalyzeTool's ArgsSchema is treated as JSON Schema 2020-12.
-func buildToolInfos(reg map[string]core.AnalyzeTool) ([]*schema.ToolInfo, error) {
-	out := make([]*schema.ToolInfo, 0, len(reg))
-	for name, t := range reg {
-		info := &schema.ToolInfo{
-			Name: name,
-			Desc: t.Description(),
-		}
-		argsSchema := t.ArgsSchema()
-		if len(argsSchema) > 0 {
-			raw, err := json.Marshal(argsSchema)
-			if err != nil {
-				return nil, fmt.Errorf("analyze: marshal schema for tool %q: %w", name, err)
-			}
-			js := &jsonschema.Schema{}
-			if err := json.Unmarshal(raw, js); err != nil {
-				return nil, fmt.Errorf("analyze: parse schema for tool %q: %w", name, err)
-			}
-			info.ParamsOneOf = schema.NewParamsOneOfByJSONSchema(js)
-		}
-		out = append(out, info)
+// invoke runs the wrapped tool under the per-tool timeout. A
+// non-positive timeout disables the cap and the tool runs directly.
+// Otherwise the tool runs against a derived deadline context; if it
+// outruns the deadline (even when the tool ignores cancellation) the
+// dispatch returns a timeout error promptly while the goroutine drains
+// into a buffered channel, so no goroutine is leaked indefinitely.
+func (e *einoTool) invoke(ctx context.Context, args json.RawMessage) (*core.ToolResult, error) {
+	if e.timeout <= 0 {
+		return e.impl.Invoke(ctx, args)
 	}
-	return out, nil
+
+	tctx, cancel := context.WithTimeout(ctx, e.timeout)
+	defer cancel()
+
+	type result struct {
+		out *core.ToolResult
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		out, err := e.impl.Invoke(tctx, args)
+		done <- result{out: out, err: err}
+	}()
+
+	select {
+	case <-tctx.Done():
+		return nil, fmt.Errorf("tool %q timed out after %s", e.impl.Name(), e.timeout)
+	case r := <-done:
+		return r.out, r.err
+	}
 }

--- a/pkg/agent/ai/analyze/agent_test.go
+++ b/pkg/agent/ai/analyze/agent_test.go
@@ -3,9 +3,13 @@ package analyze
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/schema"
@@ -69,6 +73,25 @@ func (s *stubTool) Invoke(_ context.Context, args json.RawMessage) (*core.ToolRe
 		Data:  map[string]any{"echo": string(args)},
 	}, nil
 }
+
+// errTool is a read-only AnalyzeTool that always fails, used to assert
+// the ReAct loop surfaces tool errors to the model rather than aborting.
+type errTool struct {
+	name    string
+	invoked int
+}
+
+func (e *errTool) Name() string        { return e.name }
+func (e *errTool) Description() string { return "always errors" }
+func (e *errTool) ArgsSchema() map[string]any {
+	return map[string]any{"type": "object"}
+}
+func (e *errTool) Invoke(_ context.Context, _ json.RawMessage) (*core.ToolResult, error) {
+	e.invoked++
+	return nil, errBoom
+}
+
+var errBoom = fmt.Errorf("boom from tool")
 
 func newAgentWithFake(t *testing.T, fake *fakeChat, tools []core.AnalyzeTool, maxIter int) *Agent {
 	t.Helper()
@@ -163,5 +186,248 @@ func TestAgent_FilterAllowList(t *testing.T) {
 	}
 	if _, ok := a.tools["drop_me"]; !ok {
 		t.Fatalf("drop_me not registered")
+	}
+}
+
+// TestAgent_ConcurrentToolCalls exercises the Eino ReAct loop with two
+// tool calls in a single turn and parallel_tools enabled: both tools
+// must run (concurrent compose.ToolsNode fan-out) and both must be
+// recorded in the callback-built audit trace before the final finding
+// is parsed.
+func TestAgent_ConcurrentToolCalls(t *testing.T) {
+	a := &stubTool{name: "tool_a"}
+	b := &stubTool{name: "tool_b"}
+	finalJSON := `{"title":"t","summary":"s","next_steps":["x"]}`
+
+	twoCalls := schema.AssistantMessage("", []schema.ToolCall{
+		{ID: "c-a", Type: "function", Function: schema.FunctionCall{Name: "tool_a", Arguments: `{"q":"a"}`}},
+		{ID: "c-b", Type: "function", Function: schema.FunctionCall{Name: "tool_b", Arguments: `{"q":"b"}`}},
+	})
+	fake := &fakeChat{turns: []*schema.Message{twoCalls, schema.AssistantMessage(finalJSON, nil)}}
+
+	agent, err := New(context.Background(),
+		config.AgentAIConfig{Model: "fake", APIKey: "x"},
+		[]core.AnalyzeTool{a, b},
+		Options{ChatModel: fake, ParallelTools: true},
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := agent.Run(context.Background(), core.AnalyzeTask{
+		Snapshot: core.AnalyzeIncidentSnapshot{IncidentID: "i-2"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if a.invoked != 1 || b.invoked != 1 {
+		t.Fatalf("tool invocations: a=%d b=%d, want 1/1", a.invoked, b.invoked)
+	}
+	if len(res.ToolCalls) != 2 {
+		t.Fatalf("trace len = %d, want 2", len(res.ToolCalls))
+	}
+	got := map[string]bool{}
+	for _, tc := range res.ToolCalls {
+		got[tc.Name] = true
+		if tc.Output == "" {
+			t.Fatalf("trace %q has empty output", tc.Name)
+		}
+	}
+	if !got["tool_a"] || !got["tool_b"] {
+		t.Fatalf("trace missing a tool: %+v", res.ToolCalls)
+	}
+	if res.Finding == nil || res.Finding.Title != "t" {
+		t.Fatalf("finding parsed wrong: %+v", res.Finding)
+	}
+}
+
+// TestAgent_ToolErrorDoesNotAbort asserts a failing tool is surfaced to
+// the model as a structured error instead of aborting the ReAct graph,
+// so the model can still produce a final finding.
+func TestAgent_ToolErrorDoesNotAbort(t *testing.T) {
+	boom := &errTool{name: "boom"}
+	finalJSON := `{"title":"recovered","summary":"s","next_steps":["x"]}`
+
+	callMsg := schema.AssistantMessage("", []schema.ToolCall{
+		{ID: "c-1", Type: "function", Function: schema.FunctionCall{Name: "boom", Arguments: `{}`}},
+	})
+	fake := &fakeChat{turns: []*schema.Message{callMsg, schema.AssistantMessage(finalJSON, nil)}}
+
+	agent := newAgentWithFake(t, fake, []core.AnalyzeTool{boom}, 3)
+	res, err := agent.Run(context.Background(), core.AnalyzeTask{
+		Snapshot: core.AnalyzeIncidentSnapshot{IncidentID: "i-3"},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error, want graceful recovery: %v", err)
+	}
+	if res.Finding == nil || res.Finding.Title != "recovered" {
+		t.Fatalf("finding parsed wrong: %+v", res.Finding)
+	}
+	if len(res.ToolCalls) != 1 || !strings.Contains(res.ToolCalls[0].Output, "error") {
+		t.Fatalf("expected tool error surfaced in trace output: %+v", res.ToolCalls)
+	}
+}
+
+// blockTool blocks until its context is cancelled or it is released,
+// used to assert the per-tool timeout cancels a slow dispatch.
+type blockTool struct {
+	name    string
+	release chan struct{}
+	invoked int32
+}
+
+func (b *blockTool) Name() string               { return b.name }
+func (b *blockTool) Description() string        { return "blocks" }
+func (b *blockTool) ArgsSchema() map[string]any { return map[string]any{"type": "object"} }
+func (b *blockTool) Invoke(ctx context.Context, _ json.RawMessage) (*core.ToolResult, error) {
+	atomic.AddInt32(&b.invoked, 1)
+	select {
+	case <-b.release:
+	case <-ctx.Done():
+	}
+	return &core.ToolResult{Tool: b.name, Found: true}, nil
+}
+
+// TestAgent_ToolTimeout asserts a tool that outruns the per-tool
+// timeout is abandoned, its timeout surfaces as a structured tool error
+// in the audit trace, and the ReAct graph still recovers a finding from
+// the model's final message.
+func TestAgent_ToolTimeout(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	slow := &blockTool{name: "slow_tool", release: release}
+
+	callMsg := schema.AssistantMessage("", []schema.ToolCall{
+		{ID: "c-1", Type: "function", Function: schema.FunctionCall{Name: "slow_tool", Arguments: `{}`}},
+	})
+	finalJSON := `{"title":"recovered","summary":"s","next_steps":["x"]}`
+	fake := &fakeChat{turns: []*schema.Message{callMsg, schema.AssistantMessage(finalJSON, nil)}}
+
+	a, err := New(context.Background(),
+		config.AgentAIConfig{Model: "fake", APIKey: "x"},
+		[]core.AnalyzeTool{slow},
+		Options{ChatModel: fake, ToolTimeout: 50 * time.Millisecond},
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	start := time.Now()
+	res, err := a.Run(context.Background(), core.AnalyzeTask{
+		Snapshot: core.AnalyzeIncidentSnapshot{IncidentID: "i-timeout"},
+	})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Run returned error, want graceful recovery: %v", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("run took %s, expected the tool to be abandoned quickly", elapsed)
+	}
+	if atomic.LoadInt32(&slow.invoked) != 1 {
+		t.Fatalf("tool invoked %d times, want 1", slow.invoked)
+	}
+	if len(res.ToolCalls) != 1 || !strings.Contains(res.ToolCalls[0].Output, "timed out") {
+		t.Fatalf("expected timeout surfaced in trace output: %+v", res.ToolCalls)
+	}
+	if res.Finding == nil || res.Finding.Title != "recovered" {
+		t.Fatalf("finding parsed wrong: %+v", res.Finding)
+	}
+}
+
+// concProbe is shared state across two probeTool instances. Each tool
+// records the peak number of simultaneously-active invocations so a
+// test can distinguish concurrent fan-out (maxActive == 2) from
+// sequential dispatch (maxActive == 1).
+type concProbe struct {
+	active    int32
+	maxActive int32
+	want      int32
+	wait      time.Duration
+	proceed   chan struct{}
+	once      sync.Once
+}
+
+type probeTool struct {
+	name  string
+	probe *concProbe
+}
+
+func (p *probeTool) Name() string               { return p.name }
+func (p *probeTool) Description() string        { return "probe" }
+func (p *probeTool) ArgsSchema() map[string]any { return map[string]any{"type": "object"} }
+func (p *probeTool) Invoke(ctx context.Context, _ json.RawMessage) (*core.ToolResult, error) {
+	c := p.probe
+	n := atomic.AddInt32(&c.active, 1)
+	for {
+		m := atomic.LoadInt32(&c.maxActive)
+		if n <= m || atomic.CompareAndSwapInt32(&c.maxActive, m, n) {
+			break
+		}
+	}
+	if n >= c.want {
+		c.once.Do(func() { close(c.proceed) })
+	}
+	select {
+	case <-c.proceed:
+	case <-time.After(c.wait):
+	case <-ctx.Done():
+	}
+	atomic.AddInt32(&c.active, -1)
+	return &core.ToolResult{Tool: p.name, Found: true}, nil
+}
+
+func runProbeAgent(t *testing.T, parallel bool, wait time.Duration) int32 {
+	t.Helper()
+	probe := &concProbe{want: 2, wait: wait, proceed: make(chan struct{})}
+	a := &probeTool{name: "probe_a", probe: probe}
+	b := &probeTool{name: "probe_b", probe: probe}
+
+	twoCalls := schema.AssistantMessage("", []schema.ToolCall{
+		{ID: "p-a", Type: "function", Function: schema.FunctionCall{Name: "probe_a", Arguments: `{}`}},
+		{ID: "p-b", Type: "function", Function: schema.FunctionCall{Name: "probe_b", Arguments: `{}`}},
+	})
+	finalJSON := `{"title":"t","summary":"s","next_steps":["x"]}`
+	fake := &fakeChat{turns: []*schema.Message{twoCalls, schema.AssistantMessage(finalJSON, nil)}}
+
+	agent, err := New(context.Background(),
+		config.AgentAIConfig{Model: "fake", APIKey: "x"},
+		[]core.AnalyzeTool{a, b},
+		Options{ChatModel: fake, ParallelTools: parallel},
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := agent.Run(context.Background(), core.AnalyzeTask{
+		Snapshot: core.AnalyzeIncidentSnapshot{IncidentID: "i-probe"},
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return atomic.LoadInt32(&probe.maxActive)
+}
+
+// TestAgent_ParallelTools asserts the parallel_tools knob controls
+// whether two tool calls in one turn overlap. With it enabled both
+// tools are in flight simultaneously (peak 2); with it disabled (the
+// default) dispatch is sequential (peak 1).
+func TestAgent_ParallelTools(t *testing.T) {
+	if got := runProbeAgent(t, true, 2*time.Second); got != 2 {
+		t.Fatalf("parallel: maxActive = %d, want 2", got)
+	}
+	if got := runProbeAgent(t, false, 60*time.Millisecond); got != 1 {
+		t.Fatalf("sequential: maxActive = %d, want 1", got)
+	}
+}
+
+// TestAgent_DefaultToolTimeout asserts newEinoTool carries the built-in
+// default timeout that New applies when Options.ToolTimeout is zero, so
+// production always has a per-tool cap even when analyze.tool_timeout is
+// unset.
+func TestAgent_DefaultToolTimeout(t *testing.T) {
+	stub := &stubTool{name: "echo"}
+	tool, err := newEinoTool(stub, defaultToolTimeout)
+	if err != nil {
+		t.Fatalf("newEinoTool: %v", err)
+	}
+	if tool.timeout != defaultToolTimeout {
+		t.Fatalf("default tool timeout = %s, want %s", tool.timeout, defaultToolTimeout)
 	}
 }

--- a/pkg/agent/ai/analyze/tools/describe_dependencies.go
+++ b/pkg/agent/ai/analyze/tools/describe_dependencies.go
@@ -1,0 +1,196 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/core"
+	"github.com/VersusControl/versus-incident/pkg/storage"
+)
+
+// DependencyGraph is the read-only service-dependency graph that powers
+// the describe_dependencies tool. It is built from the operator-authored
+// `depends_on` (upstream) edges; the reverse `depended_on_by`
+// (downstream) edges are derived automatically. The graph is immutable
+// after construction.
+type DependencyGraph struct {
+	// upstream[s] = services s depends on.
+	upstream map[string][]string
+	// downstream[s] = services that depend on s.
+	downstream map[string][]string
+	// known is the set of every service that appears as a node anywhere
+	// in the graph (either as a key or as a neighbour).
+	known map[string]bool
+}
+
+// NewDependencyGraph builds a DependencyGraph from per-service upstream
+// edges. The map key is a service name; the value is the list of
+// services it depends on. Self-edges and duplicate neighbours are
+// dropped; the reverse edges are derived. A nil/empty input yields an
+// empty graph (every lookup is then a miss).
+func NewDependencyGraph(dependsOn map[string][]string) *DependencyGraph {
+	g := &DependencyGraph{
+		upstream:   make(map[string][]string),
+		downstream: make(map[string][]string),
+		known:      make(map[string]bool),
+	}
+	for svc, deps := range dependsOn {
+		if svc == "" {
+			continue
+		}
+		g.known[svc] = true
+		seen := make(map[string]bool)
+		for _, dep := range deps {
+			if dep == "" || dep == svc || seen[dep] {
+				continue
+			}
+			seen[dep] = true
+			g.known[dep] = true
+			g.upstream[svc] = append(g.upstream[svc], dep)
+			g.downstream[dep] = append(g.downstream[dep], svc)
+		}
+	}
+	for _, list := range g.upstream {
+		sort.Strings(list)
+	}
+	for _, list := range g.downstream {
+		sort.Strings(list)
+	}
+	return g
+}
+
+// Len reports how many service nodes the graph knows about.
+func (g *DependencyGraph) Len() int {
+	if g == nil {
+		return 0
+	}
+	return len(g.known)
+}
+
+// DescribeDependencies surfaces the upstream and downstream neighbours of
+// a service from the operator-authored dependency graph, each annotated
+// with whether that neighbour also has a recent incident. The agent uses
+// it to reason about cascading failures.
+type DescribeDependencies struct {
+	Graph *DependencyGraph
+	// Store is optional. When nil, neighbours are returned without the
+	// has_recent_incident annotation.
+	Store storage.Provider
+}
+
+// Name implements core.AnalyzeTool.
+func (DescribeDependencies) Name() string { return "describe_dependencies" }
+
+// Description implements core.AnalyzeTool.
+func (DescribeDependencies) Description() string {
+	return "Look up a service's upstream (depends_on) and downstream (depended_on_by) neighbours from the dependency graph, each flagged with whether it also has a recent incident. Useful for reasoning about cascading failures."
+}
+
+// ArgsSchema implements core.AnalyzeTool.
+func (DescribeDependencies) ArgsSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"service": map[string]any{
+				"type":        "string",
+				"description": "Required. The service to look up in the dependency graph.",
+			},
+			"window_minutes": map[string]any{
+				"type":        "integer",
+				"description": "Look back this many minutes when flagging neighbours with recent incidents. Default 60, max 1440.",
+			},
+		},
+		"required": []string{"service"},
+	}
+}
+
+type describeDependenciesArgs struct {
+	Service       string `json:"service"`
+	WindowMinutes int    `json:"window_minutes"`
+}
+
+type dependencyNeighbour struct {
+	Service           string `json:"service"`
+	HasRecentIncident bool   `json:"has_recent_incident"`
+}
+
+// Invoke implements core.AnalyzeTool.
+func (d DescribeDependencies) Invoke(_ context.Context, args json.RawMessage) (*core.ToolResult, error) {
+	var a describeDependenciesArgs
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &a); err != nil {
+			return nil, fmt.Errorf("describe_dependencies: parse args: %w", err)
+		}
+	}
+	if a.Service == "" {
+		return nil, fmt.Errorf("describe_dependencies: service is required")
+	}
+	if a.WindowMinutes <= 0 {
+		a.WindowMinutes = 60
+	}
+	if a.WindowMinutes > 1440 {
+		a.WindowMinutes = 1440
+	}
+
+	res := &core.ToolResult{
+		Tool: DescribeDependencies{}.Name(),
+		Data: map[string]any{
+			"service":        a.Service,
+			"window_minutes": a.WindowMinutes,
+		},
+	}
+
+	if d.Graph == nil || !d.Graph.known[a.Service] {
+		// Unknown to the graph: a clean miss, not an error, so the model
+		// can move on without burning a retry.
+		res.Found = false
+		res.Data["upstream"] = []dependencyNeighbour{}
+		res.Data["downstream"] = []dependencyNeighbour{}
+		return res, nil
+	}
+
+	firing := d.servicesWithRecentIncident(a.WindowMinutes)
+	res.Found = true
+	res.Data["upstream"] = annotate(d.Graph.upstream[a.Service], firing)
+	res.Data["downstream"] = annotate(d.Graph.downstream[a.Service], firing)
+	return res, nil
+}
+
+// servicesWithRecentIncident returns the set of service names that have
+// at least one incident newer than the cutoff. A nil store yields a nil
+// set (annotations default to false).
+func (d DescribeDependencies) servicesWithRecentIncident(windowMinutes int) map[string]bool {
+	if d.Store == nil {
+		return nil
+	}
+	all, err := d.Store.ListIncidents(0)
+	if err != nil {
+		// Annotation is best-effort; a store error degrades to no flags
+		// rather than failing the whole lookup.
+		return nil
+	}
+	cutoff := time.Now().UTC().Add(-time.Duration(windowMinutes) * time.Minute)
+	set := make(map[string]bool)
+	for _, rec := range all {
+		if rec.Service == "" || rec.CreatedAt.Before(cutoff) {
+			continue
+		}
+		set[strings.ToLower(rec.Service)] = true
+	}
+	return set
+}
+
+func annotate(neighbours []string, firing map[string]bool) []dependencyNeighbour {
+	out := make([]dependencyNeighbour, 0, len(neighbours))
+	for _, n := range neighbours {
+		out = append(out, dependencyNeighbour{
+			Service:           n,
+			HasRecentIncident: firing[strings.ToLower(n)],
+		})
+	}
+	return out
+}

--- a/pkg/agent/ai/analyze/tools/describe_dependencies_test.go
+++ b/pkg/agent/ai/analyze/tools/describe_dependencies_test.go
@@ -1,0 +1,152 @@
+package tools
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/storage"
+)
+
+func TestDescribeDependencies_Metadata(t *testing.T) {
+	tool := DescribeDependencies{}
+	if got := tool.Name(); got != "describe_dependencies" {
+		t.Errorf("Name() = %q, want describe_dependencies", got)
+	}
+	if tool.Description() == "" {
+		t.Error("Description() is empty")
+	}
+	schema := tool.ArgsSchema()
+	req, ok := schema["required"].([]string)
+	if !ok || len(req) != 1 || req[0] != "service" {
+		t.Errorf("ArgsSchema required = %v, want [service]", schema["required"])
+	}
+}
+
+func TestNewDependencyGraph_DerivesReverseEdges(t *testing.T) {
+	g := NewDependencyGraph(map[string][]string{
+		"web":    {"api"},
+		"api":    {"database", "cache", "database"}, // duplicate dropped
+		"worker": {"database", "worker"},            // self-edge dropped
+		"":       {"ignored"},                       // empty key dropped
+	})
+
+	if g.Len() != 5 {
+		t.Errorf("Len() = %d, want 5 (web, api, worker, database, cache)", g.Len())
+	}
+	// Upstream edges sorted and de-duplicated.
+	if got := g.upstream["api"]; len(got) != 2 || got[0] != "cache" || got[1] != "database" {
+		t.Errorf("upstream[api] = %v, want [cache database]", got)
+	}
+	// Self-edge for worker dropped.
+	if got := g.upstream["worker"]; len(got) != 1 || got[0] != "database" {
+		t.Errorf("upstream[worker] = %v, want [database]", got)
+	}
+	// Reverse edges derived: database is depended on by api + worker.
+	if got := g.downstream["database"]; len(got) != 2 || got[0] != "api" || got[1] != "worker" {
+		t.Errorf("downstream[database] = %v, want [api worker]", got)
+	}
+	if got := g.downstream["api"]; len(got) != 1 || got[0] != "web" {
+		t.Errorf("downstream[api] = %v, want [web]", got)
+	}
+}
+
+func TestDescribeDependencies_MissingService(t *testing.T) {
+	tool := DescribeDependencies{Graph: NewDependencyGraph(map[string][]string{"web": {"api"}})}
+	if _, err := tool.Invoke(context.Background(), mustArgs(t, describeDependenciesArgs{})); err == nil {
+		t.Fatal("expected error when service is empty")
+	}
+}
+
+func TestDescribeDependencies_BadArgs(t *testing.T) {
+	tool := DescribeDependencies{Graph: NewDependencyGraph(nil)}
+	if _, err := tool.Invoke(context.Background(), []byte("{bad")); err == nil {
+		t.Fatal("expected error on malformed args")
+	}
+}
+
+func TestDescribeDependencies_UnknownService(t *testing.T) {
+	tool := DescribeDependencies{Graph: NewDependencyGraph(map[string][]string{"web": {"api"}})}
+	res, err := tool.Invoke(context.Background(), mustArgs(t, describeDependenciesArgs{Service: "ghost"}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if res.Found {
+		t.Error("Found = true, want false for service unknown to graph")
+	}
+	if up := res.Data["upstream"].([]dependencyNeighbour); len(up) != 0 {
+		t.Errorf("upstream = %v, want empty", up)
+	}
+}
+
+func TestDescribeDependencies_NilGraph(t *testing.T) {
+	tool := DescribeDependencies{}
+	res, err := tool.Invoke(context.Background(), mustArgs(t, describeDependenciesArgs{Service: "api"}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if res.Found {
+		t.Error("Found = true, want false when graph is nil")
+	}
+}
+
+func TestDescribeDependencies_TraversalAndAnnotation(t *testing.T) {
+	now := time.Now().UTC()
+	// api depends on database + cache; web depends on api.
+	graph := NewDependencyGraph(map[string][]string{
+		"web": {"api"},
+		"api": {"database", "cache"},
+	})
+	// database has a recent incident; web (downstream) does too; cache does not.
+	store := newStoreWithIncidents(t,
+		&storage.IncidentRecord{ID: "i1", Service: "DataBase", CreatedAt: now.Add(-5 * time.Minute)},
+		&storage.IncidentRecord{ID: "i2", Service: "web", CreatedAt: now.Add(-10 * time.Minute)},
+		&storage.IncidentRecord{ID: "i3", Service: "cache", CreatedAt: now.Add(-3 * time.Hour)}, // outside window
+	)
+	tool := DescribeDependencies{Graph: graph, Store: store}
+
+	res, err := tool.Invoke(context.Background(), mustArgs(t, describeDependenciesArgs{Service: "api"}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !res.Found {
+		t.Fatal("Found = false, want true for known service")
+	}
+
+	up := res.Data["upstream"].([]dependencyNeighbour)
+	// Sorted: cache, database.
+	if len(up) != 2 || up[0].Service != "cache" || up[1].Service != "database" {
+		t.Fatalf("upstream = %v, want [cache database]", up)
+	}
+	if up[0].HasRecentIncident {
+		t.Error("cache flagged with recent incident, want false (incident is outside window)")
+	}
+	if !up[1].HasRecentIncident {
+		t.Error("database not flagged, want true (case-insensitive match on 'DataBase')")
+	}
+
+	down := res.Data["downstream"].([]dependencyNeighbour)
+	if len(down) != 1 || down[0].Service != "web" {
+		t.Fatalf("downstream = %v, want [web]", down)
+	}
+	if !down[0].HasRecentIncident {
+		t.Error("web not flagged, want true")
+	}
+}
+
+func TestDescribeDependencies_WindowClampAndNilStore(t *testing.T) {
+	graph := NewDependencyGraph(map[string][]string{"api": {"database"}})
+	tool := DescribeDependencies{Graph: graph} // nil store
+
+	res, err := tool.Invoke(context.Background(), mustArgs(t, describeDependenciesArgs{Service: "api", WindowMinutes: 99999}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if res.Data["window_minutes"] != 1440 {
+		t.Errorf("window_minutes = %v, want 1440 (clamped)", res.Data["window_minutes"])
+	}
+	up := res.Data["upstream"].([]dependencyNeighbour)
+	if len(up) != 1 || up[0].HasRecentIncident {
+		t.Errorf("upstream = %v, want database with no annotation (nil store)", up)
+	}
+}

--- a/pkg/agent/ai/analyze/tools/describe_service.go
+++ b/pkg/agent/ai/analyze/tools/describe_service.go
@@ -1,0 +1,111 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/VersusControl/versus-incident/pkg/core"
+)
+
+// DescribeService returns the catalog-known summary for a service: how
+// long it has been observed and how many patterns are attributed to it.
+type DescribeService struct {
+	Catalog PatternCatalog
+}
+
+// Name implements core.AnalyzeTool.
+func (DescribeService) Name() string { return "describe_service" }
+
+// Description implements core.AnalyzeTool.
+func (DescribeService) Description() string {
+	return "Summarize what the agent knows about a service: first-seen timestamp and the top learned patterns attributed to it."
+}
+
+// ArgsSchema implements core.AnalyzeTool.
+func (DescribeService) ArgsSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"service": map[string]any{
+				"type":        "string",
+				"description": "Required. The service name to look up.",
+			},
+			"top_patterns": map[string]any{
+				"type":        "integer",
+				"description": "How many top patterns to include. Default 5, max 20.",
+			},
+		},
+		"required": []string{"service"},
+	}
+}
+
+type describeServiceArgs struct {
+	Service     string `json:"service"`
+	TopPatterns int    `json:"top_patterns"`
+}
+
+type describePatternEntry struct {
+	ID       string  `json:"id"`
+	Template string  `json:"template"`
+	Count    int     `json:"count"`
+	Baseline float64 `json:"baseline"`
+	Verdict  string  `json:"verdict,omitempty"`
+}
+
+// Invoke implements core.AnalyzeTool.
+func (d DescribeService) Invoke(_ context.Context, args json.RawMessage) (*core.ToolResult, error) {
+	if d.Catalog == nil {
+		return nil, fmt.Errorf("describe_service: catalog not configured")
+	}
+	var a describeServiceArgs
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &a); err != nil {
+			return nil, fmt.Errorf("describe_service: parse args: %w", err)
+		}
+	}
+	if a.Service == "" {
+		return nil, fmt.Errorf("describe_service: service is required")
+	}
+	if a.TopPatterns <= 0 {
+		a.TopPatterns = 5
+	}
+	if a.TopPatterns > 20 {
+		a.TopPatterns = 20
+	}
+
+	res := &core.ToolResult{
+		Tool: DescribeService{}.Name(),
+		Data: map[string]any{"service": a.Service},
+	}
+	services := d.Catalog.AllServices()
+	if info, ok := services[a.Service]; ok {
+		res.Found = true
+		res.Data["first_seen"] = info.FirstSeen
+	}
+
+	matches := make([]describePatternEntry, 0)
+	for _, p := range d.Catalog.All() {
+		if !strings.EqualFold(p.Service, a.Service) {
+			continue
+		}
+		matches = append(matches, describePatternEntry{
+			ID:       p.ID,
+			Template: p.Template,
+			Count:    p.Count,
+			Baseline: p.Baseline,
+			Verdict:  p.Verdict,
+		})
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		return matches[i].Count > matches[j].Count
+	})
+	if len(matches) > a.TopPatterns {
+		matches = matches[:a.TopPatterns]
+	}
+	res.Data["pattern_count"] = len(matches)
+	res.Data["top_patterns"] = matches
+	return res, nil
+}

--- a/pkg/agent/ai/analyze/tools/describe_service_test.go
+++ b/pkg/agent/ai/analyze/tools/describe_service_test.go
@@ -1,0 +1,108 @@
+package tools
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestDescribeService_Metadata(t *testing.T) {
+	tool := DescribeService{}
+	if got := tool.Name(); got != "describe_service" {
+		t.Errorf("Name() = %q, want describe_service", got)
+	}
+	if tool.Description() == "" {
+		t.Error("Description() is empty")
+	}
+	schema := tool.ArgsSchema()
+	req, ok := schema["required"].([]string)
+	if !ok || len(req) != 1 || req[0] != "service" {
+		t.Errorf("ArgsSchema required = %v, want [service]", schema["required"])
+	}
+}
+
+func TestDescribeService_NilCatalog(t *testing.T) {
+	tool := DescribeService{}
+	if _, err := tool.Invoke(context.Background(), mustArgs(t, describeServiceArgs{Service: "api"})); err == nil {
+		t.Fatal("expected error when catalog not configured")
+	}
+}
+
+func TestDescribeService_BadArgs(t *testing.T) {
+	tool := DescribeService{Catalog: &fakeCatalog{}}
+	if _, err := tool.Invoke(context.Background(), []byte("{bad")); err == nil {
+		t.Fatal("expected error on malformed args")
+	}
+}
+
+func TestDescribeService_MissingService(t *testing.T) {
+	tool := DescribeService{Catalog: &fakeCatalog{}}
+	if _, err := tool.Invoke(context.Background(), mustArgs(t, describeServiceArgs{})); err == nil {
+		t.Fatal("expected error when service is empty")
+	}
+}
+
+func TestDescribeService_UnknownService(t *testing.T) {
+	tool := DescribeService{Catalog: &fakeCatalog{}}
+	res, err := tool.Invoke(context.Background(), mustArgs(t, describeServiceArgs{Service: "ghost"}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if res.Found {
+		t.Error("Found = true, want false for unknown service")
+	}
+	if res.Data["service"] != "ghost" {
+		t.Errorf("service = %v, want ghost", res.Data["service"])
+	}
+	if res.Data["pattern_count"] != 0 {
+		t.Errorf("pattern_count = %v, want 0", res.Data["pattern_count"])
+	}
+}
+
+func TestDescribeService_FoundWithTopPatternsSorted(t *testing.T) {
+	now := time.Now().UTC()
+	cat := &fakeCatalog{
+		services: map[string]ServiceInfo{"api": {FirstSeen: now.Add(-2 * time.Hour)}},
+		all: []*PatternView{
+			{ID: "p1", Service: "api", Template: "low", Count: 5, Baseline: 1},
+			{ID: "p2", Service: "api", Template: "high", Count: 50, Baseline: 2, Verdict: "known"},
+			{ID: "p3", Service: "api", Template: "mid", Count: 20, Baseline: 3},
+			{ID: "x1", Service: "other", Template: "skip", Count: 999},
+		},
+	}
+	tool := DescribeService{Catalog: cat}
+
+	res, err := tool.Invoke(context.Background(), mustArgs(t, describeServiceArgs{Service: "api", TopPatterns: 2}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !res.Found {
+		t.Fatal("Found = false, want true")
+	}
+	if _, ok := res.Data["first_seen"]; !ok {
+		t.Error("Data missing first_seen for known service")
+	}
+	top := res.Data["top_patterns"].([]describePatternEntry)
+	if len(top) != 2 {
+		t.Fatalf("len(top_patterns) = %d, want 2 (TopPatterns cap)", len(top))
+	}
+	// Sorted by count desc: p2 (50) then p3 (20). The other-service
+	// pattern must be excluded despite its higher count.
+	if top[0].ID != "p2" || top[1].ID != "p3" {
+		t.Errorf("top_patterns order = [%s, %s], want [p2, p3]", top[0].ID, top[1].ID)
+	}
+}
+
+func TestDescribeService_TopPatternsClamp(t *testing.T) {
+	cat := &fakeCatalog{all: []*PatternView{{ID: "p1", Service: "api", Count: 1}}}
+	tool := DescribeService{Catalog: cat}
+
+	// top_patterns over cap (20) should not error and still return.
+	res, err := tool.Invoke(context.Background(), mustArgs(t, describeServiceArgs{Service: "api", TopPatterns: 9999}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if res.Data["pattern_count"] != 1 {
+		t.Errorf("pattern_count = %v, want 1", res.Data["pattern_count"])
+	}
+}

--- a/pkg/agent/ai/analyze/tools/pattern_history.go
+++ b/pkg/agent/ai/analyze/tools/pattern_history.go
@@ -1,0 +1,82 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/VersusControl/versus-incident/pkg/core"
+)
+
+// PatternHistory looks up the agent catalog by pattern id and returns
+// the curated metadata (template, counts, baseline, verdict, tags).
+type PatternHistory struct {
+	Catalog PatternCatalog
+}
+
+// Name implements core.AnalyzeTool.
+func (PatternHistory) Name() string { return "pattern_history" }
+
+// Description implements core.AnalyzeTool.
+func (PatternHistory) Description() string {
+	return "Look up a learned log-pattern by id and return its template, observed counts, EWMA baseline, service, verdict, and operator tags."
+}
+
+// ArgsSchema implements core.AnalyzeTool.
+func (PatternHistory) ArgsSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"pattern_id": map[string]any{
+				"type":        "string",
+				"description": "Required. The pattern id from a prior incident or finding.",
+			},
+		},
+		"required": []string{"pattern_id"},
+	}
+}
+
+type patternHistoryArgs struct {
+	PatternID string `json:"pattern_id"`
+}
+
+// Invoke implements core.AnalyzeTool.
+func (p PatternHistory) Invoke(_ context.Context, args json.RawMessage) (*core.ToolResult, error) {
+	if p.Catalog == nil {
+		return nil, fmt.Errorf("pattern_history: catalog not configured")
+	}
+	var a patternHistoryArgs
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &a); err != nil {
+			return nil, fmt.Errorf("pattern_history: parse args: %w", err)
+		}
+	}
+	if a.PatternID == "" {
+		return nil, fmt.Errorf("pattern_history: pattern_id is required")
+	}
+	pat := p.Catalog.Get(a.PatternID)
+	if pat == nil {
+		return &core.ToolResult{
+			Tool:  PatternHistory{}.Name(),
+			Found: false,
+			Data:  map[string]any{"pattern_id": a.PatternID},
+		}, nil
+	}
+	return &core.ToolResult{
+		Tool:  PatternHistory{}.Name(),
+		Found: true,
+		Data: map[string]any{
+			"pattern_id": pat.ID,
+			"template":   pat.Template,
+			"source":     pat.Source,
+			"service":    pat.Service,
+			"rule_name":  pat.RuleName,
+			"verdict":    pat.Verdict,
+			"tags":       pat.Tags,
+			"count":      pat.Count,
+			"baseline":   pat.Baseline,
+			"first_seen": pat.FirstSeen,
+			"last_seen":  pat.LastSeen,
+		},
+	}, nil
+}

--- a/pkg/agent/ai/analyze/tools/pattern_history_test.go
+++ b/pkg/agent/ai/analyze/tools/pattern_history_test.go
@@ -1,0 +1,116 @@
+package tools
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// fakeCatalog is a scripted PatternCatalog for tests. Declaring it in
+// the tools package keeps the import graph one-directional (no
+// dependency on pkg/agent).
+type fakeCatalog struct {
+	byID     map[string]*PatternView
+	all      []*PatternView
+	services map[string]ServiceInfo
+}
+
+func (f *fakeCatalog) Get(id string) *PatternView { return f.byID[id] }
+func (f *fakeCatalog) All() []*PatternView        { return f.all }
+func (f *fakeCatalog) AllServices() map[string]ServiceInfo {
+	if f.services == nil {
+		return map[string]ServiceInfo{}
+	}
+	return f.services
+}
+
+func TestPatternHistory_Metadata(t *testing.T) {
+	tool := PatternHistory{}
+	if got := tool.Name(); got != "pattern_history" {
+		t.Errorf("Name() = %q, want pattern_history", got)
+	}
+	if tool.Description() == "" {
+		t.Error("Description() is empty")
+	}
+	schema := tool.ArgsSchema()
+	req, ok := schema["required"].([]string)
+	if !ok || len(req) != 1 || req[0] != "pattern_id" {
+		t.Errorf("ArgsSchema required = %v, want [pattern_id]", schema["required"])
+	}
+}
+
+func TestPatternHistory_NilCatalog(t *testing.T) {
+	tool := PatternHistory{}
+	if _, err := tool.Invoke(context.Background(), mustArgs(t, patternHistoryArgs{PatternID: "p1"})); err == nil {
+		t.Fatal("expected error when catalog not configured")
+	}
+}
+
+func TestPatternHistory_BadArgs(t *testing.T) {
+	tool := PatternHistory{Catalog: &fakeCatalog{}}
+	if _, err := tool.Invoke(context.Background(), []byte("{bad")); err == nil {
+		t.Fatal("expected error on malformed args")
+	}
+}
+
+func TestPatternHistory_MissingPatternID(t *testing.T) {
+	tool := PatternHistory{Catalog: &fakeCatalog{}}
+	if _, err := tool.Invoke(context.Background(), mustArgs(t, patternHistoryArgs{})); err == nil {
+		t.Fatal("expected error when pattern_id is empty")
+	}
+}
+
+func TestPatternHistory_NotFound(t *testing.T) {
+	tool := PatternHistory{Catalog: &fakeCatalog{byID: map[string]*PatternView{}}}
+	res, err := tool.Invoke(context.Background(), mustArgs(t, patternHistoryArgs{PatternID: "missing"}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if res.Found {
+		t.Error("Found = true, want false for unknown pattern")
+	}
+	if res.Data["pattern_id"] != "missing" {
+		t.Errorf("pattern_id = %v, want missing", res.Data["pattern_id"])
+	}
+}
+
+func TestPatternHistory_Found(t *testing.T) {
+	now := time.Now().UTC()
+	pat := &PatternView{
+		ID:        "p1",
+		Template:  "connection refused <*>",
+		Source:    "file:app",
+		Service:   "api",
+		RuleName:  "errors",
+		Verdict:   "known",
+		Tags:      []string{"net"},
+		Count:     42,
+		Baseline:  3.14,
+		FirstSeen: now.Add(-time.Hour),
+		LastSeen:  now,
+	}
+	cat := &fakeCatalog{byID: map[string]*PatternView{"p1": pat}}
+	tool := PatternHistory{Catalog: cat}
+
+	res, err := tool.Invoke(context.Background(), mustArgs(t, patternHistoryArgs{PatternID: "p1"}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !res.Found {
+		t.Fatal("Found = false, want true")
+	}
+	checks := map[string]any{
+		"pattern_id": "p1",
+		"template":   "connection refused <*>",
+		"service":    "api",
+		"rule_name":  "errors",
+		"verdict":    "known",
+		"count":      42,
+		"baseline":   3.14,
+	}
+	for k, want := range checks {
+		if got := res.Data[k]; got != want {
+			t.Errorf("Data[%q] = %v, want %v", k, got, want)
+		}
+	}
+}

--- a/pkg/agent/ai/analyze/tools/recent_changes.go
+++ b/pkg/agent/ai/analyze/tools/recent_changes.go
@@ -1,0 +1,435 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/core"
+)
+
+// ChangeRecord is one change derived from a git commit: a deploy,
+// config change, or feature-flag flip recorded in the repository's
+// history.
+type ChangeRecord struct {
+	Timestamp time.Time `json:"timestamp"`
+	Service   string    `json:"service"`
+	Kind      string    `json:"kind"`
+	Summary   string    `json:"summary"`
+	Ref       string    `json:"ref,omitempty"`
+}
+
+// ChangeFeed is the read-only feed of recent changes the recent_changes
+// tool reads from. It is declared as a local interface so the tools
+// package stays decoupled from config and pkg/agent.
+type ChangeFeed interface {
+	// Changes returns every change record at or after `since`. A missing
+	// or empty feed yields an empty slice and a nil error (a clean miss,
+	// never a hard failure).
+	Changes(ctx context.Context, since time.Time) ([]ChangeRecord, error)
+}
+
+// RecentChanges surfaces recent deploys, config changes, and
+// feature-flag flips so the analyze agent can correlate an incident with
+// what changed just before it. It is strictly read-only.
+type RecentChanges struct {
+	Feed ChangeFeed
+}
+
+const (
+	recentChangesDefaultWindow = 120
+	recentChangesMaxWindow     = 1440
+)
+
+// Name implements core.AnalyzeTool.
+func (RecentChanges) Name() string { return "recent_changes" }
+
+// Description implements core.AnalyzeTool.
+func (RecentChanges) Description() string {
+	return "List recent deploys, config changes, and feature-flag flips from the change feed within a time window, newest first. Optionally filter by service. Use it to correlate an incident with what changed just before it."
+}
+
+// ArgsSchema implements core.AnalyzeTool.
+func (RecentChanges) ArgsSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"service": map[string]any{
+				"type":        "string",
+				"description": "Optional service name to filter changes by (case-insensitive exact match).",
+			},
+			"window_minutes": map[string]any{
+				"type":        "integer",
+				"description": "Look back this many minutes from now. Default 120, max 1440.",
+			},
+		},
+	}
+}
+
+type recentChangesArgs struct {
+	Service       string `json:"service"`
+	WindowMinutes int    `json:"window_minutes"`
+}
+
+// Invoke implements core.AnalyzeTool.
+func (rc RecentChanges) Invoke(ctx context.Context, args json.RawMessage) (*core.ToolResult, error) {
+	var a recentChangesArgs
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &a); err != nil {
+			return nil, fmt.Errorf("recent_changes: parse args: %w", err)
+		}
+	}
+	if a.WindowMinutes <= 0 {
+		a.WindowMinutes = recentChangesDefaultWindow
+	}
+	if a.WindowMinutes > recentChangesMaxWindow {
+		a.WindowMinutes = recentChangesMaxWindow
+	}
+
+	// An unconfigured feed is a clean miss, never an error: the model
+	// simply learns there is no change data to correlate against.
+	if rc.Feed == nil {
+		return rc.miss(a), nil
+	}
+
+	now := time.Now().UTC()
+	since := now.Add(-time.Duration(a.WindowMinutes) * time.Minute)
+
+	records, err := rc.Feed.Changes(ctx, since)
+	if err != nil {
+		return nil, fmt.Errorf("recent_changes: read feed: %w", err)
+	}
+
+	out := make([]ChangeRecord, 0, len(records))
+	for _, r := range records {
+		if r.Timestamp.Before(since) {
+			continue
+		}
+		if a.Service != "" && !strings.EqualFold(r.Service, a.Service) {
+			continue
+		}
+		out = append(out, r)
+	}
+
+	// Newest first.
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Timestamp.After(out[j].Timestamp)
+	})
+
+	if len(out) == 0 {
+		return rc.miss(a), nil
+	}
+
+	return &core.ToolResult{
+		Tool:  RecentChanges{}.Name(),
+		Found: true,
+		Data: map[string]any{
+			"count":          len(out),
+			"window_minutes": a.WindowMinutes,
+			"service":        a.Service,
+			"changes":        out,
+		},
+	}, nil
+}
+
+// miss is the uniform empty envelope for an unconfigured feed or a
+// window/service combination that matched nothing.
+func (RecentChanges) miss(a recentChangesArgs) *core.ToolResult {
+	return &core.ToolResult{
+		Tool:  RecentChanges{}.Name(),
+		Found: false,
+		Data: map[string]any{
+			"count":          0,
+			"window_minutes": a.WindowMinutes,
+			"service":        a.Service,
+		},
+	}
+}
+
+// changesGitKind labels every record sourced from a git commit.
+const changesGitKind = "commit"
+
+// Git output field/record separators. ASCII unit/record separators are
+// used because they never appear in commit subjects or file paths, so
+// parsing stays robust without escaping.
+const (
+	gitFieldSep  = "\x1f"
+	gitRecordSep = "\x1e"
+)
+
+// gitChangeFeed reads change records from one or more remote git
+// repositories' commit histories on every call. It shells out to the
+// `git` binary (which must be on PATH) so no Go git dependency is pulled
+// in. Each repository is mirror-cloned into a local cache directory on
+// first use and fetched on subsequent lookups; reading per-call keeps the
+// feed fresh and the tool stateless.
+type gitChangeFeed struct {
+	repos    []GitRepo
+	cacheDir string
+}
+
+// GitRepo describes one remote git repository the change feed reads.
+type GitRepo struct {
+	// URL is the remote clone URL (https or scp-like git@host:org/repo).
+	URL string
+	// Branch optionally pins which branch to read; empty = default HEAD.
+	Branch string
+	// Service maps every commit in this repository to a service name.
+	// Empty derives the service from the repository name in the URL.
+	Service string
+	// Token is an HTTPS access token / PAT used to authenticate to the
+	// remote. Empty relies on the ambient git credentials.
+	Token string
+	// SSHKeyPath is the path to a private SSH key used for ssh / scp-like
+	// remotes. Empty relies on the ambient SSH configuration.
+	SSHKeyPath string
+}
+
+// gitCacheDirName is the subdirectory of the OS temp dir where remote
+// repositories are mirror-cloned. It is not configurable.
+const gitCacheDirName = "versus-incident-git-cache"
+
+// NewGitChangeFeed returns a ChangeFeed backed by the given remote git
+// repositories. Repos with an empty URL are ignored; an empty (or
+// all-empty) list yields nil so analyzetools.Default omits the
+// recent_changes tool. The `git` binary must be available on PATH.
+func NewGitChangeFeed(repos []GitRepo) ChangeFeed {
+	return newGitChangeFeed(repos, filepath.Join(os.TempDir(), gitCacheDirName))
+}
+
+// newGitChangeFeed is the cache-dir-injectable constructor used by tests.
+func newGitChangeFeed(repos []GitRepo, cacheDir string) ChangeFeed {
+	cleaned := make([]GitRepo, 0, len(repos))
+	for _, r := range repos {
+		if strings.TrimSpace(r.URL) == "" {
+			continue
+		}
+		cleaned = append(cleaned, GitRepo{
+			URL:        strings.TrimSpace(r.URL),
+			Branch:     strings.TrimSpace(r.Branch),
+			Service:    strings.TrimSpace(r.Service),
+			Token:      strings.TrimSpace(r.Token),
+			SSHKeyPath: strings.TrimSpace(r.SSHKeyPath),
+		})
+	}
+	if len(cleaned) == 0 {
+		return nil
+	}
+	return &gitChangeFeed{repos: cleaned, cacheDir: cacheDir}
+}
+
+// Changes implements ChangeFeed. It reads each configured repository's
+// commit history since the given time and aggregates the records. A
+// per-repository failure (e.g. a transient network error) is skipped so
+// one broken remote cannot blind the whole feed; an error surfaces only
+// when every repository failed. No commits in the window is a clean empty
+// result, not an error.
+func (f *gitChangeFeed) Changes(ctx context.Context, since time.Time) ([]ChangeRecord, error) {
+	var (
+		all      []ChangeRecord
+		firstErr error
+		ok       int
+	)
+	for _, r := range f.repos {
+		recs, err := f.changesForRepo(ctx, r, since)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		ok++
+		all = append(all, recs...)
+	}
+	if ok == 0 && firstErr != nil {
+		return nil, firstErr
+	}
+	return all, nil
+}
+
+// changesForRepo mirrors the remote into the local cache (cloning on
+// first use, fetching afterwards) and runs `git log` over the configured
+// branch since the given time. Every record is stamped with the
+// repository's service (explicit config or derived from the URL).
+func (f *gitChangeFeed) changesForRepo(ctx context.Context, repo GitRepo, since time.Time) ([]ChangeRecord, error) {
+	cachePath, err := f.ensureMirror(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	service := repo.Service
+	if service == "" {
+		service = serviceFromURL(repo.URL)
+	}
+
+	authArgs, authEnv := gitAuthArgs(repo)
+	args := append([]string{}, authArgs...)
+	args = append(args, "-C", cachePath, "log")
+	if repo.Branch != "" {
+		args = append(args, repo.Branch)
+	}
+	args = append(args,
+		"--no-color",
+		"--since="+since.UTC().Format(time.RFC3339),
+		// <RS>%H<US>%cI<US>%s — one line per commit.
+		"--pretty=format:"+gitRecordSep+"%H"+gitFieldSep+"%cI"+gitFieldSep+"%s",
+	)
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if len(authEnv) > 0 {
+		cmd.Env = append(os.Environ(), authEnv...)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("git log %q: %w: %s", repo.URL, err, strings.TrimSpace(stderr.String()))
+	}
+
+	return parseGitLog(stdout.String(), service), nil
+}
+
+// ensureMirror makes sure a local mirror of the remote exists under the
+// cache directory and is up to date: it mirror-clones on first use and
+// fetches on subsequent calls. Repo auth (HTTPS token / SSH key) is wired
+// through for both operations. It returns the local mirror path.
+func (f *gitChangeFeed) ensureMirror(ctx context.Context, repo GitRepo) (string, error) {
+	path := f.cachePathFor(repo.URL)
+	authArgs, authEnv := gitAuthArgs(repo)
+	if _, err := os.Stat(path); err == nil {
+		args := append([]string{}, authArgs...)
+		args = append(args, "-C", path, "fetch", "--prune", "--quiet")
+		cmd := exec.CommandContext(ctx, "git", args...)
+		if len(authEnv) > 0 {
+			cmd.Env = append(os.Environ(), authEnv...)
+		}
+		if out, ferr := cmd.CombinedOutput(); ferr != nil {
+			return "", fmt.Errorf("git fetch %q: %w: %s", repo.URL, ferr, strings.TrimSpace(string(out)))
+		}
+		return path, nil
+	}
+	if err := os.MkdirAll(f.cacheDir, 0o700); err != nil {
+		return "", fmt.Errorf("git cache dir %q: %w", f.cacheDir, err)
+	}
+	args := append([]string{}, authArgs...)
+	args = append(args, "clone", "--mirror", "--quiet", repo.URL, path)
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if len(authEnv) > 0 {
+		cmd.Env = append(os.Environ(), authEnv...)
+	}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("git clone %q: %w: %s", repo.URL, err, strings.TrimSpace(string(out)))
+	}
+	return path, nil
+}
+
+// gitAuthArgs returns the extra `git -c` arguments and environment
+// additions needed to authenticate to repo's remote. An HTTPS token is
+// injected via an http.extraHeader Authorization header (never persisted
+// to the local mirror's config); an SSH key path is wired through
+// GIT_SSH_COMMAND. An empty auth config returns nothing, so the ambient
+// git credentials are used.
+func gitAuthArgs(repo GitRepo) (configArgs []string, env []string) {
+	if token := strings.TrimSpace(repo.Token); token != "" {
+		// Basic auth with any username + token as password is accepted by
+		// GitHub, GitLab, Bitbucket and most providers for HTTPS remotes.
+		cred := base64.StdEncoding.EncodeToString([]byte("x-access-token:" + token))
+		configArgs = append(configArgs, "-c", "http.extraHeader=Authorization: Basic "+cred)
+	}
+	if key := strings.TrimSpace(repo.SSHKeyPath); key != "" {
+		env = append(env, "GIT_SSH_COMMAND=ssh -i "+key+" -o IdentitiesOnly=yes")
+	}
+	return configArgs, env
+}
+
+// cachePathFor maps a remote URL to a deterministic local mirror path:
+// the derived repository name plus a short hash of the URL keeps it both
+// readable and collision-free across different remotes with the same
+// basename.
+func (f *gitChangeFeed) cachePathFor(url string) string {
+	sum := sha256.Sum256([]byte(url))
+	name := serviceFromURL(url)
+	if name == "" {
+		name = "repo"
+	}
+	return filepath.Join(f.cacheDir, sanitizeCacheName(name)+"-"+hex.EncodeToString(sum[:])[:12]+".git")
+}
+
+// sanitizeCacheName keeps a cache directory name filesystem-safe.
+func sanitizeCacheName(name string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			return r
+		default:
+			return '_'
+		}
+	}, name)
+}
+
+// parseGitLog turns the record-separated `git log` output into
+// ChangeRecords, stamping each with the given service. Each record begins
+// with gitRecordSep, followed by the SHA, committer date, and subject.
+func parseGitLog(out, service string) []ChangeRecord {
+	var records []ChangeRecord
+	for _, block := range strings.Split(out, gitRecordSep) {
+		block = strings.Trim(block, "\n")
+		if block == "" {
+			continue
+		}
+		line := block
+		if i := strings.IndexByte(block, '\n'); i >= 0 {
+			line = block[:i]
+		}
+		fields := strings.Split(line, gitFieldSep)
+		if len(fields) != 3 {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339, strings.TrimSpace(fields[1]))
+		if err != nil {
+			continue
+		}
+		records = append(records, ChangeRecord{
+			Timestamp: ts.UTC(),
+			Service:   service,
+			Kind:      changesGitKind,
+			Summary:   strings.TrimSpace(fields[2]),
+			Ref:       shortSHA(fields[0]),
+		})
+	}
+	return records
+}
+
+// serviceFromURL derives a service name from a git remote URL: the last
+// path segment with any trailing ".git" stripped (e.g.
+// "git@github.com:acme/web.git" → "web",
+// "https://github.com/acme/api.git" → "api"). Empty when no segment can
+// be derived.
+func serviceFromURL(url string) string {
+	u := strings.TrimSpace(url)
+	u = strings.TrimRight(u, "/")
+	u = strings.TrimSuffix(u, ".git")
+	if i := strings.LastIndexAny(u, "/:"); i >= 0 {
+		u = u[i+1:]
+	}
+	return u
+}
+
+// shortSHA abbreviates a full commit hash to the conventional 7 chars.
+func shortSHA(sha string) string {
+	sha = strings.TrimSpace(sha)
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}

--- a/pkg/agent/ai/analyze/tools/recent_changes_test.go
+++ b/pkg/agent/ai/analyze/tools/recent_changes_test.go
@@ -1,0 +1,466 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/core"
+)
+
+// fakeChangeFeed is a scripted ChangeFeed for tests. It records the
+// `since` it was called with so assertions can verify window math.
+type fakeChangeFeed struct {
+	records  []ChangeRecord
+	err      error
+	gotSince time.Time
+	calls    int
+}
+
+func (f *fakeChangeFeed) Changes(_ context.Context, since time.Time) ([]ChangeRecord, error) {
+	f.calls++
+	f.gotSince = since
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.records, nil
+}
+
+func mustInvoke(t *testing.T, rc RecentChanges, args map[string]any) *core.ToolResult {
+	t.Helper()
+	var raw json.RawMessage
+	if args != nil {
+		b, err := json.Marshal(args)
+		if err != nil {
+			t.Fatalf("marshal args: %v", err)
+		}
+		raw = b
+	}
+	res, err := rc.Invoke(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	return res
+}
+
+func TestRecentChanges_Metadata(t *testing.T) {
+	rc := RecentChanges{}
+	if rc.Name() != "recent_changes" {
+		t.Fatalf("Name = %q", rc.Name())
+	}
+	if rc.Description() == "" {
+		t.Fatal("Description empty")
+	}
+	schema := rc.ArgsSchema()
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema properties missing: %+v", schema)
+	}
+	for _, k := range []string{"service", "window_minutes"} {
+		if _, ok := props[k]; !ok {
+			t.Fatalf("schema missing property %q", k)
+		}
+	}
+}
+
+func TestRecentChanges_NilFeedIsCleanMiss(t *testing.T) {
+	rc := RecentChanges{Feed: nil}
+	res := mustInvoke(t, rc, nil)
+	if res.Found {
+		t.Fatal("nil feed should be Found=false")
+	}
+	if res.Tool != "recent_changes" {
+		t.Fatalf("Tool = %q", res.Tool)
+	}
+	if res.Data["count"] != 0 {
+		t.Fatalf("count = %v, want 0", res.Data["count"])
+	}
+	if res.Data["window_minutes"] != recentChangesDefaultWindow {
+		t.Fatalf("window_minutes = %v, want %d", res.Data["window_minutes"], recentChangesDefaultWindow)
+	}
+}
+
+func TestRecentChanges_WindowClamping(t *testing.T) {
+	now := time.Now().UTC()
+	tests := []struct {
+		name       string
+		window     int
+		wantWindow int
+		wantMaxAge time.Duration
+	}{
+		{"default when zero", 0, recentChangesDefaultWindow, time.Duration(recentChangesDefaultWindow) * time.Minute},
+		{"default when negative", -5, recentChangesDefaultWindow, time.Duration(recentChangesDefaultWindow) * time.Minute},
+		{"passthrough mid", 300, 300, 300 * time.Minute},
+		{"cap at max", 100000, recentChangesMaxWindow, time.Duration(recentChangesMaxWindow) * time.Minute},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			feed := &fakeChangeFeed{}
+			rc := RecentChanges{Feed: feed}
+			args := map[string]any{}
+			if tc.window != 0 {
+				args["window_minutes"] = tc.window
+			}
+			res := mustInvoke(t, rc, args)
+			if res.Data["window_minutes"] != tc.wantWindow {
+				t.Fatalf("window_minutes = %v, want %d", res.Data["window_minutes"], tc.wantWindow)
+			}
+			// since should be ~now-wantMaxAge.
+			gotAge := now.Sub(feed.gotSince)
+			if gotAge < tc.wantMaxAge-time.Minute || gotAge > tc.wantMaxAge+time.Minute {
+				t.Fatalf("since age = %s, want ~%s", gotAge, tc.wantMaxAge)
+			}
+		})
+	}
+}
+
+func TestRecentChanges_ServiceFilterAndOrdering(t *testing.T) {
+	now := time.Now().UTC()
+	feed := &fakeChangeFeed{records: []ChangeRecord{
+		{Timestamp: now.Add(-10 * time.Minute), Service: "api", Kind: "deploy", Summary: "newest api"},
+		{Timestamp: now.Add(-30 * time.Minute), Service: "API", Kind: "config", Summary: "older api"},
+		{Timestamp: now.Add(-20 * time.Minute), Service: "db", Kind: "deploy", Summary: "db change"},
+	}}
+	rc := RecentChanges{Feed: feed}
+
+	res := mustInvoke(t, rc, map[string]any{"service": "api"})
+	if !res.Found {
+		t.Fatal("expected Found=true")
+	}
+	if res.Data["count"] != 2 {
+		t.Fatalf("count = %v, want 2 (case-insensitive api match)", res.Data["count"])
+	}
+	changes, ok := res.Data["changes"].([]ChangeRecord)
+	if !ok {
+		t.Fatalf("changes wrong type: %T", res.Data["changes"])
+	}
+	if len(changes) != 2 {
+		t.Fatalf("len(changes) = %d, want 2", len(changes))
+	}
+	// Newest first.
+	if changes[0].Summary != "newest api" || changes[1].Summary != "older api" {
+		t.Fatalf("ordering wrong: %+v", changes)
+	}
+}
+
+func TestRecentChanges_DropsOutOfWindow(t *testing.T) {
+	now := time.Now().UTC()
+	feed := &fakeChangeFeed{records: []ChangeRecord{
+		{Timestamp: now.Add(-5 * time.Minute), Service: "api", Summary: "in"},
+		{Timestamp: now.Add(-200 * time.Minute), Service: "api", Summary: "out"},
+	}}
+	rc := RecentChanges{Feed: feed}
+	res := mustInvoke(t, rc, map[string]any{"window_minutes": 60})
+	if res.Data["count"] != 1 {
+		t.Fatalf("count = %v, want 1", res.Data["count"])
+	}
+}
+
+func TestRecentChanges_EmptyFeedIsMiss(t *testing.T) {
+	rc := RecentChanges{Feed: &fakeChangeFeed{}}
+	res := mustInvoke(t, rc, nil)
+	if res.Found {
+		t.Fatal("empty feed should be Found=false")
+	}
+	if _, ok := res.Data["changes"]; ok {
+		t.Fatal("miss should not carry a changes key")
+	}
+}
+
+func TestRecentChanges_FeedErrorSurfaces(t *testing.T) {
+	rc := RecentChanges{Feed: &fakeChangeFeed{err: context.DeadlineExceeded}}
+	_, err := rc.Invoke(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error from feed to surface")
+	}
+}
+
+func TestRecentChanges_BadArgs(t *testing.T) {
+	rc := RecentChanges{Feed: &fakeChangeFeed{}}
+	_, err := rc.Invoke(context.Background(), json.RawMessage(`{"window_minutes":"oops"}`))
+	if err == nil {
+		t.Fatal("expected parse error for non-integer window_minutes")
+	}
+}
+
+func TestNewGitChangeFeed_EmptyReposNil(t *testing.T) {
+	if NewGitChangeFeed(nil) != nil {
+		t.Fatal("nil repos should yield nil feed")
+	}
+	if NewGitChangeFeed([]GitRepo{}) != nil {
+		t.Fatal("empty repos should yield nil feed")
+	}
+	if NewGitChangeFeed([]GitRepo{{URL: "   "}}) != nil {
+		t.Fatal("whitespace-only URL should be dropped, yielding nil feed")
+	}
+}
+
+func TestGitAuthArgs(t *testing.T) {
+	t.Run("empty auth yields nothing", func(t *testing.T) {
+		args, env := gitAuthArgs(GitRepo{URL: "https://example.com/x.git"})
+		if len(args) != 0 || len(env) != 0 {
+			t.Fatalf("empty auth should add no args/env, got args=%v env=%v", args, env)
+		}
+	})
+	t.Run("token sets http.extraHeader", func(t *testing.T) {
+		args, env := gitAuthArgs(GitRepo{Token: "secret-token"})
+		if len(env) != 0 {
+			t.Fatalf("token should not set env, got %v", env)
+		}
+		want := "http.extraHeader=Authorization: Basic " +
+			base64.StdEncoding.EncodeToString([]byte("x-access-token:secret-token"))
+		if len(args) != 2 || args[0] != "-c" || args[1] != want {
+			t.Fatalf("token args = %v, want [-c %q]", args, want)
+		}
+	})
+	t.Run("ssh key sets GIT_SSH_COMMAND", func(t *testing.T) {
+		args, env := gitAuthArgs(GitRepo{SSHKeyPath: "/home/u/.ssh/id_ed25519"})
+		if len(args) != 0 {
+			t.Fatalf("ssh key should not set config args, got %v", args)
+		}
+		if len(env) != 1 || env[0] != "GIT_SSH_COMMAND=ssh -i /home/u/.ssh/id_ed25519 -o IdentitiesOnly=yes" {
+			t.Fatalf("ssh env = %v", env)
+		}
+	})
+	t.Run("both token and ssh key", func(t *testing.T) {
+		args, env := gitAuthArgs(GitRepo{Token: "t", SSHKeyPath: "/k"})
+		if len(args) != 2 || len(env) != 1 {
+			t.Fatalf("expected both auth methods wired, got args=%v env=%v", args, env)
+		}
+	})
+}
+
+func TestServiceFromURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"git@github.com:acme/web.git", "web"},
+		{"https://github.com/acme/api.git", "api"},
+		{"https://github.com/acme/api", "api"},
+		{"https://github.com/acme/api/", "api"},
+		{"/srv/payments", "payments"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		if got := serviceFromURL(tc.url); got != tc.want {
+			t.Fatalf("serviceFromURL(%q) = %q, want %q", tc.url, got, tc.want)
+		}
+	}
+}
+
+func TestParseGitLog(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	older := now.Add(-30 * time.Minute)
+	// Two commits, newest first, separated by the record separator. Both
+	// are stamped with the supplied service ("api").
+	out := gitRecordSep + "abcdef1234567890" + gitFieldSep + now.Format(time.RFC3339) + gitFieldSep + "deploy api" + "\n" +
+		gitRecordSep + "0123456789abcdef" + gitFieldSep + older.Format(time.RFC3339) + gitFieldSep + "docs" + "\n"
+
+	recs := parseGitLog(out, "api")
+	if len(recs) != 2 {
+		t.Fatalf("got %d records, want 2: %+v", len(recs), recs)
+	}
+	if recs[0].Summary != "deploy api" || recs[0].Service != "api" {
+		t.Fatalf("first record = %+v", recs[0])
+	}
+	if recs[0].Ref != "abcdef1" {
+		t.Fatalf("short SHA = %q, want abcdef1", recs[0].Ref)
+	}
+	if recs[0].Kind != changesGitKind {
+		t.Fatalf("kind = %q, want %q", recs[0].Kind, changesGitKind)
+	}
+	if !recs[0].Timestamp.Equal(now) {
+		t.Fatalf("timestamp = %s, want %s", recs[0].Timestamp, now)
+	}
+	if recs[1].Service != "api" {
+		t.Fatalf("second record service = %q, want api", recs[1].Service)
+	}
+}
+
+func TestParseGitLog_SkipsMalformed(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	out := gitRecordSep + "shaonly" + "\n" + // header missing date/subject fields
+		gitRecordSep + "deadbeef" + gitFieldSep + "not-a-date" + gitFieldSep + "bad ts" + "\n" +
+		gitRecordSep + "feedface1234" + gitFieldSep + now.Format(time.RFC3339) + gitFieldSep + "good" + "\n"
+	recs := parseGitLog(out, "svc")
+	if len(recs) != 1 {
+		t.Fatalf("got %d records, want 1 (only the well-formed commit): %+v", len(recs), recs)
+	}
+	if recs[0].Summary != "good" || recs[0].Service != "svc" {
+		t.Fatalf("survivor = %+v", recs[0])
+	}
+}
+
+func TestParseGitLog_Empty(t *testing.T) {
+	if recs := parseGitLog("", "svc"); len(recs) != 0 {
+		t.Fatalf("empty output should yield no records, got %d", len(recs))
+	}
+}
+
+// initGitRepo builds a throwaway git repo with the given commits (oldest
+// first) under a subdirectory named `name` (so the auto-detected service
+// is predictable) and returns its path. Each commit stamps the same
+// author and committer date so windowing is deterministic. The test is
+// skipped when the git binary is unavailable.
+func initGitRepo(t *testing.T, name string, commits []struct {
+	when    time.Time
+	file    string
+	message string
+}) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	run := func(env []string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(), env...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run(nil, "init")
+	run(nil, "config", "user.email", "test@example.com")
+	run(nil, "config", "user.name", "Test")
+	for _, c := range commits {
+		path := filepath.Join(dir, c.file)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(c.message), 0o600); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+		run(nil, "add", ".")
+		stamp := c.when.UTC().Format(time.RFC3339)
+		run([]string{"GIT_AUTHOR_DATE=" + stamp, "GIT_COMMITTER_DATE=" + stamp},
+			"commit", "-m", c.message)
+	}
+	return dir
+}
+
+type commitSpec = struct {
+	when    time.Time
+	file    string
+	message string
+}
+
+func TestGitChangeFeed_EndToEnd_ServiceAutoDetect(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	repo := initGitRepo(t, "payments", []commitSpec{
+		{now.Add(-300 * time.Minute), "old.go", "old deploy"},
+		{now.Add(-10 * time.Minute), "new.go", "new deploy"},
+		{now.Add(-5 * time.Minute), "schema.sql", "db change"},
+	})
+
+	// No explicit service: it is auto-detected from the repo name. A
+	// local path is a valid git URL for the mirror clone.
+	feed := newGitChangeFeed([]GitRepo{{URL: repo}}, t.TempDir())
+	if feed == nil {
+		t.Fatal("non-empty repos should yield a feed")
+	}
+
+	// Window covers only the last two commits (the -300m one is excluded).
+	recs, err := feed.Changes(context.Background(), now.Add(-60*time.Minute))
+	if err != nil {
+		t.Fatalf("Changes: %v", err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("got %d records, want 2: %+v", len(recs), recs)
+	}
+	for _, r := range recs {
+		if r.Kind != changesGitKind {
+			t.Fatalf("kind = %q", r.Kind)
+		}
+		if r.Service != "payments" {
+			t.Fatalf("service = %q, want payments (auto-detected)", r.Service)
+		}
+	}
+}
+
+func TestGitChangeFeed_ExplicitServiceAndMultiRepo(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	apiRepo := initGitRepo(t, "api-src", []commitSpec{
+		{now.Add(-8 * time.Minute), "main.go", "api deploy"},
+	})
+	webRepo := initGitRepo(t, "web", []commitSpec{
+		{now.Add(-4 * time.Minute), "index.js", "web deploy"},
+	})
+
+	feed := newGitChangeFeed([]GitRepo{
+		{URL: apiRepo, Service: "api"}, // explicit service overrides repo name
+		{URL: webRepo},                 // auto-detected as "web"
+	}, t.TempDir())
+
+	recs, err := feed.Changes(context.Background(), now.Add(-60*time.Minute))
+	if err != nil {
+		t.Fatalf("Changes: %v", err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("got %d records, want 2 (aggregated across repos): %+v", len(recs), recs)
+	}
+	services := map[string]bool{}
+	for _, r := range recs {
+		services[r.Service] = true
+	}
+	if !services["api"] || !services["web"] {
+		t.Fatalf("services = %v, want both api and web", services)
+	}
+}
+
+func TestGitChangeFeed_ThroughTool(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	repo := initGitRepo(t, "billing", []commitSpec{
+		{now.Add(-3 * time.Minute), "main.go", "latest"},
+	})
+
+	rc := RecentChanges{Feed: newGitChangeFeed([]GitRepo{{URL: repo}}, t.TempDir())}
+	res := mustInvoke(t, rc, map[string]any{"service": "billing"})
+	if !res.Found {
+		t.Fatal("expected Found=true from end-to-end git feed")
+	}
+	if res.Data["count"] != 1 {
+		t.Fatalf("count = %v, want 1", res.Data["count"])
+	}
+}
+
+func TestGitChangeFeed_BadRepoErrors(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	feed := newGitChangeFeed([]GitRepo{{URL: filepath.Join(t.TempDir(), "not-a-repo")}}, t.TempDir())
+	if _, err := feed.Changes(context.Background(), time.Now().Add(-time.Hour)); err == nil {
+		t.Fatal("expected error when the only repo fails to clone")
+	}
+}
+
+func TestGitChangeFeed_PartialFailureDegrades(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	good := initGitRepo(t, "good", []commitSpec{
+		{now.Add(-2 * time.Minute), "main.go", "good deploy"},
+	})
+
+	// One healthy repo plus one broken remote: the broken one is skipped
+	// and the healthy repo's records still surface.
+	feed := newGitChangeFeed([]GitRepo{
+		{URL: filepath.Join(t.TempDir(), "missing")},
+		{URL: good},
+	}, t.TempDir())
+
+	recs, err := feed.Changes(context.Background(), now.Add(-60*time.Minute))
+	if err != nil {
+		t.Fatalf("partial failure should not surface an error: %v", err)
+	}
+	if len(recs) != 1 || recs[0].Service != "good" {
+		t.Fatalf("records = %+v, want one record for service good", recs)
+	}
+}

--- a/pkg/agent/ai/analyze/tools/recent_incidents.go
+++ b/pkg/agent/ai/analyze/tools/recent_incidents.go
@@ -1,0 +1,123 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/core"
+	"github.com/VersusControl/versus-incident/pkg/storage"
+)
+
+// RecentIncidents lists incidents from storage within a time window,
+// optionally filtered by service. The agent uses it to spot bursts /
+// recurring incidents on the same service.
+type RecentIncidents struct {
+	Store storage.Provider
+}
+
+// Name implements core.AnalyzeTool.
+func (RecentIncidents) Name() string { return "recent_incidents" }
+
+// Description implements core.AnalyzeTool.
+func (RecentIncidents) Description() string {
+	return "List incidents from the local store within the last N minutes, optionally filtered by service. Returns id, title, service, severity, resolved, created_at."
+}
+
+// ArgsSchema implements core.AnalyzeTool.
+func (RecentIncidents) ArgsSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"window_minutes": map[string]any{
+				"type":        "integer",
+				"description": "Look back this many minutes from now. Default 60, max 1440.",
+			},
+			"service": map[string]any{
+				"type":        "string",
+				"description": "Optional service name to filter by (exact match).",
+			},
+			"limit": map[string]any{
+				"type":        "integer",
+				"description": "Cap the number of incidents returned. Default 20, max 100.",
+			},
+		},
+	}
+}
+
+type recentIncidentsArgs struct {
+	WindowMinutes int    `json:"window_minutes"`
+	Service       string `json:"service"`
+	Limit         int    `json:"limit"`
+}
+
+type recentIncidentItem struct {
+	ID        string    `json:"id"`
+	Title     string    `json:"title,omitempty"`
+	Service   string    `json:"service,omitempty"`
+	Severity  string    `json:"severity,omitempty"`
+	Resolved  bool      `json:"resolved"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Invoke implements core.AnalyzeTool.
+func (r RecentIncidents) Invoke(_ context.Context, args json.RawMessage) (*core.ToolResult, error) {
+	if r.Store == nil {
+		return nil, fmt.Errorf("recent_incidents: storage not configured")
+	}
+	var a recentIncidentsArgs
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &a); err != nil {
+			return nil, fmt.Errorf("recent_incidents: parse args: %w", err)
+		}
+	}
+	if a.WindowMinutes <= 0 {
+		a.WindowMinutes = 60
+	}
+	if a.WindowMinutes > 1440 {
+		a.WindowMinutes = 1440
+	}
+	if a.Limit <= 0 {
+		a.Limit = 20
+	}
+	if a.Limit > 100 {
+		a.Limit = 100
+	}
+
+	all, err := r.Store.ListIncidents(0)
+	if err != nil {
+		return nil, fmt.Errorf("recent_incidents: list: %w", err)
+	}
+	cutoff := time.Now().UTC().Add(-time.Duration(a.WindowMinutes) * time.Minute)
+	out := make([]recentIncidentItem, 0)
+	for _, rec := range all {
+		if rec.CreatedAt.Before(cutoff) {
+			continue
+		}
+		if a.Service != "" && !strings.EqualFold(rec.Service, a.Service) {
+			continue
+		}
+		out = append(out, recentIncidentItem{
+			ID:        rec.ID,
+			Title:     rec.Title,
+			Service:   rec.Service,
+			Resolved:  rec.Resolved,
+			CreatedAt: rec.CreatedAt,
+		})
+		if len(out) >= a.Limit {
+			break
+		}
+	}
+	return &core.ToolResult{
+		Tool:  RecentIncidents{}.Name(),
+		Found: true,
+		Data: map[string]any{
+			"count":          len(out),
+			"window_minutes": a.WindowMinutes,
+			"service":        a.Service,
+			"incidents":      out,
+		},
+	}, nil
+}

--- a/pkg/agent/ai/analyze/tools/recent_incidents_test.go
+++ b/pkg/agent/ai/analyze/tools/recent_incidents_test.go
@@ -1,0 +1,129 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/storage"
+)
+
+func newStoreWithIncidents(t *testing.T, recs ...*storage.IncidentRecord) storage.Provider {
+	t.Helper()
+	store := storage.NewMemory()
+	for _, rec := range recs {
+		if err := store.SaveIncident(rec); err != nil {
+			t.Fatalf("SaveIncident: %v", err)
+		}
+	}
+	return store
+}
+
+func TestRecentIncidents_Metadata(t *testing.T) {
+	tool := RecentIncidents{}
+	if got := tool.Name(); got != "recent_incidents" {
+		t.Errorf("Name() = %q, want recent_incidents", got)
+	}
+	if tool.Description() == "" {
+		t.Error("Description() is empty")
+	}
+	schema := tool.ArgsSchema()
+	if schema["type"] != "object" {
+		t.Errorf("ArgsSchema type = %v, want object", schema["type"])
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("ArgsSchema properties missing or wrong type")
+	}
+	for _, key := range []string{"window_minutes", "service", "limit"} {
+		if _, ok := props[key]; !ok {
+			t.Errorf("ArgsSchema missing property %q", key)
+		}
+	}
+}
+
+func TestRecentIncidents_NilStore(t *testing.T) {
+	tool := RecentIncidents{}
+	if _, err := tool.Invoke(context.Background(), nil); err == nil {
+		t.Fatal("expected error when storage not configured")
+	}
+}
+
+func TestRecentIncidents_BadArgs(t *testing.T) {
+	tool := RecentIncidents{Store: storage.NewMemory()}
+	if _, err := tool.Invoke(context.Background(), []byte("{not json")); err == nil {
+		t.Fatal("expected error on malformed args")
+	}
+}
+
+func TestRecentIncidents_WindowFilter(t *testing.T) {
+	now := time.Now().UTC()
+	store := newStoreWithIncidents(t,
+		&storage.IncidentRecord{ID: "recent", Title: "fresh", Service: "api", CreatedAt: now.Add(-10 * time.Minute)},
+		&storage.IncidentRecord{ID: "old", Title: "stale", Service: "api", CreatedAt: now.Add(-5 * time.Hour)},
+	)
+	tool := RecentIncidents{Store: store}
+
+	res, err := tool.Invoke(context.Background(), mustArgs(t, recentIncidentsArgs{WindowMinutes: 60}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if !res.Found {
+		t.Error("Found = false, want true")
+	}
+	if got := res.Data["count"]; got != 1 {
+		t.Errorf("count = %v, want 1 (old incident excluded)", got)
+	}
+	incidents := res.Data["incidents"].([]recentIncidentItem)
+	if len(incidents) != 1 || incidents[0].ID != "recent" {
+		t.Errorf("incidents = %+v, want only the recent one", incidents)
+	}
+}
+
+func TestRecentIncidents_ServiceFilter(t *testing.T) {
+	now := time.Now().UTC()
+	store := newStoreWithIncidents(t,
+		&storage.IncidentRecord{ID: "a", Service: "api", CreatedAt: now.Add(-time.Minute)},
+		&storage.IncidentRecord{ID: "b", Service: "worker", CreatedAt: now.Add(-time.Minute)},
+	)
+	tool := RecentIncidents{Store: store}
+
+	res, err := tool.Invoke(context.Background(), mustArgs(t, recentIncidentsArgs{Service: "WORKER"}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	incidents := res.Data["incidents"].([]recentIncidentItem)
+	if len(incidents) != 1 || incidents[0].ID != "b" {
+		t.Errorf("incidents = %+v, want only service=worker (case-insensitive)", incidents)
+	}
+}
+
+func TestRecentIncidents_LimitCapAndDefaults(t *testing.T) {
+	now := time.Now().UTC()
+	recs := make([]*storage.IncidentRecord, 0, 150)
+	for i := 0; i < 150; i++ {
+		recs = append(recs, &storage.IncidentRecord{
+			ID:        fmt.Sprintf("inc-%d", i),
+			Service:   "api",
+			CreatedAt: now.Add(-time.Duration(i) * time.Second),
+		})
+	}
+	tool := RecentIncidents{Store: newStoreWithIncidents(t, recs...)}
+
+	// limit over cap → clamp to 100; window over cap → clamp to 1440.
+	res, err := tool.Invoke(context.Background(), mustArgs(t, recentIncidentsArgs{
+		WindowMinutes: 99999,
+		Limit:         9999,
+	}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if got := res.Data["window_minutes"]; got != 1440 {
+		t.Errorf("window_minutes = %v, want 1440", got)
+	}
+	incidents := res.Data["incidents"].([]recentIncidentItem)
+	if len(incidents) != 100 {
+		t.Errorf("len(incidents) = %d, want 100 (limit cap)", len(incidents))
+	}
+}

--- a/pkg/agent/ai/analyze/tools/related_logs.go
+++ b/pkg/agent/ai/analyze/tools/related_logs.go
@@ -1,0 +1,191 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/core"
+)
+
+// RelatedLogs pulls a raw-log slice from the configured signal sources
+// around the incident window so the analyze agent can inspect the
+// surrounding context. Every returned line is scrubbed through the same
+// redactor used before any AI call, so secrets never reach the model.
+type RelatedLogs struct {
+	Reader   SignalReader
+	Redactor LineRedactor
+	Services ServiceExtractor
+}
+
+const (
+	relatedLogsDefaultWindow = 15
+	relatedLogsMaxWindow     = 1440
+	relatedLogsDefaultLimit  = 50
+	relatedLogsMaxLimit      = 200
+)
+
+// Name implements core.AnalyzeTool.
+func (RelatedLogs) Name() string { return "get_related_logs" }
+
+// Description implements core.AnalyzeTool.
+func (RelatedLogs) Description() string {
+	return "Pull a redacted slice of raw logs from a configured signal source around the incident window. Optionally filter by source name or service. Returns timestamp, severity, source, and message per line."
+}
+
+// ArgsSchema implements core.AnalyzeTool.
+func (RelatedLogs) ArgsSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"source": map[string]any{
+				"type":        "string",
+				"description": "Optional source name (e.g. \"file:noisy-app\"). When omitted, every configured source is queried.",
+			},
+			"service": map[string]any{
+				"type":        "string",
+				"description": "Optional service name to filter lines by (best-effort match against fields and source).",
+			},
+			"window_minutes": map[string]any{
+				"type":        "integer",
+				"description": "Look back this many minutes from now. Default 15, max 1440.",
+			},
+			"limit": map[string]any{
+				"type":        "integer",
+				"description": "Cap the number of log lines returned. Default 50, max 200.",
+			},
+		},
+	}
+}
+
+type relatedLogsArgs struct {
+	Source        string `json:"source"`
+	Service       string `json:"service"`
+	WindowMinutes int    `json:"window_minutes"`
+	Limit         int    `json:"limit"`
+}
+
+type relatedLogLine struct {
+	Timestamp time.Time `json:"timestamp"`
+	Severity  string    `json:"severity,omitempty"`
+	Source    string    `json:"source"`
+	Message   string    `json:"message"`
+}
+
+// Invoke implements core.AnalyzeTool.
+func (rl RelatedLogs) Invoke(ctx context.Context, args json.RawMessage) (*core.ToolResult, error) {
+	if rl.Reader == nil {
+		return nil, fmt.Errorf("get_related_logs: no signal sources configured")
+	}
+	var a relatedLogsArgs
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &a); err != nil {
+			return nil, fmt.Errorf("get_related_logs: parse args: %w", err)
+		}
+	}
+	if a.WindowMinutes <= 0 {
+		a.WindowMinutes = relatedLogsDefaultWindow
+	}
+	if a.WindowMinutes > relatedLogsMaxWindow {
+		a.WindowMinutes = relatedLogsMaxWindow
+	}
+	if a.Limit <= 0 {
+		a.Limit = relatedLogsDefaultLimit
+	}
+	if a.Limit > relatedLogsMaxLimit {
+		a.Limit = relatedLogsMaxLimit
+	}
+
+	now := time.Now().UTC()
+	since := now.Add(-time.Duration(a.WindowMinutes) * time.Minute)
+
+	// Resolve which sources to query.
+	var targets []string
+	if a.Source != "" {
+		targets = []string{a.Source}
+	} else {
+		targets = rl.Reader.Sources()
+	}
+
+	out := make([]relatedLogLine, 0, a.Limit)
+	for _, name := range targets {
+		sigs, err := rl.Reader.Pull(ctx, name, since)
+		if err != nil {
+			// A single bad source must not sink the whole call when the
+			// model asked for "all sources"; surface the error only when
+			// the model explicitly targeted that source.
+			if a.Source != "" {
+				return nil, fmt.Errorf("get_related_logs: pull %q: %w", name, err)
+			}
+			continue
+		}
+		for _, s := range sigs {
+			if s.Timestamp.Before(since) {
+				continue
+			}
+			msg := rl.scrub(s.Message)
+			if a.Service != "" && !rl.signalMatchesService(s, msg, a.Service) {
+				continue
+			}
+			out = append(out, relatedLogLine{
+				Timestamp: s.Timestamp,
+				Severity:  s.Severity,
+				Source:    s.Source,
+				Message:   msg,
+			})
+		}
+	}
+
+	// Newest first, then cap.
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Timestamp.After(out[j].Timestamp)
+	})
+	if len(out) > a.Limit {
+		out = out[:a.Limit]
+	}
+
+	return &core.ToolResult{
+		Tool:  RelatedLogs{}.Name(),
+		Found: len(out) > 0,
+		Data: map[string]any{
+			"count":          len(out),
+			"window_minutes": a.WindowMinutes,
+			"source":         a.Source,
+			"service":        a.Service,
+			"logs":           out,
+		},
+	}, nil
+}
+
+func (rl RelatedLogs) scrub(s string) string {
+	if rl.Redactor == nil {
+		return s
+	}
+	return rl.Redactor.Scrub(s)
+}
+
+// signalMatchesService is a best-effort filter. It first tries the same
+// `agent.service_patterns` extraction the worker uses (so the filter is
+// consistent with how signals are attributed to services), then falls
+// back to the common structured service keys, and finally to a substring
+// match against the source name. Kept loose on purpose — the model uses
+// this to narrow noise, not as an exact join. msg is the post-redaction
+// message, matching the worker's redact-then-extract order.
+func (rl RelatedLogs) signalMatchesService(s core.Signal, msg, service string) bool {
+	if rl.Services != nil {
+		if extracted := rl.Services.Extract(msg); extracted != "" {
+			return strings.EqualFold(extracted, service)
+		}
+	}
+	for _, key := range []string{"service", "service.name", "svc", "app", "component"} {
+		if v, ok := s.Fields[key]; ok {
+			if str, ok := v.(string); ok && strings.EqualFold(str, service) {
+				return true
+			}
+		}
+	}
+	return strings.Contains(strings.ToLower(s.Source), strings.ToLower(service))
+}

--- a/pkg/agent/ai/analyze/tools/related_logs_test.go
+++ b/pkg/agent/ai/analyze/tools/related_logs_test.go
@@ -1,0 +1,264 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/core"
+)
+
+// fakeReader is a scripted SignalReader for tests.
+type fakeReader struct {
+	names   []string
+	byName  map[string][]core.Signal
+	gotConn []struct {
+		source string
+		since  time.Time
+	}
+}
+
+func (f *fakeReader) Sources() []string { return f.names }
+
+func (f *fakeReader) Pull(_ context.Context, source string, since time.Time) ([]core.Signal, error) {
+	f.gotConn = append(f.gotConn, struct {
+		source string
+		since  time.Time
+	}{source, since})
+	return f.byName[source], nil
+}
+
+// fakeRedactor replaces a literal secret marker so the test can assert
+// scrubbing happened without importing pkg/agent (which would form an
+// import cycle with this package).
+type fakeRedactor struct{}
+
+func (fakeRedactor) Scrub(s string) string {
+	return strings.ReplaceAll(s, "password=hunter2", "password=[redacted]")
+}
+
+func mustArgs(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	return b
+}
+
+func TestRelatedLogs_WindowAndLimitClamp(t *testing.T) {
+	now := time.Now().UTC()
+	sigs := make([]core.Signal, 0, 300)
+	for i := 0; i < 300; i++ {
+		sigs = append(sigs, core.Signal{
+			Source:    "file:app",
+			Timestamp: now.Add(-time.Duration(i) * time.Second),
+			Message:   "line",
+		})
+	}
+	r := &fakeReader{
+		names:  []string{"file:app"},
+		byName: map[string][]core.Signal{"file:app": sigs},
+	}
+	tool := RelatedLogs{Reader: r, Redactor: fakeRedactor{}}
+
+	// window over cap → clamp to 1440; limit over cap → clamp to 200.
+	res, err := tool.Invoke(context.Background(), mustArgs(t, relatedLogsArgs{
+		WindowMinutes: 999999,
+		Limit:         9999,
+	}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if got := res.Data["window_minutes"]; got != relatedLogsMaxWindow {
+		t.Errorf("window_minutes = %v, want %d", got, relatedLogsMaxWindow)
+	}
+	logs := res.Data["logs"].([]relatedLogLine)
+	if len(logs) != relatedLogsMaxLimit {
+		t.Errorf("len(logs) = %d, want %d (limit cap)", len(logs), relatedLogsMaxLimit)
+	}
+	if !res.Found {
+		t.Error("Found = false, want true")
+	}
+	// since must be window before now.
+	if len(r.gotConn) != 1 {
+		t.Fatalf("Pull called %d times, want 1", len(r.gotConn))
+	}
+	wantSince := now.Add(-time.Duration(relatedLogsMaxWindow) * time.Minute)
+	if diff := r.gotConn[0].since.Sub(wantSince); diff > time.Minute || diff < -time.Minute {
+		t.Errorf("since = %v, want ~%v", r.gotConn[0].since, wantSince)
+	}
+}
+
+func TestRelatedLogs_NewestFirst(t *testing.T) {
+	now := time.Now().UTC()
+	r := &fakeReader{
+		names: []string{"file:app"},
+		byName: map[string][]core.Signal{"file:app": {
+			{Source: "file:app", Timestamp: now.Add(-3 * time.Minute), Message: "old"},
+			{Source: "file:app", Timestamp: now.Add(-1 * time.Minute), Message: "new"},
+			{Source: "file:app", Timestamp: now.Add(-2 * time.Minute), Message: "mid"},
+		}},
+	}
+	tool := RelatedLogs{Reader: r}
+	res, err := tool.Invoke(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	logs := res.Data["logs"].([]relatedLogLine)
+	if len(logs) != 3 {
+		t.Fatalf("len(logs) = %d, want 3", len(logs))
+	}
+	if logs[0].Message != "new" || logs[2].Message != "old" {
+		t.Errorf("order = %q..%q, want new..old", logs[0].Message, logs[2].Message)
+	}
+}
+
+func TestRelatedLogs_RedactionApplied(t *testing.T) {
+	now := time.Now().UTC()
+	r := &fakeReader{
+		names: []string{"file:app"},
+		byName: map[string][]core.Signal{"file:app": {
+			{Source: "file:app", Timestamp: now, Message: "login password=hunter2 ok"},
+		}},
+	}
+	tool := RelatedLogs{Reader: r, Redactor: fakeRedactor{}}
+	res, err := tool.Invoke(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	logs := res.Data["logs"].([]relatedLogLine)
+	if len(logs) != 1 {
+		t.Fatalf("len(logs) = %d, want 1", len(logs))
+	}
+	if strings.Contains(logs[0].Message, "hunter2") {
+		t.Errorf("secret leaked: %q", logs[0].Message)
+	}
+	if !strings.Contains(logs[0].Message, "[redacted]") {
+		t.Errorf("redaction not applied: %q", logs[0].Message)
+	}
+}
+
+func TestRelatedLogs_OutsideWindowDropped(t *testing.T) {
+	now := time.Now().UTC()
+	r := &fakeReader{
+		names: []string{"file:app"},
+		byName: map[string][]core.Signal{"file:app": {
+			{Source: "file:app", Timestamp: now.Add(-2 * time.Minute), Message: "inside"},
+			{Source: "file:app", Timestamp: now.Add(-90 * time.Minute), Message: "outside"},
+		}},
+	}
+	tool := RelatedLogs{Reader: r}
+	res, err := tool.Invoke(context.Background(), mustArgs(t, relatedLogsArgs{WindowMinutes: 10}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	logs := res.Data["logs"].([]relatedLogLine)
+	if len(logs) != 1 || logs[0].Message != "inside" {
+		t.Errorf("logs = %+v, want only 'inside'", logs)
+	}
+}
+
+func TestRelatedLogs_ServiceFilter(t *testing.T) {
+	now := time.Now().UTC()
+	r := &fakeReader{
+		names: []string{"file:app"},
+		byName: map[string][]core.Signal{"file:app": {
+			{Source: "file:app", Timestamp: now, Message: "a", Fields: map[string]interface{}{"service": "payments"}},
+			{Source: "file:app", Timestamp: now, Message: "b", Fields: map[string]interface{}{"service": "billing"}},
+		}},
+	}
+	tool := RelatedLogs{Reader: r}
+	res, err := tool.Invoke(context.Background(), mustArgs(t, relatedLogsArgs{Service: "payments"}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	logs := res.Data["logs"].([]relatedLogLine)
+	if len(logs) != 1 || logs[0].Message != "a" {
+		t.Errorf("logs = %+v, want only payments line", logs)
+	}
+}
+
+// fakeExtractor mirrors agent.ServiceMatcher: it pulls the value after
+// "service=" out of the message.
+type fakeExtractor struct{}
+
+func (fakeExtractor) Extract(message string) string {
+	const key = "service="
+	i := strings.Index(message, key)
+	if i < 0 {
+		return ""
+	}
+	rest := message[i+len(key):]
+	if sp := strings.IndexAny(rest, " \t"); sp >= 0 {
+		rest = rest[:sp]
+	}
+	return rest
+}
+
+func TestRelatedLogs_ServiceFilterUsesExtractor(t *testing.T) {
+	now := time.Now().UTC()
+	r := &fakeReader{
+		names: []string{"file:app"},
+		byName: map[string][]core.Signal{"file:app": {
+			// No structured fields — only the extractor can resolve the service.
+			{Source: "file:app", Timestamp: now, Message: "level=error service=payments boom"},
+			{Source: "file:app", Timestamp: now, Message: "level=error service=billing ok"},
+		}},
+	}
+	tool := RelatedLogs{Reader: r, Services: fakeExtractor{}}
+	res, err := tool.Invoke(context.Background(), mustArgs(t, relatedLogsArgs{Service: "payments"}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	logs := res.Data["logs"].([]relatedLogLine)
+	if len(logs) != 1 || !strings.Contains(logs[0].Message, "service=payments") {
+		t.Errorf("logs = %+v, want only the payments line", logs)
+	}
+}
+
+func TestRelatedLogs_Miss(t *testing.T) {
+	r := &fakeReader{names: []string{"file:app"}, byName: map[string][]core.Signal{"file:app": {}}}
+	tool := RelatedLogs{Reader: r}
+	res, err := tool.Invoke(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if res.Found {
+		t.Error("Found = true, want false on empty result")
+	}
+	if res.Data["count"] != 0 {
+		t.Errorf("count = %v, want 0", res.Data["count"])
+	}
+}
+
+func TestRelatedLogs_AllSourcesTolerateBadSource(t *testing.T) {
+	now := time.Now().UTC()
+	// One source returns data; an unknown name in the list errors but
+	// must not sink the whole call when querying all sources.
+	r := &fakeReader{
+		names: []string{"file:good", "file:missing"},
+		byName: map[string][]core.Signal{
+			"file:good": {{Source: "file:good", Timestamp: now, Message: "ok"}},
+			// "file:missing" intentionally absent → Pull returns nil, nil here.
+		},
+	}
+	tool := RelatedLogs{Reader: r}
+	res, err := tool.Invoke(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	logs := res.Data["logs"].([]relatedLogLine)
+	if len(logs) != 1 || logs[0].Message != "ok" {
+		t.Errorf("logs = %+v, want single 'ok' line", logs)
+	}
+}
+
+func TestRelatedLogs_NoReader(t *testing.T) {
+	tool := RelatedLogs{}
+	if _, err := tool.Invoke(context.Background(), nil); err == nil {
+		t.Error("expected error when reader is nil")
+	}
+}

--- a/pkg/agent/ai/analyze/tools/tools.go
+++ b/pkg/agent/ai/analyze/tools/tools.go
@@ -8,10 +8,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"sort"
-	"strings"
 	"time"
 
 	"github.com/VersusControl/versus-incident/pkg/core"
@@ -51,301 +47,72 @@ type ServiceInfo struct {
 	FirstSeen time.Time
 }
 
-// RecentIncidents lists incidents from storage within a time window,
-// optionally filtered by service. The agent uses it to spot bursts /
-// recurring incidents on the same service.
-type RecentIncidents struct {
-	Store storage.Provider
+// SignalReader is the read-only slice of the configured signal sources
+// the analyze tools depend on. Declaring it as a local interface (not
+// importing pkg/agent or pkg/signalsources) keeps the import graph
+// one-directional. The bridge in pkg/agent/analyze_adapter.go wraps an
+// independent source set so pulling logs during an analysis never
+// advances the worker's polling cursors.
+type SignalReader interface {
+	// Sources returns the names of every configured source.
+	Sources() []string
+	// Pull returns signals from the named source at or after `since`.
+	// The reader does no windowing or capping; callers filter and cap
+	// client-side. An unknown source name yields an error.
+	Pull(ctx context.Context, source string, since time.Time) ([]core.Signal, error)
 }
 
-// Name implements core.AnalyzeTool.
-func (RecentIncidents) Name() string { return "recent_incidents" }
-
-// Description implements core.AnalyzeTool.
-func (RecentIncidents) Description() string {
-	return "List incidents from the local store within the last N minutes, optionally filtered by service. Returns id, title, service, severity, resolved, created_at."
+// LineRedactor scrubs sensitive substrings from a single log line
+// before it is handed to the model. *agent.Redactor satisfies this
+// interface directly via its Scrub method.
+type LineRedactor interface {
+	Scrub(s string) string
 }
 
-// ArgsSchema implements core.AnalyzeTool.
-func (RecentIncidents) ArgsSchema() map[string]any {
-	return map[string]any{
-		"type": "object",
-		"properties": map[string]any{
-			"window_minutes": map[string]any{
-				"type":        "integer",
-				"description": "Look back this many minutes from now. Default 60, max 1440.",
-			},
-			"service": map[string]any{
-				"type":        "string",
-				"description": "Optional service name to filter by (exact match).",
-			},
-			"limit": map[string]any{
-				"type":        "integer",
-				"description": "Cap the number of incidents returned. Default 20, max 100.",
-			},
-		},
-	}
-}
-
-type recentIncidentsArgs struct {
-	WindowMinutes int    `json:"window_minutes"`
-	Service       string `json:"service"`
-	Limit         int    `json:"limit"`
-}
-
-type recentIncidentItem struct {
-	ID        string    `json:"id"`
-	Title     string    `json:"title,omitempty"`
-	Service   string    `json:"service,omitempty"`
-	Severity  string    `json:"severity,omitempty"`
-	Resolved  bool      `json:"resolved"`
-	CreatedAt time.Time `json:"created_at"`
-}
-
-// Invoke implements core.AnalyzeTool.
-func (r RecentIncidents) Invoke(_ context.Context, args json.RawMessage) (*core.ToolResult, error) {
-	if r.Store == nil {
-		return nil, fmt.Errorf("recent_incidents: storage not configured")
-	}
-	var a recentIncidentsArgs
-	if len(args) > 0 {
-		if err := json.Unmarshal(args, &a); err != nil {
-			return nil, fmt.Errorf("recent_incidents: parse args: %w", err)
-		}
-	}
-	if a.WindowMinutes <= 0 {
-		a.WindowMinutes = 60
-	}
-	if a.WindowMinutes > 1440 {
-		a.WindowMinutes = 1440
-	}
-	if a.Limit <= 0 {
-		a.Limit = 20
-	}
-	if a.Limit > 100 {
-		a.Limit = 100
-	}
-
-	all, err := r.Store.ListIncidents(0)
-	if err != nil {
-		return nil, fmt.Errorf("recent_incidents: list: %w", err)
-	}
-	cutoff := time.Now().UTC().Add(-time.Duration(a.WindowMinutes) * time.Minute)
-	out := make([]recentIncidentItem, 0)
-	for _, rec := range all {
-		if rec.CreatedAt.Before(cutoff) {
-			continue
-		}
-		if a.Service != "" && !strings.EqualFold(rec.Service, a.Service) {
-			continue
-		}
-		out = append(out, recentIncidentItem{
-			ID:        rec.ID,
-			Title:     rec.Title,
-			Service:   rec.Service,
-			Resolved:  rec.Resolved,
-			CreatedAt: rec.CreatedAt,
-		})
-		if len(out) >= a.Limit {
-			break
-		}
-	}
-	return &core.ToolResult{
-		Tool:  RecentIncidents{}.Name(),
-		Found: true,
-		Data: map[string]any{
-			"count":          len(out),
-			"window_minutes": a.WindowMinutes,
-			"service":        a.Service,
-			"incidents":      out,
-		},
-	}, nil
-}
-
-// PatternHistory looks up the agent catalog by pattern id and returns
-// the curated metadata (template, counts, baseline, verdict, tags).
-type PatternHistory struct {
-	Catalog PatternCatalog
-}
-
-// Name implements core.AnalyzeTool.
-func (PatternHistory) Name() string { return "pattern_history" }
-
-// Description implements core.AnalyzeTool.
-func (PatternHistory) Description() string {
-	return "Look up a learned log-pattern by id and return its template, observed counts, EWMA baseline, service, verdict, and operator tags."
-}
-
-// ArgsSchema implements core.AnalyzeTool.
-func (PatternHistory) ArgsSchema() map[string]any {
-	return map[string]any{
-		"type": "object",
-		"properties": map[string]any{
-			"pattern_id": map[string]any{
-				"type":        "string",
-				"description": "Required. The pattern id from a prior incident or finding.",
-			},
-		},
-		"required": []string{"pattern_id"},
-	}
-}
-
-type patternHistoryArgs struct {
-	PatternID string `json:"pattern_id"`
-}
-
-// Invoke implements core.AnalyzeTool.
-func (p PatternHistory) Invoke(_ context.Context, args json.RawMessage) (*core.ToolResult, error) {
-	if p.Catalog == nil {
-		return nil, fmt.Errorf("pattern_history: catalog not configured")
-	}
-	var a patternHistoryArgs
-	if len(args) > 0 {
-		if err := json.Unmarshal(args, &a); err != nil {
-			return nil, fmt.Errorf("pattern_history: parse args: %w", err)
-		}
-	}
-	if a.PatternID == "" {
-		return nil, fmt.Errorf("pattern_history: pattern_id is required")
-	}
-	pat := p.Catalog.Get(a.PatternID)
-	if pat == nil {
-		return &core.ToolResult{
-			Tool:  PatternHistory{}.Name(),
-			Found: false,
-			Data:  map[string]any{"pattern_id": a.PatternID},
-		}, nil
-	}
-	return &core.ToolResult{
-		Tool:  PatternHistory{}.Name(),
-		Found: true,
-		Data: map[string]any{
-			"pattern_id": pat.ID,
-			"template":   pat.Template,
-			"source":     pat.Source,
-			"service":    pat.Service,
-			"rule_name":  pat.RuleName,
-			"verdict":    pat.Verdict,
-			"tags":       pat.Tags,
-			"count":      pat.Count,
-			"baseline":   pat.Baseline,
-			"first_seen": pat.FirstSeen,
-			"last_seen":  pat.LastSeen,
-		},
-	}, nil
-}
-
-// DescribeService returns the catalog-known summary for a service: how
-// long it has been observed and how many patterns are attributed to it.
-type DescribeService struct {
-	Catalog PatternCatalog
-}
-
-// Name implements core.AnalyzeTool.
-func (DescribeService) Name() string { return "describe_service" }
-
-// Description implements core.AnalyzeTool.
-func (DescribeService) Description() string {
-	return "Summarize what the agent knows about a service: first-seen timestamp and the top learned patterns attributed to it."
-}
-
-// ArgsSchema implements core.AnalyzeTool.
-func (DescribeService) ArgsSchema() map[string]any {
-	return map[string]any{
-		"type": "object",
-		"properties": map[string]any{
-			"service": map[string]any{
-				"type":        "string",
-				"description": "Required. The service name to look up.",
-			},
-			"top_patterns": map[string]any{
-				"type":        "integer",
-				"description": "How many top patterns to include. Default 5, max 20.",
-			},
-		},
-		"required": []string{"service"},
-	}
-}
-
-type describeServiceArgs struct {
-	Service     string `json:"service"`
-	TopPatterns int    `json:"top_patterns"`
-}
-
-type describePatternEntry struct {
-	ID       string  `json:"id"`
-	Template string  `json:"template"`
-	Count    int     `json:"count"`
-	Baseline float64 `json:"baseline"`
-	Verdict  string  `json:"verdict,omitempty"`
-}
-
-// Invoke implements core.AnalyzeTool.
-func (d DescribeService) Invoke(_ context.Context, args json.RawMessage) (*core.ToolResult, error) {
-	if d.Catalog == nil {
-		return nil, fmt.Errorf("describe_service: catalog not configured")
-	}
-	var a describeServiceArgs
-	if len(args) > 0 {
-		if err := json.Unmarshal(args, &a); err != nil {
-			return nil, fmt.Errorf("describe_service: parse args: %w", err)
-		}
-	}
-	if a.Service == "" {
-		return nil, fmt.Errorf("describe_service: service is required")
-	}
-	if a.TopPatterns <= 0 {
-		a.TopPatterns = 5
-	}
-	if a.TopPatterns > 20 {
-		a.TopPatterns = 20
-	}
-
-	res := &core.ToolResult{
-		Tool: DescribeService{}.Name(),
-		Data: map[string]any{"service": a.Service},
-	}
-	services := d.Catalog.AllServices()
-	if info, ok := services[a.Service]; ok {
-		res.Found = true
-		res.Data["first_seen"] = info.FirstSeen
-	}
-
-	matches := make([]describePatternEntry, 0)
-	for _, p := range d.Catalog.All() {
-		if !strings.EqualFold(p.Service, a.Service) {
-			continue
-		}
-		matches = append(matches, describePatternEntry{
-			ID:       p.ID,
-			Template: p.Template,
-			Count:    p.Count,
-			Baseline: p.Baseline,
-			Verdict:  p.Verdict,
-		})
-	}
-	sort.SliceStable(matches, func(i, j int) bool {
-		return matches[i].Count > matches[j].Count
-	})
-	if len(matches) > a.TopPatterns {
-		matches = matches[:a.TopPatterns]
-	}
-	res.Data["pattern_count"] = len(matches)
-	res.Data["top_patterns"] = matches
-	return res, nil
+// ServiceExtractor pulls a service name out of a raw log message using
+// the operator-configured `agent.service_patterns`. *agent.ServiceMatcher
+// satisfies this interface directly via its Extract method, so the
+// get_related_logs service filter matches lines the exact same way the
+// worker attributes signals to services. A nil extractor (or an empty
+// result) makes the tool fall back to structured fields / source name.
+type ServiceExtractor interface {
+	Extract(message string) string
 }
 
 // Default returns the production tool set wired to the given storage
 // and catalog. Callers can also assemble a custom set by constructing
 // the individual tool structs.
-func Default(store storage.Provider, cat PatternCatalog) []core.AnalyzeTool {
-	out := make([]core.AnalyzeTool, 0, 3)
+//
+// reader/redactor power the get_related_logs tool. When reader is nil
+// (no sources configured) that tool is omitted; when redactor is nil
+// log lines are returned unscrubbed (callers should always pass a
+// redactor in production). services is the same ServiceMatcher the
+// worker uses so the get_related_logs service filter matches lines
+// consistently; it may be nil (the filter then falls back to fields).
+//
+// graph powers the describe_dependencies tool. When nil or empty (no
+// service-dependency graph configured) that tool is omitted.
+//
+// changes powers the recent_changes tool. When nil (no change feed
+// configured) that tool is omitted; the tool itself still treats a
+// missing or empty feed as a clean Found=false rather than an error.
+func Default(store storage.Provider, cat PatternCatalog, reader SignalReader, redactor LineRedactor, services ServiceExtractor, graph *DependencyGraph, changes ChangeFeed) []core.AnalyzeTool {
+	out := make([]core.AnalyzeTool, 0, 6)
 	if store != nil {
 		out = append(out, RecentIncidents{Store: store})
 	}
 	if cat != nil {
 		out = append(out, PatternHistory{Catalog: cat})
 		out = append(out, DescribeService{Catalog: cat})
+	}
+	if reader != nil {
+		out = append(out, RelatedLogs{Reader: reader, Redactor: redactor, Services: services})
+	}
+	if graph != nil && graph.Len() > 0 {
+		out = append(out, DescribeDependencies{Graph: graph, Store: store})
+	}
+	if changes != nil {
+		out = append(out, RecentChanges{Feed: changes})
 	}
 	return out
 }

--- a/pkg/agent/analyze_adapter.go
+++ b/pkg/agent/analyze_adapter.go
@@ -1,8 +1,66 @@
 package agent
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	analyzetools "github.com/VersusControl/versus-incident/pkg/agent/ai/analyze/tools"
+	"github.com/VersusControl/versus-incident/pkg/config"
+	"github.com/VersusControl/versus-incident/pkg/core"
 )
+
+// signalReaderAdapter wraps a set of core.SignalSource instances so they
+// satisfy analyzetools.SignalReader without leaking pkg/agent (or the
+// concrete source types) into the tools package. The wrapped sources are
+// an independent set built solely for the read-only get_related_logs
+// tool, so calling Pull here never advances the worker's cursors.
+type signalReaderAdapter struct {
+	sources map[string]core.SignalSource
+	order   []string
+}
+
+func newSignalReaderAdapter(sources []core.SignalSource) analyzetools.SignalReader {
+	if len(sources) == 0 {
+		return nil
+	}
+	m := make(map[string]core.SignalSource, len(sources))
+	order := make([]string, 0, len(sources))
+	for _, s := range sources {
+		if s == nil {
+			continue
+		}
+		name := s.Name()
+		if _, dup := m[name]; dup {
+			continue
+		}
+		m[name] = s
+		order = append(order, name)
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return &signalReaderAdapter{sources: m, order: order}
+}
+
+func (a *signalReaderAdapter) Sources() []string {
+	if a == nil {
+		return nil
+	}
+	return append([]string(nil), a.order...)
+}
+
+func (a *signalReaderAdapter) Pull(ctx context.Context, source string, since time.Time) ([]core.Signal, error) {
+	if a == nil {
+		return nil, fmt.Errorf("signal reader not configured")
+	}
+	src, ok := a.sources[source]
+	if !ok {
+		return nil, fmt.Errorf("unknown source %q", source)
+	}
+	sigs, _, err := src.Pull(ctx, since)
+	return sigs, err
+}
 
 // catalogAdapter wraps *Catalog so it satisfies the
 // analyzetools.PatternCatalog interface without leaking the agent
@@ -69,4 +127,54 @@ func toView(p *Pattern) analyzetools.PatternView {
 		FirstSeen: p.FirstSeen,
 		LastSeen:  p.LastSeen,
 	}
+}
+
+// buildDependencyGraph converts the operator-authored config service
+// graph into the tools-package DependencyGraph used by the
+// describe_dependencies tool. A nil/empty input yields a nil graph so
+// the tool is omitted by analyzetools.Default.
+func buildDependencyGraph(nodes []config.ServiceDependency) *analyzetools.DependencyGraph {
+	if len(nodes) == 0 {
+		return nil
+	}
+	dependsOn := make(map[string][]string, len(nodes))
+	for _, n := range nodes {
+		if n.Name == "" {
+			continue
+		}
+		dependsOn[n.Name] = append(dependsOn[n.Name], n.DependsOn...)
+	}
+	if len(dependsOn) == 0 {
+		return nil
+	}
+	return analyzetools.NewDependencyGraph(dependsOn)
+}
+
+// buildGitRepos converts the operator-authored config repo list into the
+// tools-package GitRepo slice used by the recent_changes change feed.
+// Each repo's auth falls back to the global default (git.auth) when its
+// own auth fields are empty.
+func buildGitRepos(git config.RecentChangesGitConfig) []analyzetools.GitRepo {
+	if len(git.Repos) == 0 {
+		return nil
+	}
+	out := make([]analyzetools.GitRepo, 0, len(git.Repos))
+	for _, r := range git.Repos {
+		token := r.Auth.Token
+		if token == "" {
+			token = git.Auth.Token
+		}
+		sshKey := r.Auth.SSHKeyPath
+		if sshKey == "" {
+			sshKey = git.Auth.SSHKeyPath
+		}
+		out = append(out, analyzetools.GitRepo{
+			URL:        r.URL,
+			Branch:     r.Branch,
+			Service:    r.Service,
+			Token:      token,
+			SSHKeyPath: sshKey,
+		})
+	}
+	return out
 }

--- a/pkg/agent/analyze_adapter_test.go
+++ b/pkg/agent/analyze_adapter_test.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"testing"
+
+	analyzetools "github.com/VersusControl/versus-incident/pkg/agent/ai/analyze/tools"
+	"github.com/VersusControl/versus-incident/pkg/config"
+)
+
+// TestBuildGitRepos_EmptyNil asserts an empty repo list yields a nil
+// slice so analyzetools.Default omits the recent_changes tool.
+func TestBuildGitRepos_EmptyNil(t *testing.T) {
+	if got := buildGitRepos(config.RecentChangesGitConfig{}); got != nil {
+		t.Fatalf("empty config should yield nil, got %v", got)
+	}
+}
+
+// TestBuildGitRepos_AuthFallback asserts each repo inherits the global
+// git.auth when its own auth fields are empty, and that a per-repo auth
+// value overrides the global default field-by-field.
+func TestBuildGitRepos_AuthFallback(t *testing.T) {
+	src := config.RecentChangesGitConfig{
+		Auth: config.GitAuthConfig{Token: "global-token", SSHKeyPath: "/global/key"},
+		Repos: []config.RecentChangesGitRepo{
+			// Inherits both global fields.
+			{URL: "https://github.com/acme/api.git", Service: "api"},
+			// Overrides token; inherits global ssh key.
+			{URL: "https://github.com/acme/web.git", Auth: config.GitAuthConfig{Token: "web-token"}},
+			// Overrides ssh key; inherits global token.
+			{URL: "git@github.com:acme/db.git", Auth: config.GitAuthConfig{SSHKeyPath: "/db/key"}},
+		},
+	}
+	got := buildGitRepos(src)
+	if len(got) != 3 {
+		t.Fatalf("got %d repos, want 3", len(got))
+	}
+
+	if got[0].Token != "global-token" || got[0].SSHKeyPath != "/global/key" {
+		t.Fatalf("repo[0] should inherit both global auth fields: %+v", got[0])
+	}
+	if got[0].URL != "https://github.com/acme/api.git" || got[0].Service != "api" {
+		t.Fatalf("repo[0] non-auth fields wrong: %+v", got[0])
+	}
+	if got[1].Token != "web-token" || got[1].SSHKeyPath != "/global/key" {
+		t.Fatalf("repo[1] should override token, inherit ssh key: %+v", got[1])
+	}
+	if got[2].Token != "global-token" || got[2].SSHKeyPath != "/db/key" {
+		t.Fatalf("repo[2] should inherit token, override ssh key: %+v", got[2])
+	}
+}
+
+// TestBuildGitRepos_NoGlobalAuth asserts empty global auth leaves each
+// repo's auth empty so the feed relies on ambient git credentials.
+func TestBuildGitRepos_NoGlobalAuth(t *testing.T) {
+	got := buildGitRepos(config.RecentChangesGitConfig{
+		Repos: []config.RecentChangesGitRepo{{URL: "https://example.com/x.git"}},
+	})
+	want := analyzetools.GitRepo{URL: "https://example.com/x.git"}
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("got %+v, want single %+v", got, want)
+	}
+}

--- a/pkg/agent/factory_ai.go
+++ b/pkg/agent/factory_ai.go
@@ -69,9 +69,44 @@ func BuildAIs(cfg config.AgentConfig, catalog *Catalog, store storage.Provider, 
 	var analyzeRate *ai.RateLimiter
 	{
 		analyzeBaseCfg := cfg.AI.Resolve(config.AgentAITaskConfig{Model: cfg.AI.Analyze.Model})
-		tools := analyzetools.Default(store, newCatalogAdapter(catalog))
+
+		// Independent source set + redactor for the read-only
+		// get_related_logs tool. Built separately from the worker's
+		// sources so pulling logs during an analysis never advances the
+		// worker's polling cursors. A nil reader simply omits the tool.
+		readerSources, srcErrs := BuildSources(cfg)
+		for _, e := range srcErrs {
+			log.Printf("agent: analyze reader source warning: %v", e)
+		}
+		reader := newSignalReaderAdapter(readerSources)
+		redactor, redactErrs := NewRedactor(cfg.Redaction.Enable && cfg.Redaction.RedactIPs, cfg.Redaction.ExtraPatterns)
+		for _, e := range redactErrs {
+			log.Printf("agent: analyze reader redactor warning: %v", e)
+		}
+		serviceMatcher, svcErrs := NewServiceMatcher(cfg.ServicePatterns)
+		for _, e := range svcErrs {
+			log.Printf("agent: analyze reader service_patterns warning: %v", e)
+		}
+
+		// Optional service-dependency graph for the describe_dependencies
+		// tool. Built from the operator-authored upstream edges in
+		// tools.yaml (tools.describe_dependencies.services); a nil/empty
+		// graph omits the tool.
+		graph := buildDependencyGraph(cfg.Tools.DescribeDependencies.Services)
+
+		// Optional git-backed change feed for the recent_changes tool. It
+		// mirror-clones each configured remote git repository into a local
+		// cache and reads its commit history, configured via tools.yaml
+		// (tools.recent_changes.git.repos). An empty repos list leaves the
+		// feed nil so the tool is omitted; the `git` binary must be on PATH
+		// when configured.
+		changes := analyzetools.NewGitChangeFeed(buildGitRepos(cfg.Tools.RecentChanges.Git))
+
+		tools := analyzetools.Default(store, newCatalogAdapter(catalog), reader, redactor, serviceMatcher, graph, changes)
 		a, aErr := analyze.New(context.Background(), analyzeBaseCfg, tools, analyze.Options{
-			HTTPClient: httpClient,
+			HTTPClient:    httpClient,
+			ToolTimeout:   parseDurationOr(cfg.Tools.ToolTimeout, 20*time.Second),
+			ParallelTools: cfg.Tools.ParallelTools,
 		})
 		if aErr != nil {
 			log.Printf("agent: analyze agent disabled: %v", aErr)

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -34,6 +34,17 @@ type AgentConfig struct {
 	// sources). The file's top-level key is `sources`. ${VAR} references
 	// in the file are expanded against the process environment.
 	Sources []AgentSourceConfig `mapstructure:"sources"`
+
+	// Tools holds per-tool configuration for analyze-mode tools that need
+	// external data (e.g. the `recent_changes` tool's git repository and
+	// the `describe_dependencies` tool's service-dependency graph).
+	// Versus loads it from the file `tools.yaml` sitting next to the main
+	// config file (path is hardcoded; missing file is OK — tools needing
+	// config then simply degrade to a clean "nothing found"). The file's
+	// top-level key is `tools`. This is per-tool DATA config, not a
+	// registration allow-list: tools are still registered in code via
+	// `analyzetools.Default`.
+	Tools ToolsConfig `mapstructure:"tools"`
 }
 
 type AgentRedactionConfig struct {
@@ -317,12 +328,17 @@ type AgentAIConfig struct {
 	Analyze AgentAIAnalyzeConfig `mapstructure:"analyze"`
 }
 
-// AgentAIAnalyzeConfig is the analyze-agent override block. The only
-// operator-tunable knob is the model: analyze deep dives can point at a
-// stronger model than the shared ai.model. All other LLM settings
-// (temperature, max_tokens, rate limit, cache) are inherited from the
-// top-level ai block. The analyze agent is constructed whenever
+// AgentAIAnalyzeConfig is the analyze-agent override block. The model
+// knob lets analyze deep dives point at a stronger model than the
+// shared ai.model. All other LLM settings (temperature, max_tokens,
+// rate limit, cache) are inherited from the top-level ai block, and the
+// tool-loop knobs (tool_timeout, parallel_tools) live on the shared
+// tools block (tools.yaml). The analyze agent is constructed whenever
 // AI.Enable is true — there is no separate opt-in gate.
+//
+// The Model knob is read directly from cfg.AI.Analyze (NOT via Resolve,
+// which zeroes the Analyze overlay), so it must be deep-cloned in
+// clone_config.go.
 type AgentAIAnalyzeConfig struct {
 	// Model overrides the shared ai.model for analyze deep dives.
 	// Empty inherits ai.model.

--- a/pkg/config/clone_config.go
+++ b/pkg/config/clone_config.go
@@ -404,7 +404,32 @@ func cloneAgentConfig(src AgentConfig) AgentConfig {
 			cloned.Sources[i] = c
 		}
 	}
+	cloned.Tools = cloneToolsConfig(src.Tools)
 	return cloned
+}
+
+// cloneToolsConfig deep-copies the per-tool config block (tools.yaml),
+// including the slice/string fields each tool owns.
+func cloneToolsConfig(src ToolsConfig) ToolsConfig {
+	out := ToolsConfig{
+		ToolTimeout:   src.ToolTimeout,
+		ParallelTools: src.ParallelTools,
+	}
+	out.RecentChanges.Git.Auth = src.RecentChanges.Git.Auth
+	if src.RecentChanges.Git.Repos != nil {
+		out.RecentChanges.Git.Repos = make([]RecentChangesGitRepo, len(src.RecentChanges.Git.Repos))
+		copy(out.RecentChanges.Git.Repos, src.RecentChanges.Git.Repos)
+	}
+	if src.DescribeDependencies.Services != nil {
+		out.DescribeDependencies.Services = make([]ServiceDependency, len(src.DescribeDependencies.Services))
+		for i, s := range src.DescribeDependencies.Services {
+			out.DescribeDependencies.Services[i] = ServiceDependency{
+				Name:      s.Name,
+				DependsOn: append([]string(nil), s.DependsOn...),
+			}
+		}
+	}
+	return out
 }
 
 // cloneAgentAITaskConfig is a value-copy helper (all fields are
@@ -421,7 +446,9 @@ func cloneAgentAITaskConfig(src AgentAITaskConfig) AgentAITaskConfig {
 }
 
 // cloneAgentAIAnalyzeConfig copies the analyze override block (model
-// override only).
+// override only; the tool-loop knobs live on the shared tools block).
 func cloneAgentAIAnalyzeConfig(src AgentAIAnalyzeConfig) AgentAIAnalyzeConfig {
-	return AgentAIAnalyzeConfig{Model: src.Model}
+	return AgentAIAnalyzeConfig{
+		Model: src.Model,
+	}
 }

--- a/pkg/config/clone_config_test.go
+++ b/pkg/config/clone_config_test.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestCloneAgentAIAnalyzeConfig asserts the analyze model override is
+// carried into the cloned config so per-request overrides never lose the
+// operator's analyze model. (The tool-loop knobs tool_timeout and
+// parallel_tools now live on the shared tools block — see
+// TestCloneToolsConfig.)
+func TestCloneAgentAIAnalyzeConfig(t *testing.T) {
+	src := AgentAIAnalyzeConfig{
+		Model: "gpt-4o-mini",
+	}
+	got := cloneAgentAIAnalyzeConfig(src)
+	if got != src {
+		t.Fatalf("clone = %+v, want %+v", got, src)
+	}
+}
+
+// TestCloneConfigCarriesAnalyzeKnobs asserts the analyze model override
+// survives a full cloneConfig round-trip via the AI block.
+func TestCloneConfigCarriesAnalyzeKnobs(t *testing.T) {
+	src := &Config{}
+	src.Agent.AI.Analyze = AgentAIAnalyzeConfig{
+		Model: "claude-4-6-sonnet",
+	}
+	dst := cloneConfig(src)
+	if dst.Agent.AI.Analyze != src.Agent.AI.Analyze {
+		t.Fatalf("analyze block = %+v, want %+v", dst.Agent.AI.Analyze, src.Agent.AI.Analyze)
+	}
+}
+
+// TestCloneToolsConfig asserts the per-tool config (tools.yaml) is
+// carried into the clone — including the root-level tool-loop knobs, the
+// recent_changes git repos, and the describe_dependencies graph — so
+// per-request overrides never lose it. It also asserts the cloned slices
+// are independent from the source.
+func TestCloneToolsConfig(t *testing.T) {
+	src := ToolsConfig{
+		ToolTimeout:   "30s",
+		ParallelTools: true,
+		RecentChanges: RecentChangesToolConfig{
+			Git: RecentChangesGitConfig{
+				Auth: GitAuthConfig{Token: "global-token", SSHKeyPath: "/global/key"},
+				Repos: []RecentChangesGitRepo{
+					{URL: "https://github.com/acme/api.git", Branch: "main", Service: "api"},
+					{URL: "git@github.com:acme/web.git", Auth: GitAuthConfig{SSHKeyPath: "/web/key"}},
+				},
+			},
+		},
+		DescribeDependencies: DescribeDependenciesToolConfig{
+			Services: []ServiceDependency{
+				{Name: "web", DependsOn: []string{"api"}},
+				{Name: "api", DependsOn: []string{"database", "cache"}},
+			},
+		},
+	}
+	got := cloneToolsConfig(src)
+	if !reflect.DeepEqual(got, src) {
+		t.Fatalf("clone = %+v, want %+v", got, src)
+	}
+	// Mutating the clone must not affect the source (deep copy).
+	got.DescribeDependencies.Services[0].DependsOn[0] = "mutated"
+	if src.DescribeDependencies.Services[0].DependsOn[0] != "api" {
+		t.Fatal("clone shares the underlying DependsOn slice with the source")
+	}
+	got.RecentChanges.Git.Repos[0].URL = "mutated"
+	if src.RecentChanges.Git.Repos[0].URL != "https://github.com/acme/api.git" {
+		t.Fatal("clone shares the underlying Repos slice with the source")
+	}
+}
+
+// TestCloneConfigCarriesToolsConfig asserts the tools block survives a
+// full cloneConfig round-trip via the agent block.
+func TestCloneConfigCarriesToolsConfig(t *testing.T) {
+	src := &Config{}
+	src.Agent.Tools = ToolsConfig{
+		ToolTimeout:   "45s",
+		ParallelTools: true,
+		RecentChanges: RecentChangesToolConfig{
+			Git: RecentChangesGitConfig{
+				Repos: []RecentChangesGitRepo{{URL: "https://github.com/acme/api.git", Branch: "release"}},
+			},
+		},
+		DescribeDependencies: DescribeDependenciesToolConfig{
+			Services: []ServiceDependency{{Name: "api", DependsOn: []string{"database"}}},
+		},
+	}
+	dst := cloneConfig(src)
+	if !reflect.DeepEqual(dst.Agent.Tools, src.Agent.Tools) {
+		t.Fatalf("tools block = %+v, want %+v", dst.Agent.Tools, src.Agent.Tools)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -318,6 +318,22 @@ func LoadConfig(path string) error {
 			}
 			cfg.Agent.Sources = loaded
 		}
+
+		// Always load the sibling `tools.yaml` file (same directory as the
+		// main config). The file is optional — a missing file means tools
+		// needing external data config (e.g. `recent_changes`,
+		// `describe_dependencies`) degrade to a clean "nothing found".
+		// When present it REPLACES any inline `agent.tools`. The file's
+		// top-level key is `tools`.
+		toolsPath := filepath.Join(filepath.Dir(path), "tools.yaml")
+		if _, statErr := os.Stat(toolsPath); statErr == nil {
+			loaded, lerr := loadToolsFile(toolsPath)
+			if lerr != nil {
+				err = fmt.Errorf("failed to load tools file %s: %w", toolsPath, lerr)
+				return
+			}
+			cfg.Agent.Tools = loaded
+		}
 	})
 
 	return err
@@ -347,6 +363,35 @@ func loadAgentSourcesFile(path string) ([]AgentSourceConfig, error) {
 		return nil, fmt.Errorf("unmarshal: %w", err)
 	}
 	return wrapper.Sources, nil
+}
+
+// loadToolsFile reads an external YAML file containing a top-level
+// `tools:` map of per-tool configuration and returns the parsed config.
+// ${VAR} references are expanded against the process environment,
+// mirroring the main config loader.
+func loadToolsFile(path string) (ToolsConfig, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return ToolsConfig{}, fmt.Errorf("read: %w", err)
+	}
+	// Expand ${VAR} references across the whole document so values inside
+	// list items (e.g. recent_changes.git.repos[].url) are expanded too,
+	// not just top-level scalars.
+	expanded := os.ExpandEnv(string(raw))
+
+	v := viper.New()
+	v.SetConfigType("yaml")
+	if err := v.ReadConfig(strings.NewReader(expanded)); err != nil {
+		return ToolsConfig{}, fmt.Errorf("read: %w", err)
+	}
+
+	var wrapper struct {
+		Tools ToolsConfig `mapstructure:"tools"`
+	}
+	if err := v.Unmarshal(&wrapper); err != nil {
+		return ToolsConfig{}, fmt.Errorf("unmarshal: %w", err)
+	}
+	return wrapper.Tools, nil
 }
 
 func GetConfig() *Config {

--- a/pkg/config/tools.go
+++ b/pkg/config/tools.go
@@ -1,0 +1,127 @@
+package config
+
+// -----------------------------------------------------------------------------
+// Per-tool configuration (tools.yaml)
+// -----------------------------------------------------------------------------
+//
+// ToolsConfig is the home for every analyze-mode tool that needs external
+// data configuration. It is loaded from the optional sibling file
+// `tools.yaml` (same directory as the main config), mirroring the
+// `agent_sources.yaml` pattern. A missing file leaves every section zero,
+// which degrades the affected tool to a clean "nothing found" (or leaves
+// it unregistered) rather than an error.
+//
+// This is per-tool DATA config, never a registration allow-list: tools
+// are still registered in code via `analyzetools.Default`.
+
+// ToolsConfig groups the configurable analyze-mode tools by tool name.
+// It also carries the shared tool-loop knobs (tool_timeout,
+// parallel_tools) that apply to every analyze tool dispatch.
+type ToolsConfig struct {
+	// ToolTimeout caps how long a single tool dispatch may run before it
+	// is abandoned, e.g. "20s". A timeout surfaces as a tool error in the
+	// audit trace (not a hard failure) so one slow tool cannot consume
+	// the whole analysis budget. Empty, "0", or an unparseable value
+	// inherits the built-in default (20s).
+	ToolTimeout string `mapstructure:"tool_timeout"`
+	// ParallelTools controls whether multiple tool calls emitted in one
+	// model turn run concurrently. Off by default: tool dispatch is
+	// sequential, which keeps load on downstream sources predictable. The
+	// per-call audit trace is ordered deterministically regardless.
+	ParallelTools bool `mapstructure:"parallel_tools"`
+	// RecentChanges configures the `recent_changes` tool.
+	RecentChanges RecentChangesToolConfig `mapstructure:"recent_changes"`
+	// DescribeDependencies configures the `describe_dependencies` tool.
+	DescribeDependencies DescribeDependenciesToolConfig `mapstructure:"describe_dependencies"`
+}
+
+// DescribeDependenciesToolConfig configures the `describe_dependencies`
+// tool. It carries the optional service-dependency graph; an empty
+// `Services` list leaves the tool unregistered.
+type DescribeDependenciesToolConfig struct {
+	// Services is the operator-authored service-dependency graph. Each
+	// entry has a `name` and a `depends_on` list of upstream services;
+	// the reverse (downstream) edges are derived automatically at build
+	// time. Empty leaves the `describe_dependencies` tool unregistered.
+	Services []ServiceDependency `mapstructure:"services"`
+}
+
+// ServiceDependency is one node in the optional service-dependency graph.
+// `DependsOn` lists the upstream services this service relies on; the
+// reverse (downstream) edges are derived automatically.
+type ServiceDependency struct {
+	Name      string   `mapstructure:"name"`
+	DependsOn []string `mapstructure:"depends_on"`
+}
+
+// RecentChangesToolConfig configures the `recent_changes` tool. Today the
+// only supported change source is one or more remote git repositories.
+type RecentChangesToolConfig struct {
+	// Git points the tool at a set of remote git repositories' commit
+	// histories. An empty Repos list leaves the tool unregistered.
+	Git RecentChangesGitConfig `mapstructure:"git"`
+}
+
+// RecentChangesGitConfig points the `recent_changes` tool at one or more
+// remote git repositories. The tool shells out to the `git` binary (which
+// must be on PATH), so no Go git dependency is pulled in and no separate
+// event pipeline is required: the deploy/change record is the commit log
+// the team already keeps. Each repository is mirror-cloned into a local
+// cache on first use and fetched on subsequent lookups.
+//
+// Example (tools.yaml):
+//
+//	tools:
+//	  recent_changes:
+//	    git:
+//	      auth:                                      # global default auth
+//	        token: ${GIT_TOKEN}                      # HTTPS token / PAT
+//	        ssh_key_path: /home/versus/.ssh/id_ed25519
+//	      repos:
+//	        - url: https://github.com/acme/api.git   # remote clone URL
+//	          branch: main                           # optional; empty = default HEAD
+//	          service: api                           # optional; empty = derived from URL
+//	        - url: git@github.com:acme/web.git        # service auto-detected as "web"
+//	          auth:                                   # optional; overrides the global auth
+//	            ssh_key_path: /home/versus/.ssh/web_deploy
+//
+// An empty Repos list leaves the `recent_changes` tool unregistered.
+type RecentChangesGitConfig struct {
+	// Auth is the global default authentication applied to every repo that
+	// does not define its own. Empty means rely on the ambient git
+	// credentials (credential helper / default SSH keys).
+	Auth GitAuthConfig `mapstructure:"auth"`
+	// Repos is the set of remote git repositories to read commits from.
+	// Empty leaves the `recent_changes` tool unregistered.
+	Repos []RecentChangesGitRepo `mapstructure:"repos"`
+}
+
+// GitAuthConfig holds the credentials used to authenticate to a remote
+// git repository. Both fields are optional; an empty config relies on the
+// ambient git credentials (credential helper / default SSH keys).
+type GitAuthConfig struct {
+	// Token is an HTTPS access token / personal access token used for
+	// https:// remotes (sent via an Authorization header, never persisted
+	// to the local mirror's config).
+	Token string `mapstructure:"token"`
+	// SSHKeyPath is the path to a private SSH key used for ssh:// or
+	// scp-like (git@host:org/repo) remotes.
+	SSHKeyPath string `mapstructure:"ssh_key_path"`
+}
+
+// RecentChangesGitRepo is one remote git repository the change feed reads.
+type RecentChangesGitRepo struct {
+	// URL is the remote clone URL (https or scp-like git@host:org/repo).
+	// Empty entries are ignored.
+	URL string `mapstructure:"url"`
+	// Branch optionally pins which branch to read. Empty reads the
+	// repository's default HEAD.
+	Branch string `mapstructure:"branch"`
+	// Service maps every commit in this repository to a service name. When
+	// empty the service is auto-detected from the repository name in the
+	// URL (e.g. git@github.com:acme/web.git → "web").
+	Service string `mapstructure:"service"`
+	// Auth optionally overrides the global git auth for this repo. Empty
+	// fields fall back to the global default in RecentChangesGitConfig.
+	Auth GitAuthConfig `mapstructure:"auth"`
+}

--- a/pkg/config/tools_test.go
+++ b/pkg/config/tools_test.go
@@ -1,0 +1,132 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// TestLoadToolsFile asserts the tools.yaml loader parses the root-level
+// tool-loop knobs and the recent_changes git repos, expands ${VAR}
+// references, and round-trips the top-level `tools` key.
+func TestLoadToolsFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tools.yaml")
+	content := `tools:
+  tool_timeout: 30s
+  parallel_tools: true
+  recent_changes:
+    git:
+      auth:
+        token: ${TOOLS_TEST_TOKEN}
+        ssh_key_path: /etc/versus/global_key
+      repos:
+        - url: ${TOOLS_TEST_REPO}
+          branch: main
+          service: api
+        - url: git@github.com:acme/web.git
+          auth:
+            ssh_key_path: /etc/versus/web_key
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write tools.yaml: %v", err)
+	}
+	t.Setenv("TOOLS_TEST_REPO", "https://github.com/acme/api.git")
+	t.Setenv("TOOLS_TEST_TOKEN", "secret-token")
+
+	got, err := loadToolsFile(path)
+	if err != nil {
+		t.Fatalf("loadToolsFile: %v", err)
+	}
+	if got.ToolTimeout != "30s" {
+		t.Fatalf("tool_timeout = %q, want 30s", got.ToolTimeout)
+	}
+	if !got.ParallelTools {
+		t.Fatalf("parallel_tools = %v, want true", got.ParallelTools)
+	}
+	auth := got.RecentChanges.Git.Auth
+	if auth.Token != "secret-token" {
+		t.Fatalf("global auth.token = %q, want env-expanded secret-token", auth.Token)
+	}
+	if auth.SSHKeyPath != "/etc/versus/global_key" {
+		t.Fatalf("global auth.ssh_key_path = %q", auth.SSHKeyPath)
+	}
+	repos := got.RecentChanges.Git.Repos
+	if len(repos) != 2 {
+		t.Fatalf("got %d repos, want 2: %+v", len(repos), repos)
+	}
+	if repos[0].URL != "https://github.com/acme/api.git" {
+		t.Fatalf("repos[0].url = %q, want env-expanded api URL", repos[0].URL)
+	}
+	if repos[0].Branch != "main" || repos[0].Service != "api" {
+		t.Fatalf("repos[0] = %+v", repos[0])
+	}
+	if repos[1].URL != "git@github.com:acme/web.git" {
+		t.Fatalf("repos[1].url = %q", repos[1].URL)
+	}
+	if repos[1].Auth.SSHKeyPath != "/etc/versus/web_key" {
+		t.Fatalf("repos[1].auth.ssh_key_path = %q, want per-repo override", repos[1].Auth.SSHKeyPath)
+	}
+}
+
+// TestLoadToolsFile_DescribeDependencies asserts the tools.yaml loader
+// parses the describe_dependencies service-dependency graph.
+func TestLoadToolsFile_DescribeDependencies(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tools.yaml")
+	content := `tools:
+  describe_dependencies:
+    services:
+      - name: web
+        depends_on:
+          - api
+      - name: api
+        depends_on:
+          - database
+          - cache
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write tools.yaml: %v", err)
+	}
+	got, err := loadToolsFile(path)
+	if err != nil {
+		t.Fatalf("loadToolsFile: %v", err)
+	}
+	svcs := got.DescribeDependencies.Services
+	if len(svcs) != 2 {
+		t.Fatalf("got %d services, want 2: %+v", len(svcs), svcs)
+	}
+	if svcs[0].Name != "web" || len(svcs[0].DependsOn) != 1 || svcs[0].DependsOn[0] != "api" {
+		t.Fatalf("services[0] = %+v", svcs[0])
+	}
+	if svcs[1].Name != "api" || len(svcs[1].DependsOn) != 2 {
+		t.Fatalf("services[1] = %+v", svcs[1])
+	}
+}
+
+// TestLoadToolsFile_Empty asserts an empty/absent tools block parses to a
+// zero ToolsConfig without error.
+func TestLoadToolsFile_Empty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tools.yaml")
+	if err := os.WriteFile(path, []byte("tools: {}\n"), 0o600); err != nil {
+		t.Fatalf("write tools.yaml: %v", err)
+	}
+	got, err := loadToolsFile(path)
+	if err != nil {
+		t.Fatalf("loadToolsFile: %v", err)
+	}
+	if !reflect.DeepEqual(got, ToolsConfig{}) {
+		t.Fatalf("got = %+v, want zero ToolsConfig", got)
+	}
+}
+
+// TestLoadToolsFile_ReadError asserts a missing file surfaces a read
+// error (the caller only invokes the loader after a successful os.Stat).
+func TestLoadToolsFile_ReadError(t *testing.T) {
+	_, err := loadToolsFile(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+	if err == nil {
+		t.Fatal("expected error reading a missing tools.yaml")
+	}
+}

--- a/src/agent/ai-analyze-mode.md
+++ b/src/agent/ai-analyze-mode.md
@@ -42,8 +42,16 @@ agent:
     model: gpt-4o-mini    # shared default for detect + analyze
 
     analyze:
-      model: gpt-4o       # use a stronger model for deep dives
+      model: gpt-4o         # use a stronger model for deep dives
 ```
+
+The `analyze:` block only overrides the model. The tool-loop knobs
+(`tool_timeout`, `parallel_tools`) and all per-tool data live in a
+separate `tools.yaml` file — see [Tool configuration](#tool-configuration-toolsyaml)
+below.
+
+There is no `analyze.tools` allow-list: every tool wired in
+`analyzetools.Default(...)` is available to the agent.
 
 ---
 
@@ -65,6 +73,37 @@ The full tool-call trail (which tools ran, their arguments, and what
 they returned) is recorded with every analysis and shown in the
 **Tool calls** section of the analysis result, so you can audit exactly
 what the AI looked at.
+
+### Tool configuration
+
+Most tools need no configuration — they read state the agent already
+keeps (incidents, learned patterns, redacted logs) and work out of the
+box. A few tools read **external** data and need a small config block.
+That configuration lives in an optional `tools.yaml` file placed next to
+your main `config.yaml`; it is loaded automatically when present and
+supports `${VAR}` environment expansion.
+
+`tools.yaml` is per-tool **data** config, not a registration allow-list:
+tools are wired in code, so a missing block just means the tool has no
+data to read and degrades to a clean "nothing found". The root of the
+file carries the shared tool-loop knobs that apply to **every** tool:
+
+```yaml
+tools:
+  # Shared tool-loop knobs (apply to every analyze tool dispatch).
+  tool_timeout: 20s         # per-tool dispatch cap; empty/"0"/invalid = 20s
+  parallel_tools: false     # run tool calls in one model turn concurrently
+```
+
+| Knob | Default | Description |
+|---|---|---|
+| `tool_timeout` | `20s` | Caps a single tool dispatch so one slow lookup can't consume the 2-minute analysis budget. A timeout surfaces as a tool error in the **Tool calls** trail, never a hard failure. Empty, `0`, or unparseable inherits `20s`. |
+| `parallel_tools` | `false` | When the model emits several tool calls in one turn, run them concurrently instead of sequentially. The audit trail stays deterministically ordered either way. |
+
+Tools that read external data have their own block under `tools:`. Only
+two tools currently need one — see their per-tool YAML in
+[`describe_dependencies`](#describe_dependencies) and
+[`recent_changes`](#recent_changes) below.
 
 ### Available tools
 
@@ -99,23 +138,113 @@ its top learned patterns ranked by frequency.
 Use case: *"What does normal look like for this service, and which
 patterns dominate its logs?"*
 
+#### `get_related_logs`
+
+Fetches a redacted slice of recent raw log lines so the AI can read the
+actual signals around an incident instead of reasoning from summaries
+alone. Output is scrubbed by the same redactor used everywhere else, so
+secrets and PII never reach the model.
+
+- **Source / service filters** — optionally narrow to a single signal
+  source or service.
+- **Time window** — defaults to the last 15 minutes, up to a maximum of
+  1440 minutes (24 hours).
+- **Limit** — returns up to 50 lines by default, capped at 200.
+
+Use case: *"What were the surrounding log lines saying right before this
+incident fired?"*
+
+#### `describe_dependencies`
+
+Surfaces the upstream and downstream services of a given service from
+the service-dependency graph configured in `tools.yaml` and flags which
+of them have a recent incident, so the AI can reason about a cascading
+failure.
+
+- **Service** — the service whose dependencies to describe.
+- **Time window** — how far back to check each dependency for a recent
+  incident (`has_recent_incident`).
+
+**Configuration** — author the graph under
+`tools.describe_dependencies.services`. Each entry has a `name` and a
+`depends_on` list of upstream services; the reverse (downstream) edges
+are derived automatically. With an empty `services` list the tool is not
+registered.
+
+```yaml
+tools:
+  describe_dependencies:
+    services:
+      - name: web
+        depends_on:
+          - api
+      - name: api
+        depends_on:
+          - database
+          - cache
+```
+
+Use case: *"Is this failure originating here, or is an upstream
+dependency the real culprit?"*
+
+#### `recent_changes`
+
+Lists recent deploys and config changes from one or more **remote git
+repositories' commit histories** within a time window, newest first, so
+the AI can correlate an incident with what changed just before it. Each
+repository is mirror-cloned into a local cache on first use and fetched
+on later lookups; it shells out to the `git` binary, so no extra
+dependency or change pipeline is needed.
+
+- **Service filter** — optionally narrows to a single service
+  (case-insensitive exact match against the commit's repository service).
+- **Time window** — defaults to the last 120 minutes, up to a maximum
+  of 1440 minutes (24 hours).
+
+**Configuration** — list the repositories under
+`tools.recent_changes.git.repos`. Each entry has a `url` (https or
+scp-like `git@host:org/repo`), an optional `branch`, and an optional
+`service` (auto-detected from the repo name when omitted). Private
+remotes authenticate via an `auth` block (HTTPS `token` or
+`ssh_key_path`): a global `git.auth` default applies to every repo and
+any repo may override it, with empty fields falling back to the global
+default. With an empty `repos` list the tool is not registered.
+
+```yaml
+tools:
+  recent_changes:
+    git:
+      auth:                 # global default auth; per-repo auth overrides it
+        token: ${GIT_TOKEN}   # HTTPS PAT (empty = ambient git credentials)
+        ssh_key_path: ""      # SSH key path for ssh/scp-like remotes
+      repos:
+        - url: https://github.com/acme/api.git   # inherits global auth.token
+          branch: main                           # optional; empty = default HEAD
+          service: api                           # optional; empty = derived from URL
+        - url: git@github.com:acme/web.git        # service auto-detected as "web"
+          auth:                                  # optional; overrides git.auth
+            ssh_key_path: /home/versus/.ssh/web_deploy
+```
+
+Each commit in the window maps to a change record (`timestamp`, `service`,
+`kind: commit`, `summary`, short SHA `ref`). A window with no commits is a
+clean "nothing found" rather than an error.
+
+Use case: *"Did a deploy or config change in the last hour line up with
+when this incident started?"*
+
 ---
 
 ## Roadmap — more tools for deeper analysis
 
-The three tools above form the foundation of analyze mode. The tool
-interface is intentionally pluggable, and we plan to expand the
-catalog so the AI can investigate further without manual digging.
-Areas we're exploring for future tools include:
+The tools above form the foundation of analyze mode. The tool interface
+is intentionally pluggable, and we plan to expand the catalog so the AI
+can investigate further without manual digging. Areas we're exploring
+for future tools include:
 
-- **Deploy & change correlation** — line up an incident with recent
-  deployments, config changes, or feature-flag flips.
 - **Metric & dashboard lookups** — pull the relevant time-series
-  (error rate, latency, saturation) around the incident window.
-- **Cross-source log retrieval** — fetch a wider slice of raw logs
-  from the originating data source on demand.
-- **Dependency awareness** — surface upstream/downstream services that
-  could explain a cascading failure.
+  (error rate, latency, saturation) around the incident window. Metric
+  retrieval remains a later-phase item.
 
 As new tools ship they will appear automatically in the **Tool calls**
 audit trail, and no configuration change is required to benefit from
@@ -126,7 +255,7 @@ them.
 ## Key Features
 
 - **Non-intrusive**: Analyze mode never sends notifications or modifies systems.
-- **Read-only tools**: The AI uses tools like `recent_incidents`, `pattern_history`, and `describe_service` to gather context.
+- **Read-only tools**: The AI uses tools like `recent_incidents`, `pattern_history`, `describe_service`, `get_related_logs`, `describe_dependencies`, and `recent_changes` to gather context.
 - **Customizable**: Fine-tune the AI's behavior with optional settings.
 
 Analyze mode empowers you to make informed decisions by providing structured insights when you need them most.

--- a/src/agent/configuration.md
+++ b/src/agent/configuration.md
@@ -273,6 +273,167 @@ the two caps together.
 
 ---
 
+## `ai`
+
+The `agent.ai` block powers both the **detect** triage call and the
+on-demand **analyze** investigation. Shared keys apply to both; the
+`detect:` and `analyze:` overlays tune each task independently.
+
+```yaml
+agent:
+  ai:
+    enable: true
+    api_key: ${AGENT_AI_API_KEY}
+    model: gpt-4o-mini          # shared default for detect + analyze
+    temperature: 0.2
+    max_tokens: 1024
+    base_url: ""                # optional OpenAI-compatible endpoint
+
+    analyze:
+      model: gpt-4o             # stronger model for deep dives
+```
+
+> The tool-loop knobs `tool_timeout` and `parallel_tools` are **not** set
+> here — they live at the root of `tools.yaml` (see *Per-tool config*
+> below) because they apply to every analyze tool dispatch.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `enable` | bool | `false` | Turns on the AI SRE (detect triage + analyze). Env: `AGENT_AI_ENABLE`. |
+| `api_key` | string | — | API key for the model provider. Env: `AGENT_AI_API_KEY`. |
+| `model` | string | — | Shared default model for both tasks. Env: `AGENT_AI_MODEL`. |
+| `analyze.model` | string | inherits `model` | Optional stronger model just for analyze. |
+
+> The tool-loop knobs `tool_timeout` and `parallel_tools` moved to the
+> root of `tools.yaml` (see below) — they apply to every analyze tool
+> dispatch, not just one task.
+
+> **No tool allow-list.** There is no `analyze.tools` key. Every tool
+> wired in `analyzetools.Default(...)` is available to the analyze
+> agent. Two tools are conditionally registered: `describe_dependencies`
+> only when a service-dependency graph is configured in `tools.yaml`
+> (`tools.describe_dependencies.services`), and `recent_changes` only
+> when at least one git repository is configured in `tools.yaml`
+> (`tools.recent_changes.git.repos`).
+
+### Per-tool config (`tools.yaml`)
+
+Some analyze tools read external data. That **data** configuration lives
+in an optional `tools.yaml` file sitting next to your main config — it is
+loaded automatically when present and supports `${VAR}` expansion.
+`tools.yaml` is per-tool *data* config, **not** a registration allow-list
+(tools are still wired in code via `analyzetools.Default`). The root of
+`tools.yaml` also carries the shared tool-loop knobs.
+
+```yaml
+tools:
+  tool_timeout: 20s         # per-tool dispatch cap (applies to every tool)
+  parallel_tools: false     # run tool calls in one model turn concurrently
+
+  recent_changes:
+    git:
+      auth:                 # global default auth; per-repo auth overrides it
+        token: ${GIT_TOKEN}   # HTTPS PAT (empty = ambient credentials)
+        ssh_key_path: ""      # SSH key path for ssh/scp-like remotes
+      repos:                # one or more remote git repositories
+        - url: https://github.com/acme/api.git   # remote clone URL (required)
+          branch: main                           # optional; empty = default HEAD
+          service: api                           # optional; empty = derived from URL
+        - url: git@github.com:acme/web.git        # service auto-detected as "web"
+          auth:                                  # optional; overrides git.auth
+            ssh_key_path: /home/versus/.ssh/web_deploy
+  describe_dependencies:
+    services:               # optional service-dependency graph
+      - name: web
+        depends_on:
+          - api
+      - name: api
+        depends_on:
+          - database
+          - cache
+```
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `tool_timeout` | duration | `20s` | Per-tool dispatch cap. Empty, `0`, or an unparseable value inherits the `20s` default. A timeout surfaces as a tool error in the analysis trail, never a hard failure. |
+| `parallel_tools` | bool | `false` | When the model emits several tool calls in one turn, run them concurrently instead of sequentially. The audit trail stays deterministically ordered either way. |
+
+### Service-dependency graph (`describe_dependencies`)
+
+The `describe_dependencies` tool returns, for a given service, its
+upstream and downstream neighbours, each flagged with whether that
+neighbour also has a recent incident — helping the model reason about
+cascading failures. Author the graph under
+`tools.describe_dependencies.services` in `tools.yaml`: each entry has a
+`name` and a `depends_on` list of upstream services. Only `depends_on`
+(upstream edges) is authored by hand; the reverse edges
+(`depended_on_by`, downstream consumers) are derived automatically. An
+empty `services` list leaves the tool unregistered.
+
+### Change feed source (`recent_changes`)
+
+The `recent_changes` tool reads one or more **remote git repositories'
+commit histories** — the deploy/change record most teams already keep —
+to line an incident up against recent deploys and config changes. It
+shells out to the `git` binary (which must be on `PATH`), so no Go git
+dependency is added and no separate change pipeline is needed. Each
+configured repository is mirror-cloned into a local cache on first use and
+fetched on subsequent lookups, so the feed stays fresh on its own.
+
+Configure the repositories via `tools.yaml`
+(`tools.recent_changes.git.repos`). Each entry has a remote `url` (https
+or scp-like `git@host:org/repo`), an optional `branch`, and an optional
+`service`. When `service` is omitted it is auto-detected from the
+repository name in the URL (e.g. `git@github.com:acme/web.git` → `web`).
+With an empty `repos` list the tool is simply not registered.
+
+**Authentication.** Private remotes authenticate via an optional `auth`
+block. A global default under `tools.recent_changes.git.auth` applies to
+every repo, and any repo may override it field-by-field with its own
+`auth` (empty per-repo fields fall back to the global default; both empty
+= ambient git credentials / SSH agent). For HTTPS remotes set
+`auth.token` (a personal access token) — it is sent as an `Authorization`
+header and never written to the local clone. For SSH remotes set
+`auth.ssh_key_path` (passed through `GIT_SSH_COMMAND`). Each commit in the
+query window maps to a change record:
+
+| Field | Source |
+|---|---|
+| `timestamp` | Committer date (RFC3339). |
+| `service` | The repository's configured `service`, or the name auto-detected from its URL. Used by the optional service filter. |
+| `kind` | Always `commit`. |
+| `summary` | Commit subject line. |
+| `ref` | Short (7-char) commit SHA. |
+
+A missing window or no commits is a clean "nothing found", so the analysis
+proceeds without it.
+
+#### Worked example
+
+A production setup using a cheap model for high-volume detect triage and
+a stronger model with bounded, concurrent tool calls for deep dives:
+
+```yaml
+agent:
+  enable: true
+  mode: detect
+  ai:
+    enable: true
+    api_key: ${AGENT_AI_API_KEY}
+    model: gpt-4o-mini          # cheap, fast — used for every detect call
+    analyze:
+      model: gpt-4o             # reserved for the on-demand analyze action
+      tool_timeout: 10s         # no single lookup may stall the 2-min budget
+      parallel_tools: true      # fan out multi-tool turns for faster analyses
+```
+
+With `parallel_tools: true`, an analyze turn that calls
+`recent_incidents`, `describe_service`, and `describe_dependencies`
+together runs all three at once; each is still individually capped at
+`10s` by `tool_timeout`.
+
+---
+
 ## Admin UI
 
 Everything the agent records is reviewed through the admin UI,


### PR DESCRIPTION
<!--
Thanks for the contribution! Please make sure you have read CONTRIBUTING.md
and that your branch passes `go test ./...`, `go vet ./...`, and `gofmt -w .`.
-->

## What does this PR do?

Implement the three new read-only investigation tools for the AI SRE
analyze agent, plus shared tool-dispatch infrastructure.

## Why?

E7 — get_related_logs:
- SignalReader bridge (pkg/agent/analyze_adapter.go) exposes sources
  to tools without import cycles
- Pulls redacted log lines within a time window (default 15m, cap 1440m)
- Filters by source/service, caps at 200 lines

E8 — recent_changes (git change feed):
- Introduce tools.yaml sibling config (per-tool DATA config, not allow-list)
- Mirror-clone remote git repos into OS-temp cache, fetch on reuse
- Global + per-repo auth: HTTPS token via http.extraHeader (never
  persisted), SSH key via GIT_SSH_COMMAND
- Window default 120m, cap 1440m, newest-first

E9 — describe_dependencies:
- Service-dependency graph authored in tools.yaml
- Returns upstream/downstream neighbours with has_recent_incident flag
- Reverse edges (depended_on_by) derived automatically

E10 — tool-loop knobs & docs:
- tool_timeout (default 20s) caps each tool dispatch; surfaces as tool
  error, never hard failure
- parallel_tools (default false) for concurrent multi-tool turns
- Both knobs live at tools.yaml root (not on analyze block)
- Updated ai-analyze-mode.md with per-tool config YAML examples
- Updated configuration.md, AGENTS.md, copilot-instructions.md

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [x] Breaking change (config / API / default behavior)
- [ ] Documentation only
- [ ] Refactor (no functional change)
- [ ] CI / build / chore

## Checklist

- [x] `go test ./...` passes locally
- [x] `go vet ./...` is clean
- [x] Code is `gofmt`'d
- [x] Added or updated tests for the change
- [x] Updated user-facing docs under `src/` if behavior changes
- [x] Updated `ROADMAP.md` if this closes a roadmap item
- [x] No secrets, tokens, or webhook URLs introduced in source / YAML
- [x] No new third-party dependencies (or justified in the description)
