### PR TITLE
feat(oncall): add ServiceNow and incident.io on-call providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,6 @@ Incidents reach Versus two ways, and both are handled by the same notification, 
 
 Whichever source raises it, an incident is templated, fanned out to every channel you enable, and escalated to on-call if it isn't acknowledged in time.
 
-## Table of Contents
-- [Features](#features)
-- [How Versus Creates Incidents](#how-versus-creates-incidents)
-- [Getting Started](#get-started)
-- [AI Agent](#ai-agent)
-- [Webhook Alerts](#webhook-alerts)
-- [Admin Dashboard](https://versuscontrol.github.io/versus-incident/configuration/admin-ui.html)
-- [Development Custom Templates](#development-custom-templates)
-- [On-Call](#on-call)
-- [Configuration](#complete-configuration)
-- [Roadmap](#roadmap)
-- [Contributing](#contributing)
-- [License](#license)
-
 ## Features
 
 - 🤖 **AI SRE Agent** *(Beta)*: An AI agent that reads your logs, learns what normal looks like, and automatically opens an incident only when something new and unexpected appears.
@@ -48,6 +34,18 @@ Whichever source raises it, an incident is templated, fanned out to every channe
 - 📞 **On-Call**: On-Call integrations with AWS Incident Manager and PagerDuty
 
 ![Versus](src/docs/images/versus-architecture.png)
+
+## Table of Contents
+- [Getting Started](#get-started)
+- [AI Agent](#ai-agent)
+- [Webhook Alerts](#webhook-alerts)
+- [Admin Dashboard](https://versuscontrol.github.io/versus-incident/configuration/admin-ui.html)
+- [Development Custom Templates](#development-custom-templates)
+- [On-Call](#on-call)
+- [Configuration](#complete-configuration)
+- [Roadmap](#roadmap)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Get Started
 
@@ -103,6 +101,8 @@ Versus listens on port 3000 by default and exposes:
 
 - `POST /api/incidents` — webhook endpoint for monitoring tools.
 - `GET  /` — the embedded **admin dashboard**, open <http://localhost:3000/> in your browser. For the full UI walkthrough and the build/watch scripts, see [Admin Dashboard](https://versuscontrol.github.io/versus-incident/configuration/admin-ui.html).
+
+> **You can use both.** The AI agent and webhook alerts are not mutually exclusive — run them together and every incident, whether auto-detected or forwarded from your tools, flows through the same channels, templates, and on-call logic.
 
 ## AI Agent
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -100,7 +100,7 @@ oncall:
   initialized_only: false  # Initialize on-call feature but don't enable by default, requires 'oncall_enable=true' in query parameters
   enable: false # Use this to enable or disable on-call for all alerts
   wait_minutes: 3 # If you set it to 0, it means there's no need to check for an acknowledgment, and the on-call will trigger immediately
-  provider: aws_incident_manager # Valid values: "aws_incident_manager" or "pagerduty"
+  provider: aws_incident_manager # Valid values: "aws_incident_manager", "pagerduty", "servicenow" or "incident_io"
 
   aws_incident_manager: # Used when provider is "aws_incident_manager"
     response_plan_arn: ${AWS_INCIDENT_MANAGER_RESPONSE_PLAN_ARN}
@@ -115,6 +115,24 @@ oncall:
       infra: ${PAGERDUTY_OTHER_ROUTING_KEY_INFRA}
       app: ${PAGERDUTY_OTHER_ROUTING_KEY_APP}
       db: ${PAGERDUTY_OTHER_ROUTING_KEY_DB}
+
+  servicenow: # Used when provider is "servicenow"
+    instance_url: ${SERVICENOW_INSTANCE_URL} # eg https://dev12345.service-now.com (REQUIRED)
+    username: ${SERVICENOW_USERNAME} # REQUIRED
+    password: ${SERVICENOW_PASSWORD} # REQUIRED
+    table: incident # ServiceNow table to create records in; defaults to "incident"
+    other_instance_urls: # Optional: Override the default instance using query parameters, eg /api/incidents?servicenow_other_instance=infra
+      infra: ${SERVICENOW_OTHER_INSTANCE_URL_INFRA}
+      app: ${SERVICENOW_OTHER_INSTANCE_URL_APP}
+      db: ${SERVICENOW_OTHER_INSTANCE_URL_DB}
+
+  incident_io: # Used when provider is "incident_io"
+    api_key: ${INCIDENTIO_API_KEY} # Bearer API key for the HTTP alert source (REQUIRED)
+    alert_source_config_id: ${INCIDENTIO_ALERT_SOURCE_CONFIG_ID} # HTTP alert source config ID (REQUIRED)
+    other_alert_source_config_ids: # Optional: Override the default alert source using query parameters, eg /api/incidents?incidentio_other_alert_source=infra
+      infra: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_INFRA}
+      app: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_APP}
+      db: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_DB}
 
 redis: # Required for on-call functionality
   insecure_skip_verify: true # dev only

--- a/helm/versus-incident/templates/configmap.yaml
+++ b/helm/versus-incident/templates/configmap.yaml
@@ -143,6 +143,32 @@ data:
           {{- end }}
         {{- end }}
       {{- end }}
+
+      {{- if eq .Values.oncall.provider "servicenow" }}
+      servicenow:
+        instance_url: ${SERVICENOW_INSTANCE_URL}
+        username: ${SERVICENOW_USERNAME}
+        password: ${SERVICENOW_PASSWORD}
+        table: {{ .Values.oncall.servicenow.table | default "incident" }}
+        {{- if .Values.oncall.servicenow.otherInstanceUrls }}
+        other_instance_urls:
+          {{- range $key, $val := .Values.oncall.servicenow.otherInstanceUrls }}
+          {{ $key }}: ${SERVICENOW_OTHER_INSTANCE_URL_{{ $key | upper }}}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+
+      {{- if eq .Values.oncall.provider "incident_io" }}
+      incident_io:
+        api_key: ${INCIDENTIO_API_KEY}
+        alert_source_config_id: ${INCIDENTIO_ALERT_SOURCE_CONFIG_ID}
+        {{- if .Values.oncall.incidentIo.otherAlertSourceConfigIds }}
+        other_alert_source_config_ids:
+          {{- range $key, $val := .Values.oncall.incidentIo.otherAlertSourceConfigIds }}
+          {{ $key }}: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_{{ $key | upper }}}
+          {{- end }}
+        {{- end }}
+      {{- end }}
     {{- end }}
 
     # Redis Configuration Section - required for on-call functionality

--- a/helm/versus-incident/templates/deployment.yaml
+++ b/helm/versus-incident/templates/deployment.yaml
@@ -300,6 +300,51 @@ spec:
                   key: pagerduty_other_routing_key_{{ $key }}
             {{- end }}
             {{- end }}
+
+            {{- if eq .Values.oncall.provider "servicenow" }}
+            - name: SERVICENOW_INSTANCE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "versus-incident.fullname" . }}-secrets
+                  key: servicenow_instance_url
+            - name: SERVICENOW_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "versus-incident.fullname" . }}-secrets
+                  key: servicenow_username
+            - name: SERVICENOW_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "versus-incident.fullname" . }}-secrets
+                  key: servicenow_password
+            {{- range $key, $val := .Values.oncall.servicenow.otherInstanceUrls }}
+            - name: SERVICENOW_OTHER_INSTANCE_URL_{{ $key | upper }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "versus-incident.fullname" . }}-secrets
+                  key: servicenow_other_instance_url_{{ $key }}
+            {{- end }}
+            {{- end }}
+
+            {{- if eq .Values.oncall.provider "incident_io" }}
+            - name: INCIDENTIO_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "versus-incident.fullname" . }}-secrets
+                  key: incidentio_api_key
+            - name: INCIDENTIO_ALERT_SOURCE_CONFIG_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "versus-incident.fullname" . }}-secrets
+                  key: incidentio_alert_source_config_id
+            {{- range $key, $val := .Values.oncall.incidentIo.otherAlertSourceConfigIds }}
+            - name: INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_{{ $key | upper }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "versus-incident.fullname" . }}-secrets
+                  key: incidentio_other_alert_source_config_id_{{ $key }}
+            {{- end }}
+            {{- end }}
             
             {{- /* Redis configuration - used for on-call functionality */}}
             - name: REDIS_HOST

--- a/helm/versus-incident/templates/secret.yaml
+++ b/helm/versus-incident/templates/secret.yaml
@@ -93,6 +93,23 @@ data:
   pagerduty_other_routing_key_{{ $key }}: {{ $val | b64enc | quote }}
   {{- end }}
   {{- end }}
+
+  {{- if eq .Values.oncall.provider "servicenow" }}
+  servicenow_instance_url: {{ .Values.oncall.servicenow.instanceUrl | b64enc | quote }}
+  servicenow_username: {{ .Values.oncall.servicenow.username | b64enc | quote }}
+  servicenow_password: {{ .Values.oncall.servicenow.password | b64enc | quote }}
+  {{- range $key, $val := .Values.oncall.servicenow.otherInstanceUrls }}
+  servicenow_other_instance_url_{{ $key }}: {{ $val | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+
+  {{- if eq .Values.oncall.provider "incident_io" }}
+  incidentio_api_key: {{ .Values.oncall.incidentIo.apiKey | b64enc | quote }}
+  incidentio_alert_source_config_id: {{ .Values.oncall.incidentIo.alertSourceConfigId | b64enc | quote }}
+  {{- range $key, $val := .Values.oncall.incidentIo.otherAlertSourceConfigIds }}
+  incidentio_other_alert_source_config_id_{{ $key }}: {{ $val | b64enc | quote }}
+  {{- end }}
+  {{- end }}
   
   {{- if not .Values.redis.enabled }}
   redis_host: {{ .Values.externalRedis.host | b64enc | quote }}

--- a/helm/versus-incident/values.yaml
+++ b/helm/versus-incident/values.yaml
@@ -278,6 +278,18 @@ oncall:
     routingKey: ""
     otherRoutingKeys: {}
 
+  servicenow:
+    instanceUrl: ""
+    username: ""
+    password: ""
+    table: "incident"
+    otherInstanceUrls: {}
+
+  incidentIo:
+    apiKey: ""
+    alertSourceConfigId: ""
+    otherAlertSourceConfigIds: {}
+
 # Redis configuration
 #
 # Redis is REQUIRED only when on-call is enabled (oncall.enable=true or

--- a/pkg/common/factory_oncall.go
+++ b/pkg/common/factory_oncall.go
@@ -38,6 +38,32 @@ func (f *OnCallProviderFactory) CreateProvider() (core.OnCallProvider, error) {
 		}
 
 		return NewPagerDutyProvider(f.cfg.OnCall.PagerDuty.RoutingKey), nil
+	} else if f.cfg.OnCall.Provider == "servicenow" {
+		if f.cfg.OnCall.ServiceNow.InstanceURL == "" {
+			return nil, fmt.Errorf("missing Instance URL configuration for ServiceNow")
+		}
+		if f.cfg.OnCall.ServiceNow.Username == "" || f.cfg.OnCall.ServiceNow.Password == "" {
+			return nil, fmt.Errorf("missing Username/Password configuration for ServiceNow")
+		}
+
+		return NewServiceNowProvider(
+			f.cfg.OnCall.ServiceNow.InstanceURL,
+			f.cfg.OnCall.ServiceNow.Username,
+			f.cfg.OnCall.ServiceNow.Password,
+			f.cfg.OnCall.ServiceNow.Table,
+		), nil
+	} else if f.cfg.OnCall.Provider == "incident_io" {
+		if f.cfg.OnCall.Incidentio.APIKey == "" {
+			return nil, fmt.Errorf("missing API Key configuration for incident.io")
+		}
+		if f.cfg.OnCall.Incidentio.AlertSourceConfigID == "" {
+			return nil, fmt.Errorf("missing Alert Source Config ID configuration for incident.io")
+		}
+
+		return NewIncidentioProvider(
+			f.cfg.OnCall.Incidentio.APIKey,
+			f.cfg.OnCall.Incidentio.AlertSourceConfigID,
+		), nil
 	}
 
 	return nil, fmt.Errorf("unsupported on-call provider: %s", f.cfg.OnCall.Provider)

--- a/pkg/common/factory_oncall_test.go
+++ b/pkg/common/factory_oncall_test.go
@@ -1,0 +1,114 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/VersusControl/versus-incident/pkg/config"
+)
+
+func newFactoryForProvider(oncall config.OnCallConfig) *OnCallProviderFactory {
+	cfg := &config.Config{
+		OnCall: oncall,
+	}
+	return NewOnCallProviderFactory(cfg, nil)
+}
+
+func TestCreateProvider_ServiceNow(t *testing.T) {
+	factory := newFactoryForProvider(config.OnCallConfig{
+		Provider: "servicenow",
+		ServiceNow: config.ServiceNowConfig{
+			InstanceURL: "https://dev12345.service-now.com",
+			Username:    "admin",
+			Password:    "s3cret",
+		},
+	})
+
+	provider, err := factory.CreateProvider()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if _, ok := provider.(*ServiceNowProvider); !ok {
+		t.Errorf("expected *ServiceNowProvider, got %T", provider)
+	}
+}
+
+func TestCreateProvider_ServiceNow_MissingInstanceURL(t *testing.T) {
+	factory := newFactoryForProvider(config.OnCallConfig{
+		Provider: "servicenow",
+		ServiceNow: config.ServiceNowConfig{
+			Username: "admin",
+			Password: "s3cret",
+		},
+	})
+
+	if _, err := factory.CreateProvider(); err == nil {
+		t.Fatalf("expected error for missing instance URL, got nil")
+	}
+}
+
+func TestCreateProvider_ServiceNow_MissingCredentials(t *testing.T) {
+	factory := newFactoryForProvider(config.OnCallConfig{
+		Provider: "servicenow",
+		ServiceNow: config.ServiceNowConfig{
+			InstanceURL: "https://dev12345.service-now.com",
+		},
+	})
+
+	if _, err := factory.CreateProvider(); err == nil {
+		t.Fatalf("expected error for missing credentials, got nil")
+	}
+}
+
+func TestCreateProvider_Incidentio(t *testing.T) {
+	factory := newFactoryForProvider(config.OnCallConfig{
+		Provider: "incident_io",
+		Incidentio: config.IncidentioConfig{
+			APIKey:              "test-key",
+			AlertSourceConfigID: "src-123",
+		},
+	})
+
+	provider, err := factory.CreateProvider()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if _, ok := provider.(*IncidentioProvider); !ok {
+		t.Errorf("expected *IncidentioProvider, got %T", provider)
+	}
+}
+
+func TestCreateProvider_Incidentio_MissingAPIKey(t *testing.T) {
+	factory := newFactoryForProvider(config.OnCallConfig{
+		Provider: "incident_io",
+		Incidentio: config.IncidentioConfig{
+			AlertSourceConfigID: "src-123",
+		},
+	})
+
+	if _, err := factory.CreateProvider(); err == nil {
+		t.Fatalf("expected error for missing API key, got nil")
+	}
+}
+
+func TestCreateProvider_Incidentio_MissingAlertSource(t *testing.T) {
+	factory := newFactoryForProvider(config.OnCallConfig{
+		Provider: "incident_io",
+		Incidentio: config.IncidentioConfig{
+			APIKey: "test-key",
+		},
+	})
+
+	if _, err := factory.CreateProvider(); err == nil {
+		t.Fatalf("expected error for missing alert source config id, got nil")
+	}
+}
+
+func TestCreateProvider_Unsupported(t *testing.T) {
+	factory := newFactoryForProvider(config.OnCallConfig{
+		Provider: "does_not_exist",
+	})
+
+	if _, err := factory.CreateProvider(); err == nil {
+		t.Fatalf("expected error for unsupported provider, got nil")
+	}
+}

--- a/pkg/common/incidentio.go
+++ b/pkg/common/incidentio.go
@@ -1,0 +1,105 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/VersusControl/versus-incident/pkg/config"
+	"github.com/VersusControl/versus-incident/pkg/utils"
+)
+
+// incidentioAlertEventsBaseURL is the base URL of the incident.io HTTP alert
+// events endpoint. The alert source config ID is appended as the final path
+// segment.
+const incidentioAlertEventsBaseURL = "https://api.incident.io/v2/alert_events/http"
+
+// IncidentioAlertEvent is the JSON payload posted to the incident.io HTTP alert
+// events endpoint.
+type IncidentioAlertEvent struct {
+	Title            string            `json:"title"`
+	Description      string            `json:"description,omitempty"`
+	DeduplicationKey string            `json:"deduplication_key"`
+	Status           string            `json:"status"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+}
+
+// IncidentioProvider implements the OnCallProvider interface for incident.io.
+type IncidentioProvider struct {
+	apiKey              string
+	alertSourceConfigID string
+	baseURL             string
+	httpClient          *http.Client
+}
+
+// NewIncidentioProvider creates a new incident.io provider.
+func NewIncidentioProvider(apiKey, alertSourceConfigID string) *IncidentioProvider {
+	return &IncidentioProvider{
+		apiKey:              apiKey,
+		alertSourceConfigID: alertSourceConfigID,
+		baseURL:             incidentioAlertEventsBaseURL,
+		// Use the shared HTTP client (TLS verification on, no proxy).
+		httpClient: utils.CreateHTTPClient(config.ProxyConfig{}, false),
+	}
+}
+
+// TriggerOnCall creates an alert in incident.io using the HTTP alert events API.
+func (p *IncidentioProvider) TriggerOnCall(ctx context.Context, incidentID string, cfg *config.OnCallConfig) error {
+	// Use the override config if provided, otherwise use the defaults.
+	apiKey := p.apiKey
+	alertSourceConfigID := p.alertSourceConfigID
+
+	if cfg != nil {
+		if cfg.Incidentio.APIKey != "" {
+			apiKey = cfg.Incidentio.APIKey
+		}
+		if cfg.Incidentio.AlertSourceConfigID != "" {
+			alertSourceConfigID = cfg.Incidentio.AlertSourceConfigID
+		}
+	}
+
+	event := IncidentioAlertEvent{
+		Title:            "Incident " + incidentID,
+		Description:      "Escalated by Versus Incident",
+		DeduplicationKey: incidentID,
+		Status:           "firing",
+		Metadata: map[string]string{
+			"incident_id": incidentID,
+		},
+	}
+
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("failed to marshal incident.io alert event: %v", err)
+	}
+
+	baseURL := p.baseURL
+	if baseURL == "" {
+		baseURL = incidentioAlertEventsBaseURL
+	}
+	url := fmt.Sprintf("%s/%s", baseURL, alertSourceConfigID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create incident.io request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send incident.io request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("incident.io API returned non-success status: %d", resp.StatusCode)
+	}
+
+	log.Printf("incident.io alert created for incident: %s", incidentID)
+	return nil
+}

--- a/pkg/common/incidentio_test.go
+++ b/pkg/common/incidentio_test.go
@@ -1,0 +1,99 @@
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/VersusControl/versus-incident/pkg/config"
+)
+
+func TestIncidentioProvider_TriggerOnCall_HappyPath(t *testing.T) {
+	var gotPath string
+	var gotAuth string
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	provider := NewIncidentioProvider("test-api-key", "src-123")
+	provider.baseURL = server.URL
+
+	if err := provider.TriggerOnCall(context.Background(), "INC-123", nil); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if gotPath != "/src-123" {
+		t.Errorf("expected alert source config id in path, got %s", gotPath)
+	}
+	if gotAuth != "Bearer test-api-key" {
+		t.Errorf("expected Bearer auth header, got %q", gotAuth)
+	}
+	if gotBody["deduplication_key"] != "INC-123" {
+		t.Errorf("expected deduplication_key mapped from incidentID, got %v", gotBody["deduplication_key"])
+	}
+	if gotBody["title"] != "Incident INC-123" {
+		t.Errorf("expected title mapped from incidentID, got %v", gotBody["title"])
+	}
+}
+
+func TestIncidentioProvider_TriggerOnCall_NonSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	provider := NewIncidentioProvider("bad-key", "src-123")
+	provider.baseURL = server.URL
+
+	err := provider.TriggerOnCall(context.Background(), "INC-456", nil)
+	if err == nil {
+		t.Fatalf("expected an error for non-2xx response, got nil")
+	}
+	if !strings.Contains(err.Error(), "non-success status") {
+		t.Errorf("expected non-success status error, got: %v", err)
+	}
+}
+
+func TestIncidentioProvider_TriggerOnCall_ConfigOverride(t *testing.T) {
+	var gotPath string
+	var gotAuth string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	provider := NewIncidentioProvider("default-key", "default-src")
+	provider.baseURL = server.URL
+
+	cfg := &config.OnCallConfig{
+		Incidentio: config.IncidentioConfig{
+			APIKey:              "override-key",
+			AlertSourceConfigID: "override-src",
+		},
+	}
+
+	if err := provider.TriggerOnCall(context.Background(), "INC-777", cfg); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if gotPath != "/override-src" {
+		t.Errorf("expected override alert source id in path, got %s", gotPath)
+	}
+	if gotAuth != "Bearer override-key" {
+		t.Errorf("expected override Bearer auth header, got %q", gotAuth)
+	}
+}

--- a/pkg/common/servicenow.go
+++ b/pkg/common/servicenow.go
@@ -1,0 +1,110 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/VersusControl/versus-incident/pkg/config"
+	"github.com/VersusControl/versus-incident/pkg/utils"
+)
+
+// ServiceNowRecord is the JSON payload posted to the ServiceNow Table API.
+// incidentID is mapped onto both the human-readable short_description and the
+// correlation_id used by ServiceNow to de-duplicate inbound events.
+type ServiceNowRecord struct {
+	ShortDescription string `json:"short_description"`
+	CorrelationID    string `json:"correlation_id"`
+}
+
+// ServiceNowProvider implements the OnCallProvider interface for ServiceNow.
+type ServiceNowProvider struct {
+	instanceURL string
+	username    string
+	password    string
+	table       string
+	httpClient  *http.Client
+}
+
+// NewServiceNowProvider creates a new ServiceNow provider. An empty table
+// defaults to "incident".
+func NewServiceNowProvider(instanceURL, username, password, table string) *ServiceNowProvider {
+	if table == "" {
+		table = "incident"
+	}
+
+	return &ServiceNowProvider{
+		instanceURL: instanceURL,
+		username:    username,
+		password:    password,
+		table:       table,
+		// Use the shared HTTP client (TLS verification on, no proxy).
+		httpClient: utils.CreateHTTPClient(config.ProxyConfig{}, false),
+	}
+}
+
+// TriggerOnCall creates a record in ServiceNow using the Table API.
+func (p *ServiceNowProvider) TriggerOnCall(ctx context.Context, incidentID string, cfg *config.OnCallConfig) error {
+	// Use the override config if provided, otherwise use the defaults.
+	instanceURL := p.instanceURL
+	username := p.username
+	password := p.password
+	table := p.table
+
+	if cfg != nil {
+		if cfg.ServiceNow.InstanceURL != "" {
+			instanceURL = cfg.ServiceNow.InstanceURL
+		}
+		if cfg.ServiceNow.Username != "" {
+			username = cfg.ServiceNow.Username
+		}
+		if cfg.ServiceNow.Password != "" {
+			password = cfg.ServiceNow.Password
+		}
+		if cfg.ServiceNow.Table != "" {
+			table = cfg.ServiceNow.Table
+		}
+	}
+
+	if table == "" {
+		table = "incident"
+	}
+
+	record := ServiceNowRecord{
+		ShortDescription: "Incident " + incidentID,
+		CorrelationID:    incidentID,
+	}
+
+	payload, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("failed to marshal ServiceNow record: %v", err)
+	}
+
+	url := fmt.Sprintf("%s/api/now/table/%s", strings.TrimRight(instanceURL, "/"), table)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create ServiceNow request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.SetBasicAuth(username, password)
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send ServiceNow request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("ServiceNow API returned non-success status: %d", resp.StatusCode)
+	}
+
+	log.Printf("ServiceNow record created for incident: %s", incidentID)
+	return nil
+}

--- a/pkg/common/servicenow_test.go
+++ b/pkg/common/servicenow_test.go
@@ -1,0 +1,117 @@
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/VersusControl/versus-incident/pkg/config"
+)
+
+func TestServiceNowProvider_TriggerOnCall_HappyPath(t *testing.T) {
+	var gotPath string
+	var gotAuthOK bool
+	var gotBody map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+
+		username, password, ok := r.BasicAuth()
+		gotAuthOK = ok && username == "admin" && password == "s3cret"
+
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"result":{}}`))
+	}))
+	defer server.Close()
+
+	provider := NewServiceNowProvider(server.URL, "admin", "s3cret", "")
+
+	if err := provider.TriggerOnCall(context.Background(), "INC-123", nil); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if gotPath != "/api/now/table/incident" {
+		t.Errorf("expected path /api/now/table/incident, got %s", gotPath)
+	}
+	if !gotAuthOK {
+		t.Errorf("expected valid HTTP Basic auth header")
+	}
+	if gotBody["short_description"] != "Incident INC-123" {
+		t.Errorf("expected short_description mapped from incidentID, got %q", gotBody["short_description"])
+	}
+	if gotBody["correlation_id"] != "INC-123" {
+		t.Errorf("expected correlation_id mapped from incidentID, got %q", gotBody["correlation_id"])
+	}
+}
+
+func TestServiceNowProvider_TriggerOnCall_CustomTable(t *testing.T) {
+	var gotPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	provider := NewServiceNowProvider(server.URL, "admin", "s3cret", "sn_si_incident")
+
+	if err := provider.TriggerOnCall(context.Background(), "INC-999", nil); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if gotPath != "/api/now/table/sn_si_incident" {
+		t.Errorf("expected custom table path, got %s", gotPath)
+	}
+}
+
+func TestServiceNowProvider_TriggerOnCall_NonSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	provider := NewServiceNowProvider(server.URL, "admin", "wrong", "")
+
+	err := provider.TriggerOnCall(context.Background(), "INC-456", nil)
+	if err == nil {
+		t.Fatalf("expected an error for non-2xx response, got nil")
+	}
+	if !strings.Contains(err.Error(), "non-success status") {
+		t.Errorf("expected non-success status error, got: %v", err)
+	}
+}
+
+func TestServiceNowProvider_TriggerOnCall_ConfigOverride(t *testing.T) {
+	var gotPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	// Provider defaults point at an unreachable instance; the per-request
+	// config override must redirect to the test server.
+	provider := NewServiceNowProvider("https://unused.example", "default", "default", "")
+
+	cfg := &config.OnCallConfig{
+		ServiceNow: config.ServiceNowConfig{
+			InstanceURL: server.URL,
+			Username:    "admin",
+			Password:    "s3cret",
+			Table:       "incident",
+		},
+	}
+
+	if err := provider.TriggerOnCall(context.Background(), "INC-777", cfg); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if gotPath != "/api/now/table/incident" {
+		t.Errorf("expected override path, got %s", gotPath)
+	}
+}

--- a/pkg/config/clone_config.go
+++ b/pkg/config/clone_config.go
@@ -203,6 +203,8 @@ func cloneOnCallConfig(src OnCallConfig) OnCallConfig {
 		Provider:           src.Provider,
 		AwsIncidentManager: cloneAwsIncidentManagerConfig(src.AwsIncidentManager),
 		PagerDuty:          clonePagerDutyConfig(src.PagerDuty),
+		ServiceNow:         cloneServiceNowConfig(src.ServiceNow),
+		Incidentio:         cloneIncidentioConfig(src.Incidentio),
 	}
 }
 
@@ -237,6 +239,44 @@ func clonePagerDutyConfig(src PagerDutyConfig) PagerDutyConfig {
 	return PagerDutyConfig{
 		RoutingKey:       src.RoutingKey,
 		OtherRoutingKeys: otherRoutingKeysCopy,
+	}
+}
+
+// Helper function to deep clone the ServiceNowConfig struct
+func cloneServiceNowConfig(src ServiceNowConfig) ServiceNowConfig {
+	// Create a copy of OtherInstanceURLs map if it exists
+	var otherInstanceURLsCopy map[string]string
+	if src.OtherInstanceURLs != nil {
+		otherInstanceURLsCopy = make(map[string]string)
+		for k, v := range src.OtherInstanceURLs {
+			otherInstanceURLsCopy[k] = v
+		}
+	}
+
+	return ServiceNowConfig{
+		InstanceURL:       src.InstanceURL,
+		Username:          src.Username,
+		Password:          src.Password,
+		Table:             src.Table,
+		OtherInstanceURLs: otherInstanceURLsCopy,
+	}
+}
+
+// Helper function to deep clone the IncidentioConfig struct
+func cloneIncidentioConfig(src IncidentioConfig) IncidentioConfig {
+	// Create a copy of OtherAlertSourceConfigIDs map if it exists
+	var otherAlertSourceConfigIDsCopy map[string]string
+	if src.OtherAlertSourceConfigIDs != nil {
+		otherAlertSourceConfigIDsCopy = make(map[string]string)
+		for k, v := range src.OtherAlertSourceConfigIDs {
+			otherAlertSourceConfigIDsCopy[k] = v
+		}
+	}
+
+	return IncidentioConfig{
+		APIKey:                    src.APIKey,
+		AlertSourceConfigID:       src.AlertSourceConfigID,
+		OtherAlertSourceConfigIDs: otherAlertSourceConfigIDsCopy,
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -181,9 +181,11 @@ type OnCallConfig struct {
 	Enable             bool
 	InitializedOnly    bool                     `mapstructure:"initialized_only"` // Initialize infrastructure but don't enable by default
 	WaitMinutes        int                      `mapstructure:"wait_minutes"`
-	Provider           string                   `mapstructure:"provider"` // "aws_incident_manager" or "pagerduty"
+	Provider           string                   `mapstructure:"provider"` // "aws_incident_manager", "pagerduty", "servicenow" or "incident_io"
 	AwsIncidentManager AwsIncidentManagerConfig `mapstructure:"aws_incident_manager"`
 	PagerDuty          PagerDutyConfig          `mapstructure:"pagerduty"`
+	ServiceNow         ServiceNowConfig         `mapstructure:"servicenow"`
+	Incidentio         IncidentioConfig         `mapstructure:"incident_io"`
 }
 
 type AwsIncidentManagerConfig struct {
@@ -194,6 +196,20 @@ type AwsIncidentManagerConfig struct {
 type PagerDutyConfig struct {
 	RoutingKey       string            `mapstructure:"routing_key"`
 	OtherRoutingKeys map[string]string `mapstructure:"other_routing_keys"`
+}
+
+type ServiceNowConfig struct {
+	InstanceURL       string            `mapstructure:"instance_url"`
+	Username          string            `mapstructure:"username"`
+	Password          string            `mapstructure:"password"`
+	Table             string            `mapstructure:"table"` // ServiceNow table to create records in; defaults to "incident"
+	OtherInstanceURLs map[string]string `mapstructure:"other_instance_urls"`
+}
+
+type IncidentioConfig struct {
+	APIKey                    string            `mapstructure:"api_key"`
+	AlertSourceConfigID       string            `mapstructure:"alert_source_config_id"`
+	OtherAlertSourceConfigIDs map[string]string `mapstructure:"other_alert_source_config_ids"`
 }
 
 type RedisConfig struct {
@@ -477,6 +493,26 @@ func GetConfigWitParamsOverwrite(paramsOverwrite *map[string]string) *Config {
 
 			if routingKey != "" {
 				clonedCfg.OnCall.PagerDuty.RoutingKey = routingKey
+			}
+		}
+	}
+
+	if v := (*paramsOverwrite)["servicenow_other_instance"]; v != "" {
+		if clonedCfg.OnCall.ServiceNow.OtherInstanceURLs != nil {
+			instanceURL := clonedCfg.OnCall.ServiceNow.OtherInstanceURLs[v]
+
+			if instanceURL != "" {
+				clonedCfg.OnCall.ServiceNow.InstanceURL = instanceURL
+			}
+		}
+	}
+
+	if v := (*paramsOverwrite)["incidentio_other_alert_source"]; v != "" {
+		if clonedCfg.OnCall.Incidentio.OtherAlertSourceConfigIDs != nil {
+			alertSourceConfigID := clonedCfg.OnCall.Incidentio.OtherAlertSourceConfigIDs[v]
+
+			if alertSourceConfigID != "" {
+				clonedCfg.OnCall.Incidentio.AlertSourceConfigID = alertSourceConfigID
 			}
 		}
 	}

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -48,6 +48,10 @@
 - [How to Integration Incident Manager (Advanced)](./oncall/how-to-integration-aws-icm-adv.md)
 - [PagerDuty](./oncall/pagerduty.md)
 - [How to Integration PagerDuty](./oncall/how-to-integration-pagerduty.md)
+- [ServiceNow](./oncall/servicenow.md)
+- [How to Integration ServiceNow](./oncall/how-to-integration-servicenow.md)
+- [incident.io](./oncall/incident-io.md)
+- [How to Integration incident.io](./oncall/how-to-integration-incident-io.md)
 
 # Webhook Integration Examples
 - [Use Alertmanager](./examples/alertmanager.md)

--- a/src/configuration/configuration.md
+++ b/src/configuration/configuration.md
@@ -123,7 +123,7 @@ oncall:
   initialized_only: true  # Initialize on-call feature but don't enable by default; use query param oncall_enable=true to enable for specific requests
   enable: false # Use this to enable or disable on-call for all alerts
   wait_minutes: 3 # If you set it to 0, it means there's no need to check for an acknowledgment, and the on-call will trigger immediately
-  provider: aws_incident_manager # Valid values: "aws_incident_manager" or "pagerduty"
+  provider: aws_incident_manager # Valid values: "aws_incident_manager", "pagerduty", "servicenow" or "incident_io"
 
   aws_incident_manager: # Used when provider is "aws_incident_manager"
     response_plan_arn: ${AWS_INCIDENT_MANAGER_RESPONSE_PLAN_ARN}
@@ -138,6 +138,24 @@ oncall:
       infra: ${PAGERDUTY_OTHER_ROUTING_KEY_INFRA}
       app: ${PAGERDUTY_OTHER_ROUTING_KEY_APP}
       db: ${PAGERDUTY_OTHER_ROUTING_KEY_DB}
+
+  servicenow: # Used when provider is "servicenow"
+    instance_url: ${SERVICENOW_INSTANCE_URL} # eg https://dev12345.service-now.com (REQUIRED)
+    username: ${SERVICENOW_USERNAME} # REQUIRED
+    password: ${SERVICENOW_PASSWORD} # REQUIRED
+    table: incident # ServiceNow table to create records in; defaults to "incident"
+    other_instance_urls: # Optional: Override the default instance using query parameters, eg /api/incidents?servicenow_other_instance=infra
+      infra: ${SERVICENOW_OTHER_INSTANCE_URL_INFRA}
+      app: ${SERVICENOW_OTHER_INSTANCE_URL_APP}
+      db: ${SERVICENOW_OTHER_INSTANCE_URL_DB}
+
+  incident_io: # Used when provider is "incident_io"
+    api_key: ${INCIDENTIO_API_KEY} # Bearer API key for the HTTP alert source (REQUIRED)
+    alert_source_config_id: ${INCIDENTIO_ALERT_SOURCE_CONFIG_ID} # HTTP alert source config ID (REQUIRED)
+    other_alert_source_config_ids: # Optional: Override the default alert source using query parameters, eg /api/incidents?incidentio_other_alert_source=infra
+      infra: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_INFRA}
+      app: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_APP}
+      db: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_DB}
 
 redis: # Required for on-call functionality and the AI agent
   insecure_skip_verify: true # dev only
@@ -395,7 +413,7 @@ This automatic detection provides backward compatibility while supporting newer 
 | `ONCALL_ENABLE`             | Set to `true` to enable on-call functionality for all incidents by default. **Can be overridden per request using the `oncall_enable` query parameter.** |
 | `ONCALL_INITIALIZED_ONLY`   | Set to `true` to initialize on-call feature but keep it disabled by default. When set to `true`, on-call is triggered only for requests that explicitly include `?oncall_enable=true` in the URL. |
 | `ONCALL_WAIT_MINUTES`       | Time in minutes to wait for acknowledgment before escalating (default: 3). **Can be overridden per request using the `oncall_wait_minutes` query parameter.** |
-| `ONCALL_PROVIDER`           | Specify the on-call provider to use ("aws_incident_manager" or "pagerduty"). |
+| `ONCALL_PROVIDER`           | Specify the on-call provider to use ("aws_incident_manager", "pagerduty", "servicenow" or "incident_io"). |
 | `AWS_INCIDENT_MANAGER_RESPONSE_PLAN_ARN` | The ARN of the AWS Incident Manager response plan to use for on-call escalations. Required if on-call provider is "aws_incident_manager". |
 | `AWS_INCIDENT_MANAGER_OTHER_RESPONSE_PLAN_ARN_PROD` | (Optional) AWS Incident Manager response plan ARN for production environment. **Can be selected per request using the `awsim_other_response_plan=prod` query parameter.** |
 | `AWS_INCIDENT_MANAGER_OTHER_RESPONSE_PLAN_ARN_DEV` | (Optional) AWS Incident Manager response plan ARN for development environment. **Can be selected per request using the `awsim_other_response_plan=dev` query parameter.** |
@@ -404,6 +422,13 @@ This automatic detection provides backward compatibility while supporting newer 
 | `PAGERDUTY_OTHER_ROUTING_KEY_INFRA` | (Optional) PagerDuty routing key for feature team. **Can be selected per request using the `pagerduty_other_routing_key=infra` query parameter.** |
 | `PAGERDUTY_OTHER_ROUTING_KEY_APP`   | (Optional) PagerDuty routing key for application team. **Can be selected per request using the `pagerduty_other_routing_key=app` query parameter.** |
 | `PAGERDUTY_OTHER_ROUTING_KEY_DB`    | (Optional) PagerDuty routing key for database team. **Can be selected per request using the `pagerduty_other_routing_key=db` query parameter.** |
+| `SERVICENOW_INSTANCE_URL`   | Base URL of your ServiceNow instance (e.g. `https://dev12345.service-now.com`). Required if on-call provider is "servicenow". |
+| `SERVICENOW_USERNAME`       | ServiceNow Basic auth username. Required if on-call provider is "servicenow". |
+| `SERVICENOW_PASSWORD`       | ServiceNow Basic auth password. Required if on-call provider is "servicenow". |
+| `SERVICENOW_OTHER_INSTANCE_URL_INFRA` | (Optional) Alternate ServiceNow instance URL. **Can be selected per request using the `servicenow_other_instance=infra` query parameter.** |
+| `INCIDENTIO_API_KEY`        | Bearer API key for the incident.io HTTP alert source. Required if on-call provider is "incident_io". |
+| `INCIDENTIO_ALERT_SOURCE_CONFIG_ID` | incident.io HTTP alert source config ID. Required if on-call provider is "incident_io". |
+| `INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_INFRA` | (Optional) Alternate incident.io alert source config ID. **Can be selected per request using the `incidentio_other_alert_source=infra` query parameter.** |
 
 #### Enabling On-Call for Specific Incidents with initialized_only
 

--- a/src/oncall/how-to-integration-aws-icm.md
+++ b/src/oncall/how-to-integration-aws-icm.md
@@ -120,51 +120,7 @@ redis: # Required for on-call functionality
   db: 0
 ```
 
-Create Slack templates `config/slack_message.tmpl`:
-
-```
-🔥 *{{ .commonLabels.severity | upper }} Alert: {{ .commonLabels.alertname }}*
-
-🌐 *Instance*: `{{ .commonLabels.instance }}`
-🚨 *Status*: `{{ .status }}`
-
-{{ range .alerts }}
-📝 {{ .annotations.description }}  
-{{ end }}
-```
-
-**Slack Acknowledgment Button (Default)**
-
-By default, Versus automatically adds an interactive acknowledgment button to Slack notifications when on-call is enabled. This allows users to acknowledge alerts. You can customize the button appearance in your `config.yaml`, for example:
-
-![Versus On-Call Slack](/docs/images/on-call-slack.png)
-
-**ACK URL Generation**
-
-+ When an incident is created (e.g., via a POST to `/api/incidents`), Versus generates an acknowledgment URL if on-call is enabled.
-+ The URL is constructed using the `public_host` value, typically in the format: `https://your-host.example/api/incidents/ack/<incident-id>`.
-+ This URL is injected into the button.
-
-**Manual Acknowledgment Handling**
-
-If you prefer to handle acknowledgments manually or want to disable the default button (by setting `disable_button: true`), you can add the acknowledgment URL directly in your template. Here's an example of including a clickable link in your Slack template:
-
-```
-🔥 *{{ .commonLabels.severity | upper }} Alert: {{ .commonLabels.alertname }}*
-
-🌐 *Instance*: `{{ .commonLabels.instance }}`  
-🚨 *Status*: `{{ .status }}`
-
-{{ range .alerts }}
-📝 {{ .annotations.description }}  
-{{ end }}
-{{ if .AckURL }}
-----------
-<{{.AckURL}}|Click here to acknowledge>
-{{ end }}
-```
-
-The conditional `{{ if .AckURL }}` ensures the link only appears if the acknowledgment URL is available (i.e., when on-call is enabled).
+By default, Versus adds an interactive acknowledgment button to Slack notifications when on-call is enabled, using the unified template shipped in `config/slack_message.tmpl`. If the alert is acknowledged before `wait_minutes` elapses, AWS Incident Manager is never engaged.
 
 Create the `docker-compose.yml` file:
 
@@ -183,6 +139,8 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=your_redis_password
+    volumes:
+      - ./config:/app/config:ro
     depends_on:
       - redis
 

--- a/src/oncall/how-to-integration-incident-io.md
+++ b/src/oncall/how-to-integration-incident-io.md
@@ -1,0 +1,312 @@
+# Integrate with incident.io
+
+This document provides a step-by-step guide to integrate Versus Incident with [incident.io](https://incident.io/) for on-call management. The integration escalates unacknowledged alerts into incident.io through its [HTTP alert source](https://api-docs.incident.io/) events endpoint.
+
+We'll cover setting up incident.io, configuring the integration with Versus, deploying Versus, and testing the integration with practical examples.
+
+## Prerequisites
+
+Before you begin, ensure you have:
++ An incident.io account with permission to manage alert sources
++ Versus Incident deployed (instructions provided later)
++ Prometheus Alert Manager set up to monitor your systems
+
+## Setting Up incident.io for On-Call
+
+Let's configure an HTTP alert source, capture its config ID, and create an API key.
+
+### 1. Create an HTTP Alert Source
+
+The HTTP alert source is the endpoint Versus sends events to:
+
+1. Log in to incident.io
+2. Navigate to **Alerts** > **Sources** > **Add alert source**
+3. Choose **HTTP** as the source type
+4. Name the source (e.g., "Versus Incident")
+5. Save the source
+
+### 2. Capture the Alert Source Config ID
+
+Each HTTP alert source has a config ID embedded in its events endpoint:
+
+```
+https://api.incident.io/v2/alert_events/http/{alert_source_config_id}
+```
+
+1. Open the alert source you just created
+2. Copy the **config ID** from the source's settings or its endpoint URL
+3. Keep it handy — you'll set it as `alert_source_config_id` in Versus
+
+### 3. Create an API Key
+
+Versus authenticates with a Bearer API key:
+
+1. Navigate to **Settings** > **API keys** > **Add API key**
+2. Name the key (e.g., "Versus Integration")
+3. Grant the permission required to create alert events
+4. Copy the key — it's shown only once. Store it securely; you'll set it as `api_key`.
+
+### 4. Set Up Escalation in incident.io
+
+Decide what should happen when an alert event arrives:
+
+1. Configure an **alert route** that matches events from your Versus alert source
+2. Attach the **escalation path** / on-call schedule that should be paged
+3. Save the route
+
+This is what turns an inbound alert event into a page for the right on-call engineer.
+
+### 5. Verify the Endpoint
+
+You can confirm connectivity before wiring up Versus:
+
+```bash
+curl -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -X POST "https://api.incident.io/v2/alert_events/http/YOUR_CONFIG_ID" \
+  -d '{"title":"Versus connectivity test","deduplication_key":"test-001","status":"firing"}'
+```
+
+A 2xx response confirms the API key and config ID are correct.
+
+## How the Mapping Works
+
+When an alert escalates, Versus sends an HTTP `POST` to the alert events endpoint with a Bearer token and maps the incident onto the alert payload:
+
+| incident.io field | Value |
+|-------------------|-------|
+| `title` | A human-readable summary (`Incident <id>`) |
+| `deduplication_key` | The incident ID, so repeated escalations collapse onto the same alert |
+| `status` | `firing` |
+| `metadata.incident_id` | The incident ID |
+
+The request uses the shared HTTPS client with TLS verification enabled. A non-2xx response is treated as a failure and logged. The API key is never written to logs.
+
+## Deploy Versus Incident
+
+Now let's deploy Versus with incident.io integration. You can use Docker or Kubernetes.
+
+### Docker Deployment
+
+Create a directory for your configuration files:
+
+```bash
+mkdir -p ./config
+```
+
+Create `config/config.yaml` with the following content:
+
+```yaml
+name: versus
+host: 0.0.0.0
+port: 3000
+public_host: https://your-ack-host.example
+
+alert:
+  debug_body: true
+
+  slack:
+    enable: true
+    token: ${SLACK_TOKEN}
+    channel_id: ${SLACK_CHANNEL_ID}
+    template_path: "config/slack_message.tmpl"
+
+oncall:
+  enable: true
+  wait_minutes: 3
+  provider: incident_io
+
+  incident_io:
+    api_key: ${INCIDENTIO_API_KEY}                               # Bearer API key (REQUIRED)
+    alert_source_config_id: ${INCIDENTIO_ALERT_SOURCE_CONFIG_ID} # HTTP alert source config ID (REQUIRED)
+    other_alert_source_config_ids:                               # Optional: per-request override
+      infra: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_INFRA}
+      app: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_APP}
+      db: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_DB}
+
+redis: # Required for on-call functionality
+  insecure_skip_verify: true # dev only
+  host: ${REDIS_HOST}
+  port: ${REDIS_PORT}
+  password: ${REDIS_PASSWORD}
+  db: 0
+```
+
+By default, Versus adds an interactive acknowledgment button to Slack notifications when on-call is enabled, using the unified template shipped in `config/slack_message.tmpl`. If the alert is acknowledged before `wait_minutes` elapses, incident.io is never called.
+
+Create the `docker-compose.yml` file:
+
+```yaml
+version: '3.8'
+
+services:
+  versus:
+    image: ghcr.io/versuscontrol/versus-incident
+    ports:
+      - "3000:3000"
+    environment:
+      - SLACK_TOKEN=your_slack_token
+      - SLACK_CHANNEL_ID=your_channel_id
+      - INCIDENTIO_API_KEY=your_incidentio_api_key
+      - INCIDENTIO_ALERT_SOURCE_CONFIG_ID=your_alert_source_config_id
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=your_redis_password
+    volumes:
+      - ./config:/app/config:ro
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:6.2-alpine
+    command: redis-server --requirepass your_redis_password
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+volumes:
+  redis_data:
+```
+
+Run Docker Compose:
+
+```bash
+docker-compose up -d
+```
+
+> **Warning:** Always provide `api_key` through an environment variable. Never commit it to `config.yaml`.
+
+## Alert Manager Routing Configuration
+
+Now, let's configure Alert Manager to route alerts to Versus with different behaviors:
+
+### Send Alert Only (No On-Call)
+
+```yaml
+receivers:
+- name: 'versus-no-oncall'
+  webhook_configs:
+  - url: 'http://versus-service:3000/api/incidents?oncall_enable=false'
+    send_resolved: false
+
+route:
+  receiver: 'versus-no-oncall'
+  group_by: ['alertname', 'service']
+  routes:
+  - match:
+      severity: warning
+    receiver: 'versus-no-oncall'
+```
+
+### Send Alert with Acknowledgment Wait
+
+```yaml
+receivers:
+- name: 'versus-with-ack'
+  webhook_configs:
+  - url: 'http://versus-service:3000/api/incidents?oncall_wait_minutes=5'
+    send_resolved: false
+
+route:
+  routes:
+  - match:
+      severity: critical
+    receiver: 'versus-with-ack'
+```
+
+This waits 5 minutes for acknowledgment before sending an alert event to incident.io if the user doesn't click the ACK link in Slack.
+
+### Send Alert with Immediate On-Call Trigger
+
+```yaml
+receivers:
+- name: 'versus-immediate'
+  webhook_configs:
+  - url: 'http://versus-service:3000/api/incidents?oncall_wait_minutes=0'
+    send_resolved: false
+
+route:
+  routes:
+  - match:
+      severity: urgent
+    receiver: 'versus-immediate'
+```
+
+This sends the alert event to incident.io immediately without waiting.
+
+## Override the Alert Source per Alert
+
+You can route specific alerts to a different incident.io alert source using the `incidentio_other_alert_source` query parameter instead of exposing config IDs directly. The value must match a key under `other_alert_source_config_ids`:
+
+```yaml
+receivers:
+- name: 'versus-incidentio-infra'
+  webhook_configs:
+  - url: 'http://versus-service:3000/api/incidents?incidentio_other_alert_source=infra'
+    send_resolved: false
+
+route:
+  routes:
+  - match:
+      team: infrastructure
+    receiver: 'versus-incidentio-infra'
+```
+
+This routes infrastructure team alerts to the alert source named `infra`, which is mapped in your configuration file:
+
+```yaml
+oncall:
+  provider: incident_io
+  incident_io:
+    api_key: ${INCIDENTIO_API_KEY}
+    alert_source_config_id: ${INCIDENTIO_ALERT_SOURCE_CONFIG_ID}
+    other_alert_source_config_ids:
+      infra: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_INFRA}
+      app: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_APP}
+      db: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_DB}
+```
+
+The override applies to that single request only; the global config is never mutated.
+
+## Testing the Integration
+
+Let's test the complete workflow:
+
+1. **Trigger an Alert**:
+   - Simulate a critical alert in Prometheus to match the Alert Manager rule.
+
+2. **Verify Versus**:
+   - Check that Versus receives the alert and sends it to Slack.
+   - You should see a message with an acknowledgment link.
+
+3. **Check Escalation**:
+   - Option 1: Click the ACK link to acknowledge the incident — incident.io should not receive an alert event.
+   - Option 2: Wait for the acknowledgment timeout (e.g., 5 minutes) without clicking the link.
+   - In incident.io, confirm an alert was created from your Versus alert source and that the escalation path paged the on-call engineer.
+
+4. **Immediate Trigger Test**:
+   - Send an urgent alert and confirm an alert event reaches incident.io instantly.
+
+## How It Works Under the Hood
+
+When Versus integrates with incident.io, the following occurs:
+
+1. Versus receives an alert from Alert Manager.
+2. If on-call is enabled and the acknowledgment period passes without an ACK, Versus:
+   - Builds an alert event payload with `title`, `deduplication_key`, `status`, and `metadata`.
+   - Sends an authenticated `POST` to the HTTP alert events endpoint using a Bearer token.
+3. incident.io ingests the alert event, applies your alert routes, and pages the on-call engineer through the attached escalation path. The `deduplication_key` ensures repeated escalations collapse onto the same alert.
+
+## Conclusion
+
+You've now integrated Versus Incident with incident.io for on-call management. Alerts from Prometheus Alert Manager can page your on-call engineers through incident.io via Versus when they go unacknowledged.
+
+This integration provides:
+
++ A delay period for engineers to acknowledge incidents before paging
++ Slack notifications with one-click acknowledgment
++ De-duplication through the `deduplication_key` field
++ Per-alert routing to different incident.io alert sources
+
+For the full configuration reference, see [incident.io](./incident-io.md). Adjust the configuration as needed for your environment and incident response processes.

--- a/src/oncall/how-to-integration-pagerduty.md
+++ b/src/oncall/how-to-integration-pagerduty.md
@@ -131,51 +131,7 @@ redis: # Required for on-call functionality
   db: 0
 ```
 
-Create a Slack template in `config/slack_message.tmpl`:
-
-```
-🔥 *{{ .commonLabels.severity | upper }} Alert: {{ .commonLabels.alertname }}*
-
-🌐 *Instance*: `{{ .commonLabels.instance }}`  
-🚨 *Status*: `{{ .status }}`
-
-{{ range .alerts }}
-📝 {{ .annotations.description }}  
-{{ end }}
-```
-
-**Slack Acknowledgment Button (Default)**
-
-By default, Versus automatically adds an interactive acknowledgment button to Slack notifications when on-call is enabled. This allows users to acknowledge alerts. You can customize the button appearance in your `config.yaml`, for example:
-
-![Versus On-Call Slack](/docs/images/on-call-slack.png)
-
-**ACK URL Generation**
-
-+ When an incident is created (e.g., via a POST to `/api/incidents`), Versus generates an acknowledgment URL if on-call is enabled.
-+ The URL is constructed using the `public_host` value, typically in the format: `https://your-host.example/api/incidents/ack/<incident-id>`.
-+ This URL is injected into the button.
-
-**Manual Acknowledgment Handling**
-
-If you prefer to handle acknowledgments manually or want to disable the default button (by setting `disable_button: true`), you can add the acknowledgment URL directly in your template. Here's an example of including a clickable link in your Slack template:
-
-```
-🔥 *{{ .commonLabels.severity | upper }} Alert: {{ .commonLabels.alertname }}*
-
-🌐 *Instance*: `{{ .commonLabels.instance }}`  
-🚨 *Status*: `{{ .status }}`
-
-{{ range .alerts }}
-📝 {{ .annotations.description }}  
-{{ end }}
-{{ if .AckURL }}
-----------
-<{{.AckURL}}|Click here to acknowledge>
-{{ end }}
-```
-
-The conditional `{{ if .AckURL }}` ensures the link only appears if the acknowledgment URL is available (i.e., when on-call is enabled).
+By default, Versus adds an interactive acknowledgment button to Slack notifications when on-call is enabled, using the unified template shipped in `config/slack_message.tmpl`. If the alert is acknowledged before `wait_minutes` elapses, PagerDuty is never triggered.
 
 Create the `docker-compose.yml` file:
 
@@ -194,6 +150,8 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=your_redis_password
+    volumes:
+      - ./config:/app/config:ro
     depends_on:
       - redis
 

--- a/src/oncall/how-to-integration-servicenow.md
+++ b/src/oncall/how-to-integration-servicenow.md
@@ -1,0 +1,320 @@
+# Integrate with ServiceNow
+
+This document provides a step-by-step guide to integrate Versus Incident with ServiceNow for on-call management. The integration escalates unacknowledged alerts into ServiceNow by creating records through the ServiceNow [Table API](https://docs.servicenow.com/bundle/washingtondc-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html).
+
+We'll cover setting up ServiceNow, configuring the integration with Versus, deploying Versus, and testing the integration with practical examples.
+
+## Prerequisites
+
+Before you begin, ensure you have:
++ A ServiceNow instance (a free [Developer instance](https://developer.servicenow.com/) works for testing)
++ Versus Incident deployed (instructions provided later)
++ Prometheus Alert Manager set up to monitor your systems
+
+## Setting Up ServiceNow for On-Call
+
+Let's configure a practical example in ServiceNow with a dedicated integration user and the target table.
+
+### 1. Create an Integration User
+
+First, create a user that Versus will authenticate as when creating records:
+
+1. Log in to your ServiceNow instance as an administrator
+2. Navigate to **User Administration** > **Users** > **New**
+3. Fill in the user details:
+   + User ID (e.g., `versus.integration`)
+   + First/Last name (e.g., "Versus Integration")
+   + Set a strong password
+   + Check **Web service access only** so the account cannot log in to the UI
+4. Submit to create the user
+
+### 2. Grant Table Permissions
+
+The integration user needs permission to create records on the target table (the `incident` table by default):
+
+1. Navigate to **User Administration** > **Roles**
+2. Assign a role that allows record creation on your target table:
+   + For the `incident` table, the `itil` role is the common choice
+   + For a custom table, create or assign a role with `create` access
+3. Open the integration user and add the role under the **Roles** tab
+4. Save the user
+
+> **Note:** Follow least-privilege. Grant only the access needed to create records on the one table Versus writes to — nothing more.
+
+### 3. Identify Your Instance URL and Table
+
+You need two values for the Versus configuration:
+
+1. **Instance URL** — the base URL of your instance, e.g. `https://dev12345.service-now.com`
+2. **Table** — the table records are created in. Versus defaults to `incident`. To use a different table (e.g. a custom `u_versus_alert`), note its name.
+
+### 4. Confirm the Table API Endpoint
+
+Versus posts records to the standard Table API path:
+
+```
+{instance_url}/api/now/table/{table}
+```
+
+For example, with the default table:
+
+```
+https://dev12345.service-now.com/api/now/table/incident
+```
+
+You can verify access from your terminal before wiring up Versus:
+
+```bash
+curl -u "versus.integration:YOUR_PASSWORD" \
+  -H "Content-Type: application/json" \
+  -X POST "https://dev12345.service-now.com/api/now/table/incident" \
+  -d '{"short_description":"Versus connectivity test","correlation_id":"test-001"}'
+```
+
+A `201 Created` response confirms the user and permissions are correct.
+
+## How the Mapping Works
+
+When an alert escalates, Versus sends an HTTP `POST` to the Table API with HTTP Basic auth and maps the incident onto two fields:
+
+| ServiceNow field | Value |
+|------------------|-------|
+| `short_description` | A human-readable summary (`Incident <id>`) |
+| `correlation_id` | The incident ID, used by ServiceNow to de-duplicate inbound events |
+
+The request uses the shared HTTPS client with TLS verification enabled. A non-2xx response is treated as a failure and logged. Credentials are never written to logs.
+
+## Deploy Versus Incident
+
+Now let's deploy Versus with ServiceNow integration. You can use Docker or Kubernetes.
+
+### Docker Deployment
+
+Create a directory for your configuration files:
+
+```bash
+mkdir -p ./config
+```
+
+Create `config/config.yaml` with the following content:
+
+```yaml
+name: versus
+host: 0.0.0.0
+port: 3000
+public_host: https://your-ack-host.example
+
+alert:
+  debug_body: true
+
+  slack:
+    enable: true
+    token: ${SLACK_TOKEN}
+    channel_id: ${SLACK_CHANNEL_ID}
+    template_path: "config/slack_message.tmpl"
+
+oncall:
+  enable: true
+  wait_minutes: 3
+  provider: servicenow
+
+  servicenow:
+    instance_url: ${SERVICENOW_INSTANCE_URL} # e.g. https://dev12345.service-now.com (REQUIRED)
+    username: ${SERVICENOW_USERNAME}          # REQUIRED
+    password: ${SERVICENOW_PASSWORD}          # REQUIRED
+    table: incident                           # ServiceNow table; defaults to "incident"
+    other_instance_urls:                      # Optional: per-request instance override
+      infra: ${SERVICENOW_OTHER_INSTANCE_URL_INFRA}
+      app: ${SERVICENOW_OTHER_INSTANCE_URL_APP}
+      db: ${SERVICENOW_OTHER_INSTANCE_URL_DB}
+
+redis: # Required for on-call functionality
+  insecure_skip_verify: true # dev only
+  host: ${REDIS_HOST}
+  port: ${REDIS_PORT}
+  password: ${REDIS_PASSWORD}
+  db: 0
+```
+
+By default, Versus adds an interactive acknowledgment button to Slack notifications when on-call is enabled, using the unified template shipped in `config/slack_message.tmpl`. If the alert is acknowledged before `wait_minutes` elapses, ServiceNow is never called.
+
+Create the `docker-compose.yml` file:
+
+```yaml
+version: '3.8'
+
+services:
+  versus:
+    image: ghcr.io/versuscontrol/versus-incident
+    ports:
+      - "3000:3000"
+    environment:
+      - SLACK_TOKEN=your_slack_token
+      - SLACK_CHANNEL_ID=your_channel_id
+      - SERVICENOW_INSTANCE_URL=https://dev12345.service-now.com
+      - SERVICENOW_USERNAME=versus.integration
+      - SERVICENOW_PASSWORD=your_servicenow_password
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=your_redis_password
+    volumes:
+      - ./config:/app/config:ro
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:6.2-alpine
+    command: redis-server --requirepass your_redis_password
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+volumes:
+  redis_data:
+```
+
+Run Docker Compose:
+
+```bash
+docker-compose up -d
+```
+
+> **Warning:** Always provide `username` and `password` through environment variables. Never commit credentials to `config.yaml`.
+
+## Alert Manager Routing Configuration
+
+Now, let's configure Alert Manager to route alerts to Versus with different behaviors:
+
+### Send Alert Only (No On-Call)
+
+```yaml
+receivers:
+- name: 'versus-no-oncall'
+  webhook_configs:
+  - url: 'http://versus-service:3000/api/incidents?oncall_enable=false'
+    send_resolved: false
+
+route:
+  receiver: 'versus-no-oncall'
+  group_by: ['alertname', 'service']
+  routes:
+  - match:
+      severity: warning
+    receiver: 'versus-no-oncall'
+```
+
+### Send Alert with Acknowledgment Wait
+
+```yaml
+receivers:
+- name: 'versus-with-ack'
+  webhook_configs:
+  - url: 'http://versus-service:3000/api/incidents?oncall_wait_minutes=5'
+    send_resolved: false
+
+route:
+  routes:
+  - match:
+      severity: critical
+    receiver: 'versus-with-ack'
+```
+
+This waits 5 minutes for acknowledgment before creating a ServiceNow record if the user doesn't click the ACK link in Slack.
+
+### Send Alert with Immediate On-Call Trigger
+
+```yaml
+receivers:
+- name: 'versus-immediate'
+  webhook_configs:
+  - url: 'http://versus-service:3000/api/incidents?oncall_wait_minutes=0'
+    send_resolved: false
+
+route:
+  routes:
+  - match:
+      severity: urgent
+    receiver: 'versus-immediate'
+```
+
+This creates a ServiceNow record immediately without waiting.
+
+## Override the ServiceNow Instance per Alert
+
+You can route specific alerts to a different ServiceNow instance using the `servicenow_other_instance` query parameter instead of exposing instance URLs directly. The value must match a key under `other_instance_urls`:
+
+```yaml
+receivers:
+- name: 'versus-servicenow-infra'
+  webhook_configs:
+  - url: 'http://versus-service:3000/api/incidents?servicenow_other_instance=infra'
+    send_resolved: false
+
+route:
+  routes:
+  - match:
+      team: infrastructure
+    receiver: 'versus-servicenow-infra'
+```
+
+This routes infrastructure team alerts to the instance named `infra`, which is mapped in your configuration file:
+
+```yaml
+oncall:
+  provider: servicenow
+  servicenow:
+    instance_url: ${SERVICENOW_INSTANCE_URL}
+    username: ${SERVICENOW_USERNAME}
+    password: ${SERVICENOW_PASSWORD}
+    other_instance_urls:
+      infra: ${SERVICENOW_OTHER_INSTANCE_URL_INFRA}
+      app: ${SERVICENOW_OTHER_INSTANCE_URL_APP}
+      db: ${SERVICENOW_OTHER_INSTANCE_URL_DB}
+```
+
+The override applies to that single request only; the global config is never mutated.
+
+> **Warning:** Every URL listed under `other_instance_urls` is reached with the same default `username` and `password`. Only point overrides at instances that share the same credential trust domain.
+
+## Testing the Integration
+
+Let's test the complete workflow:
+
+1. **Trigger an Alert**:
+   - Simulate a critical alert in Prometheus to match the Alert Manager rule.
+
+2. **Verify Versus**:
+   - Check that Versus receives the alert and sends it to Slack.
+   - You should see a message with an acknowledgment link.
+
+3. **Check Escalation**:
+   - Option 1: Click the ACK link to acknowledge the incident — ServiceNow should not receive a record.
+   - Option 2: Wait for the acknowledgment timeout (e.g., 5 minutes) without clicking the link.
+   - In ServiceNow, open the target table (e.g. **Incident** > **All**) and confirm a new record was created with the matching `short_description` and `correlation_id`.
+
+4. **Immediate Trigger Test**:
+   - Send an urgent alert and confirm a record is created in ServiceNow instantly.
+
+## How It Works Under the Hood
+
+When Versus integrates with ServiceNow, the following occurs:
+
+1. Versus receives an alert from Alert Manager.
+2. If on-call is enabled and the acknowledgment period passes without an ACK, Versus:
+   - Builds a Table API payload with `short_description` and `correlation_id`.
+   - Sends an authenticated `POST` to `{instance_url}/api/now/table/{table}` using HTTP Basic auth.
+3. ServiceNow creates the record on the target table, where it flows into your existing assignment rules, workflows, and notifications.
+
+## Conclusion
+
+You've now integrated Versus Incident with ServiceNow for on-call management. Alerts from Prometheus Alert Manager can create ServiceNow records via Versus when they go unacknowledged.
+
+This integration provides:
+
++ A delay period for engineers to acknowledge incidents before a record is created
++ Slack notifications with one-click acknowledgment
++ De-duplication through the `correlation_id` field
++ Per-alert routing to different ServiceNow instances
+
+For the full configuration reference, see [ServiceNow](./servicenow.md). Adjust the configuration as needed for your environment and incident response processes.

--- a/src/oncall/incident-io.md
+++ b/src/oncall/incident-io.md
@@ -1,0 +1,80 @@
+# incident.io
+
+Versus Incident can escalate unacknowledged alerts to [incident.io](https://incident.io/) through its [HTTP alert source](https://api-docs.incident.io/) events endpoint. When on-call is enabled with the `incident_io` provider, Versus sends an alert event for every incident that is not acknowledged within the configured wait period.
+
+## How it works
+
+When an incident escalates, Versus sends an HTTP `POST` to the incident.io HTTP alert events endpoint:
+
+```
+https://api.incident.io/v2/alert_events/http/{alert_source_config_id}
+```
+
+- Authentication uses an `Authorization: Bearer {api_key}` header.
+- The incident fields are mapped onto the alert payload:
+  - `title` — `Incident <id>`.
+  - `deduplication_key` — the incident ID, so repeated escalations collapse onto the same alert.
+  - `status` — `firing`.
+  - `metadata.incident_id` — the incident ID.
+- The request uses the shared HTTPS client with TLS verification enabled.
+
+A non-2xx response from incident.io is treated as a failure and logged.
+
+## Configuration
+
+Add the `incident_io` block under `oncall` in your `config.yaml` and set `provider: incident_io`:
+
+```yaml
+oncall:
+  enable: true
+  wait_minutes: 3
+  provider: incident_io
+
+  incident_io:
+    api_key: ${INCIDENTIO_API_KEY}                       # Bearer API key (REQUIRED)
+    alert_source_config_id: ${INCIDENTIO_ALERT_SOURCE_CONFIG_ID} # HTTP alert source config ID (REQUIRED)
+    other_alert_source_config_ids:                       # Optional: per-request override
+      infra: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_INFRA}
+      app: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_APP}
+      db: ${INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_DB}
+
+redis: # Required for on-call functionality
+  host: ${REDIS_HOST}
+  port: ${REDIS_PORT}
+  password: ${REDIS_PASSWORD}
+  db: 0
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `api_key` | Yes | Bearer API key for the HTTP alert source. Provide via an environment variable; never commit it. |
+| `alert_source_config_id` | Yes | The HTTP alert source config ID created in incident.io. |
+| `other_alert_source_config_ids` | No | Map of named alert source config IDs selectable per request. |
+
+### Getting the alert source config ID and API key
+
+1. In incident.io, create an **HTTP alert source** under **Alerts → Sources**.
+2. Copy the alert source config ID from the source's URL/settings.
+3. Create an API key with permission to create alert events and use it as `api_key`.
+
+### Credentials
+
+Provide `api_key` through an environment variable (`${INCIDENTIO_API_KEY}`) — never hard-code it in `config.yaml`. Versus never logs the API key.
+
+## Per-request override
+
+You can route a specific alert to a different incident.io alert source using the `incidentio_other_alert_source` query parameter. The value must match a key under `other_alert_source_config_ids`:
+
+```
+POST /api/incidents?incidentio_other_alert_source=infra
+```
+
+This overrides `alert_source_config_id` for that single request only; the global config is never mutated.
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `INCIDENTIO_API_KEY` | Bearer API key. |
+| `INCIDENTIO_ALERT_SOURCE_CONFIG_ID` | Default HTTP alert source config ID. |
+| `INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_<NAME>` | Named alternate alert source config IDs (e.g. `INCIDENTIO_OTHER_ALERT_SOURCE_CONFIG_ID_INFRA`). |

--- a/src/oncall/on-call-introduction.md
+++ b/src/oncall/on-call-introduction.md
@@ -1,12 +1,16 @@
 # On-Call
 
-Versus Incident escalates unacknowledged alerts to AWS Incident Manager or PagerDuty. Start here to learn the model and pick a provider.
+Versus Incident escalates unacknowledged alerts to AWS Incident Manager, PagerDuty, ServiceNow, or incident.io. Start here to learn the model and pick a provider.
 
 
-This document provides a step-by-step guide to integrating Versus Incident with an on-call solutions. We currently support AWS Incident Manager and PagerDuty, with plans to support more tools in the future.
+This document provides a step-by-step guide to integrating Versus Incident with an on-call solutions. We currently support AWS Incident Manager, PagerDuty, ServiceNow, and incident.io, with plans to support more tools in the future.
 
 Before diving into how Versus integrates with on-call systems, let's start with the basics. You need to understand the on-call platforms we support:
 
 **[Understanding AWS Incident Manager On-Call](./aws-incident-manager.md)**
 
 **[Understanding PagerDuty On-Call](./pagerduty.md)**
+
+**[Understanding ServiceNow On-Call](./servicenow.md)**
+
+**[Understanding incident.io On-Call](./incident-io.md)**

--- a/src/oncall/servicenow.md
+++ b/src/oncall/servicenow.md
@@ -1,0 +1,77 @@
+# ServiceNow
+
+Versus Incident can escalate unacknowledged alerts to [ServiceNow](https://www.servicenow.com/) by creating records through the ServiceNow [Table API](https://docs.servicenow.com/bundle/washingtondc-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html). When on-call is enabled with the `servicenow` provider, Versus posts a new record (by default to the `incident` table) for every incident that is not acknowledged within the configured wait period.
+
+## How it works
+
+When an incident escalates, Versus sends an HTTP `POST` to:
+
+```
+{instance_url}/api/now/table/{table}
+```
+
+- Authentication uses **HTTP Basic auth** with the configured `username` and `password`.
+- The incident ID is mapped onto two fields:
+  - `short_description` — a human-readable summary (`Incident <id>`).
+  - `correlation_id` — used by ServiceNow to de-duplicate inbound events.
+- The request uses the shared HTTPS client with TLS verification enabled.
+
+A non-2xx response from ServiceNow is treated as a failure and logged.
+
+## Configuration
+
+Add the `servicenow` block under `oncall` in your `config.yaml` and set `provider: servicenow`:
+
+```yaml
+oncall:
+  enable: true
+  wait_minutes: 3
+  provider: servicenow
+
+  servicenow:
+    instance_url: ${SERVICENOW_INSTANCE_URL} # eg https://dev12345.service-now.com (REQUIRED)
+    username: ${SERVICENOW_USERNAME}          # REQUIRED
+    password: ${SERVICENOW_PASSWORD}          # REQUIRED
+    table: incident                           # ServiceNow table; defaults to "incident"
+    other_instance_urls:                      # Optional: per-request instance override
+      infra: ${SERVICENOW_OTHER_INSTANCE_URL_INFRA}
+      app: ${SERVICENOW_OTHER_INSTANCE_URL_APP}
+      db: ${SERVICENOW_OTHER_INSTANCE_URL_DB}
+
+redis: # Required for on-call functionality
+  host: ${REDIS_HOST}
+  port: ${REDIS_PORT}
+  password: ${REDIS_PASSWORD}
+  db: 0
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `instance_url` | Yes | Base URL of your ServiceNow instance, e.g. `https://dev12345.service-now.com`. |
+| `username` | Yes | ServiceNow user with permission to create records on the target table. |
+| `password` | Yes | Password for the user. Provide via an environment variable; never commit it. |
+| `table` | No | Table to create records in. Defaults to `incident`. |
+| `other_instance_urls` | No | Map of named instance URLs selectable per request. |
+
+### Credentials
+
+Provide `username` and `password` through environment variables (`${SERVICENOW_USERNAME}`, `${SERVICENOW_PASSWORD}`) — never hard-code them in `config.yaml`. Versus never logs credentials.
+
+## Per-request override
+
+You can route a specific alert to a different ServiceNow instance using the `servicenow_other_instance` query parameter. The value must match a key under `other_instance_urls`:
+
+```
+POST /api/incidents?servicenow_other_instance=infra
+```
+
+This overrides `instance_url` for that single request only; the global config is never mutated.
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `SERVICENOW_INSTANCE_URL` | Default instance URL. |
+| `SERVICENOW_USERNAME` | Basic auth username. |
+| `SERVICENOW_PASSWORD` | Basic auth password. |
+| `SERVICENOW_OTHER_INSTANCE_URL_<NAME>` | Named alternate instance URLs (e.g. `SERVICENOW_OTHER_INSTANCE_URL_INFRA`). |


### PR DESCRIPTION
## What does this PR do?

Adds two new on-call providers — ServiceNow and incident.io — completing epic E11 (Correlate & route rung). Alerts that go unacknowledged within the configured wait period are now escalated to either provider in addition to the existing PagerDuty and AWS Incident Manager options.

## Why?

Closes E11 on the SRE agent capability ladder (Rung 4 — Correlate & route). The two providers are the most-requested alternatives to PagerDuty in the community and unblock enterprise teams already standardised on ServiceNow ITSM or incident.io for on-call.

## How to test

1. Set provider: servicenow or provider: incident_io in config/config.yaml.
2. Provide the required env vars (SERVICENOW_*, INCIDENTIO_*).
3. Send a test incident via POST /api/incidents and let wait_minutes elapse without acknowledging — confirm a record appears in the target system.
4. go test ./pkg/common/... ./pkg/config/... — all green.

## Type of change

- [x] New feature (non-breaking)
- [x] Documentation only

## Checklist

- [x] go test ./... passes locally
- [x] go vet ./... is clean
- [x] Code is gofmt'd
- [x] Added or updated tests for the change
- [x] Updated user-facing docs under src/ if behavior changes
- [x] No secrets, tokens, or webhook URLs introduced in source / YAML
- [x] No new third-party dependencies (or justified in the description)