### PR TITLE
fix(agent): HTML-escape Telegram agent template to stop 400s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   single-tenant build is unchanged by default.
 - **Helm** — `agent.tools.findRunbook.*` values + configmap wiring.
 
+### Fixed
+
+#### AI SRE Agent — Telegram channel
+- **HTML-escape the agent Telegram template** (`config/agent_telegram.tmpl`,
+  `pkg/utils/func_maps.go`) — the agent Telegram template is rendered by
+  `text/template` (no auto-escaping) into a `parse_mode=HTML` body, so a
+  miner placeholder like `<*>` in `.PatternTemplate` (or any `<`/`&` in a
+  log sample) reached Telegram as an unsupported start tag and failed the
+  send with **HTTP 400 on every agent emit that carried a pattern
+  template**. Added an `escapeHTML` template function and applied it to
+  every dynamic field; static markup and numeric fields are untouched.
+  Other channels are unaffected — email renders via `html/template`
+  (auto-escaped), and Slack/Lark/MS Teams place dynamic values inside
+  Markdown code spans (literal). A regression test renders the committed
+  template through `text/template` and asserts placeholders are escaped.
+
 ---
 
 ## [1.4.3] — 2026-05

--- a/config/agent_telegram.tmpl
+++ b/config/agent_telegram.tmpl
@@ -1,49 +1,55 @@
 {{/*
   Versus Agent — Telegram template (HTML parse_mode)
+
+  parse_mode=HTML is rendered by text/template, which does NOT auto-escape.
+  Every dynamic value is therefore piped through `escapeHTML` so miner
+  placeholders (e.g. `<*>` in .PatternTemplate) and arbitrary log text
+  cannot break Telegram's HTML parser. Static <b>/<code>/<pre> tags stay
+  literal; numeric fields (printf) need no escaping.
 */}}
 {{- $sevIcons := dict "critical" "🔴" "high" "🟠" "medium" "🟡" "low" "🟢" "info" "ℹ️" -}}
 {{- $sev := lower (or .Severity "info") -}}
 {{- $sevIcon := or (index $sevIcons $sev) "ℹ️" -}}
-<b>🤖 Versus Agent — {{ or .AlertName "AI-detected incident" }}</b>
+<b>🤖 Versus Agent — {{ escapeHTML (or .AlertName "AI-detected incident") }}</b>
 
-<b>{{ $sevIcon }} Severity:</b> {{ upper (or .Severity "INFO") }}
-<b>Service:</b> {{ or .ServiceName "_unknown" }}
+<b>{{ $sevIcon }} Severity:</b> {{ escapeHTML (upper (or .Severity "INFO")) }}
+<b>Service:</b> {{ escapeHTML (or .ServiceName "_unknown") }}
 {{- if .Source }}
-<b>Source:</b> {{ .Source }}
+<b>Source:</b> {{ escapeHTML .Source }}
 {{- end }}
 {{- if .Category }}
-<b>Category:</b> {{ .Category }}
+<b>Category:</b> {{ escapeHTML .Category }}
 {{- end }}
 {{- if .Verdict }}
-<b>Verdict:</b> {{ .Verdict }}
+<b>Verdict:</b> {{ escapeHTML .Verdict }}
 {{- end }}
 {{- if .Confidence }}
 <b>Confidence:</b> {{ printf "%.2f" .Confidence }}
 {{- end }}
 
 <b>Summary:</b>
-{{ or .Summary "(no summary)" }}
+{{ escapeHTML (or .Summary "(no summary)") }}
 
 {{- if .Frequency }}
 <b>Frequency:</b> {{ .Frequency }} (baseline {{ printf "%.2f" .Baseline }})
 {{- end }}
 {{- if .PatternID }}
-<b>Pattern:</b> <code>{{ .PatternID }}</code>
+<b>Pattern:</b> <code>{{ escapeHTML .PatternID }}</code>
 {{- end }}
 {{- if .PatternTemplate }}
-<b>Template:</b> <code>{{ .PatternTemplate }}</code>
+<b>Template:</b> <code>{{ escapeHTML .PatternTemplate }}</code>
 {{- end }}
 
 {{- if .Suggestions }}
 
 <b>Suggestions:</b>
 {{- range $i, $s := .Suggestions }}
-• {{ $s }}
+• {{ escapeHTML $s }}
 {{- end }}
 {{- end }}
 
 {{- if .Logs }}
 
 <b>Sample log:</b>
-<pre>{{ .Logs }}</pre>
+<pre>{{ escapeHTML .Logs }}</pre>
 {{- end }}

--- a/pkg/utils/func_maps.go
+++ b/pkg/utils/func_maps.go
@@ -4,6 +4,7 @@ package utils
 import (
 	"bytes"
 	"fmt"
+	"html"
 	"html/template"
 	"net/url"
 	"os"
@@ -125,6 +126,15 @@ func GetTemplateFuncMaps() template.FuncMap {
 			return 0
 		},
 		"urlquery": url.QueryEscape,
+		// escapeHTML escapes <, >, &, and quotes so a dynamic value is safe
+		// to interpolate into an HTML parse_mode body. The agent channel
+		// templates are rendered by text/template (no auto-escaping), so a
+		// miner placeholder like `<*>` in .PatternTemplate would otherwise
+		// reach Telegram as an unsupported start tag and 400 the send.
+		// Accepts any value (templates pipe `or`-defaulted interfaces here).
+		"escapeHTML": func(v interface{}) string {
+			return html.EscapeString(fmt.Sprint(v))
+		},
 		"truncate": func(s string, n int) string {
 			if len(s) <= n {
 				return s

--- a/pkg/utils/func_maps_test.go
+++ b/pkg/utils/func_maps_test.go
@@ -1,10 +1,13 @@
 package utils
 
 import (
+	"bytes"
 	"html/template"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	texttemplate "text/template"
 )
 
 func TestTemplateDict_Set(t *testing.T) {
@@ -351,5 +354,76 @@ func TestIsTrue_ViaTemplate(t *testing.T) {
 		if !not(v) {
 			t.Errorf("not(%#v) should be true", v)
 		}
+	}
+}
+
+func TestEscapeHTMLFunc(t *testing.T) {
+	esc, ok := GetTemplateFuncMaps()["escapeHTML"].(func(interface{}) string)
+	if !ok {
+		t.Fatal("escapeHTML not registered as func(interface{}) string")
+	}
+	cases := []struct {
+		name string
+		in   interface{}
+		want string
+	}{
+		{"miner placeholder", "<*>", "&lt;*&gt;"},
+		{"ampersand", "a & b", "a &amp; b"},
+		{"angle pair", "<b>x</b>", "&lt;b&gt;x&lt;/b&gt;"},
+		{"plain", "api-gateway", "api-gateway"},
+		{"empty", "", ""},
+		{"number", 42, "42"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := esc(c.in); got != c.want {
+				t.Errorf("escapeHTML(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestAgentTelegramTemplateEscapesDynamicFields renders the real committed
+// agent_telegram.tmpl through text/template (the exact path the Telegram
+// provider uses) and asserts miner placeholders / arbitrary log text are
+// escaped, while static markup stays literal. Reproduces the live Telegram
+// 400 ("Unsupported start tag") class as a regression guard.
+func TestAgentTelegramTemplateEscapesDynamicFields(t *testing.T) {
+	path := filepath.Join("..", "..", AgentTelegramTemplatePath)
+	tmpl, err := texttemplate.New(filepath.Base(path)).
+		Funcs(GetTemplateFuncMaps()).
+		ParseFiles(path)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	content := map[string]interface{}{
+		"AlertName":       "spike <*>",
+		"ServiceName":     "api-gateway",
+		"Summary":         "errors & timeouts <spiking>",
+		"PatternID":       "p_abc",
+		"PatternTemplate": `WARN service = api-gateway message = " rate limit exceeded for client <*> endpoint <*>`,
+		"Logs":            "2026-01-01 ERROR <*> connection refused & reset",
+		"Suggestions":     []interface{}{"check <upstream>"},
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, content); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := buf.String()
+
+	if strings.Contains(out, "<*>") {
+		t.Errorf("raw <*> survived in rendered telegram body:\n%s", out)
+	}
+	if !strings.Contains(out, "&lt;*&gt;") {
+		t.Errorf("expected escaped &lt;*&gt; in rendered body:\n%s", out)
+	}
+	if strings.Contains(out, "<spiking>") || !strings.Contains(out, "&lt;spiking&gt;") {
+		t.Errorf("summary angle text not escaped:\n%s", out)
+	}
+	// Static markup must remain literal (proves we escaped values, not tags).
+	if !strings.Contains(out, "<code>") || !strings.Contains(out, "<pre>") {
+		t.Errorf("static HTML tags should remain literal:\n%s", out)
 	}
 }

--- a/src/agent/channels/telegram.md
+++ b/src/agent/channels/telegram.md
@@ -69,4 +69,10 @@ Telegram supports a MarkdownV2/HTML subset — keep formatting simple. Agent
 detections use `config/agent_telegram.tmpl` when present. See
 [Template Syntax](../../webhook/template-syntax.md) for the available fields and
 functions.
+
+> **HTML parse mode:** the agent template uses `parse_mode=HTML`, which
+> `text/template` does **not** auto-escape. Pipe any dynamic value through
+> the `escapeHTML` function (e.g. `<code>{{ escapeHTML .PatternTemplate }}</code>`)
+> so log text or miner placeholders like `<*>` cannot break Telegram's HTML
+> parser. Static tags such as `<b>`/`<code>`/`<pre>` stay literal.
 </content>


### PR DESCRIPTION
## Problem

Every AI-agent emission routed to Telegram that carries a pattern template
fails to send with **HTTP 400** from the Telegram API:

```
Bad Request: can't parse entities: Unsupported start tag "*" at byte offset N
```

## Root cause

`config/agent_telegram.tmpl` is sent with `parse_mode=HTML` but is rendered by
`text/template` (`pkg/common/telegram.go` imports `text/template`), which does
**not** auto-escape. The Drain miner emits templates containing `<*>`
placeholders (e.g. `… for client <*> endpoint /api/<*>`), and `.Logs` samples
routinely contain `<`/`&`. These reach Telegram as malformed HTML tags and the
send 400s — so agent detections silently never arrive on Telegram.

## Fix

- Add an `escapeHTML` template helper (`html.EscapeString`) to the shared
  FuncMap in `pkg/utils/func_maps.go`.
- Apply it to every **dynamic** field in `config/agent_telegram.tmpl`
  (`.AlertName`, `.ServiceName`, `.Source`, `.Category`, `.Verdict`,
  `.Summary`, `.PatternID`, `.PatternTemplate`, suggestions, `.Logs`). Static
  `<b>`/`<code>`/`<pre>` tags and numeric `printf` fields are left untouched.

## Scope — why only Telegram

I swept the other agent channels; none need this and escaping them would be
wrong:

| Channel | Renderer | Dynamic value placement | Action |
|---|---|---|---|
| Telegram | `text/template` + `parse_mode=HTML` | raw in HTML | **fixed** |
| Email | `html/template` | auto-escaped | none |
| Slack / Lark / MS Teams | `text/template` + Markdown | inside code spans (literal) | none |
| Viber | `text/template` + plain text | literal | none |

## Testing

- **Unit:** table-driven `escapeHTML` cases (`pkg/utils/func_maps_test.go`).
- **Regression:** renders the committed `agent_telegram.tmpl` through
  `text/template` with a `<*>`-bearing finding and asserts placeholders are
  escaped (`&lt;*&gt;`) while static tags stay literal.
- **Live round-trip:** verified against the real Telegram Bot API — the raw
  `<code><*></code>` form returns HTTP 400 (`Unsupported start tag "*"`); the
  escaped form returns HTTP 200. End-to-end through the binary
  (`POST /api/incidents` with a pattern template containing `<*>`) the incident
  now records `notify_status: sent` with no error.
- `gofmt`, `go vet`, `go build ./...`, `go test -race ./pkg/...` green
  (one unrelated pre-existing failure: `TestGitChangeFeed_RealRepo_Eino`
  clones a remote repo and fails offline).

## Checklist

- [x] Table-driven test for the new behavior
- [x] No config schema change (template + helper only) — no triple-touch needed
- [x] House conventions (`fix:` prefix, import grouping)
- [x] CHANGELOG + Telegram channel doc updated
