### PR TITLE
feature(agent): add base_url for the detect and analyze chat agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   single-tenant build is unchanged by default.
 - **Helm** — `agent.tools.findRunbook.*` values + configmap wiring.
 
+#### AI SRE Agent — bring-your-own LLM (`agent.ai.base_url`)
+- **`base_url` for the chat agents** (`pkg/config/agent.go`,
+  `pkg/agent/factory_ai.go`) — `agent.ai.base_url` (env
+  `AGENT_AI_BASE_URL`) points both the detect and analyze agents at any
+  OpenAI-compatible endpoint (Ollama / vLLM / LocalAI, an LLM gateway in
+  front of Bedrock, or Gemini's OpenAI-compatible endpoint), so inference
+  can stay inside the operator's network — a compliance requirement for
+  self-hosted and regulated environments. `detect.Options` and
+  `analyze.Options` already accepted a `BaseURL` (test-only until now); the
+  factory simply never set it from config. Per-task overrides:
+  `agent.ai.detect.base_url` and `agent.ai.analyze.base_url`. Empty keeps
+  the OpenAI default — existing deployments are unchanged.
+- **Helm** — `agent.ai.baseUrl` + `agent.ai.analyze.baseUrl` values and
+  configmap wiring.
+
 ---
 
 ## [1.4.3] — 2026-05

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -234,6 +234,10 @@ agent:
   ai:
     enable: false                   # master switch (env: AGENT_AI_ENABLE)
     api_key: ${AGENT_AI_API_KEY}
+    # base_url: override the chat endpoint to any OpenAI-compatible server
+    # (Ollama, vLLM, LocalAI, an LLM gateway, or Gemini's OpenAI endpoint).
+    # Empty uses the OpenAI default. Keeps inference inside your own network.
+    base_url: ${AGENT_AI_BASE_URL}
     model: "gpt-5.4-mini"
     # temperature: 0.0–2.0 (default 0.2). Set a NEGATIVE value (e.g. -1) to
     # omit temperature so the provider uses its own default.
@@ -251,6 +255,7 @@ agent:
     # true; the block below only tunes it.
     analyze:
       # model: "gpt-4o"             # override the shared `ai.model` for analyze deep dives
+      # base_url: "..."             # override the shared `ai.base_url` for analyze deep dives
 
   # New-service grace: when a previously unseen service starts emitting logs
   # in detect mode, it enters an implicit training window so the catalog can

--- a/helm/versus-incident/templates/configmap.yaml
+++ b/helm/versus-incident/templates/configmap.yaml
@@ -231,14 +231,22 @@ data:
       ai:
         enable: {{ .Values.agent.ai.enable }}
         api_key: ${AGENT_AI_API_KEY}
+        {{- if .Values.agent.ai.baseUrl }}
+        base_url: {{ .Values.agent.ai.baseUrl | quote }}
+        {{- end }}
         model: {{ .Values.agent.ai.model | default "gpt-4o-mini" | quote }}
         temperature: {{ .Values.agent.ai.temperature | default 0.2 }}
         max_tokens: {{ .Values.agent.ai.maxTokens | default 512 }}
         max_calls_per_hour: {{ .Values.agent.ai.maxCallsPerHour | default 60 }}
         cache_ttl: {{ .Values.agent.ai.cacheTtl | default "1h" | quote }}
-        {{- if .Values.agent.ai.analyze.model }}
+        {{- if or .Values.agent.ai.analyze.model .Values.agent.ai.analyze.baseUrl }}
         analyze:
+          {{- if .Values.agent.ai.analyze.model }}
           model: {{ .Values.agent.ai.analyze.model | quote }}
+          {{- end }}
+          {{- if .Values.agent.ai.analyze.baseUrl }}
+          base_url: {{ .Values.agent.ai.analyze.baseUrl | quote }}
+          {{- end }}
         {{- end }}
     {{- end }}
 

--- a/helm/versus-incident/values.yaml
+++ b/helm/versus-incident/values.yaml
@@ -129,6 +129,10 @@ agent:
     # OpenAI API key. Stored in the chart Secret and exposed as
     # AGENT_AI_API_KEY env var.
     apiKey: ""
+    # Override the chat endpoint to any OpenAI-compatible server (Ollama,
+    # vLLM, LocalAI, an LLM gateway, or Gemini's OpenAI endpoint). Empty
+    # uses the OpenAI default. Not a secret — rendered into the ConfigMap.
+    baseUrl: ""
     model: "gpt-4o-mini"
     # Randomness control. Set -1 to omit temperature entirely for
     # beta-limited / reasoning models (gpt-5.*, o-series) that fix it
@@ -145,6 +149,9 @@ agent:
       # Override the shared ai.model for analyze deep dives. Empty inherits
       # the top-level model above.
       model: ""
+      # Override the shared ai.baseUrl for analyze deep dives. Empty inherits
+      # the top-level base_url above.
+      baseUrl: ""
 
   # Per-tool configuration for the analyze tools (rendered into tools.yaml).
   # This is DATA config only, never a registration allow-list — tools are

--- a/pkg/agent/factory_ai.go
+++ b/pkg/agent/factory_ai.go
@@ -60,6 +60,7 @@ func BuildAIs(cfg config.AgentConfig, catalog *Catalog, store storage.Provider, 
 	detectCfg := cfg.AI.Resolve(cfg.AI.Detect)
 	detectAgent, err := detect.New(context.Background(), detectCfg, detect.Options{
 		HTTPClient: httpClient,
+		BaseURL:    detectCfg.BaseURL,
 	})
 	if err != nil {
 		log.Printf("agent: detect agent disabled: %v", err)
@@ -77,7 +78,10 @@ func BuildAIs(cfg config.AgentConfig, catalog *Catalog, store storage.Provider, 
 	var analyzeRate *ai.RateLimiter
 	var runbookMgr *runbook.Manager
 	{
-		analyzeBaseCfg := cfg.AI.Resolve(config.AgentAITaskConfig{Model: cfg.AI.Analyze.Model})
+		analyzeBaseCfg := cfg.AI.Resolve(config.AgentAITaskConfig{
+			Model:   cfg.AI.Analyze.Model,
+			BaseURL: cfg.AI.Analyze.BaseURL,
+		})
 
 		// Independent source set + redactor for the read-only
 		// get_related_logs tool. Built separately from the worker's
@@ -138,6 +142,7 @@ func BuildAIs(cfg config.AgentConfig, catalog *Catalog, store storage.Provider, 
 		tools := analyzetools.Default(store, newCatalogAdapter(catalog), reader, redactor, serviceMatcher, graph, changes, embedder, runbookSearcher)
 		a, aErr := analyze.New(context.Background(), analyzeBaseCfg, tools, analyze.Options{
 			HTTPClient:    httpClient,
+			BaseURL:       analyzeBaseCfg.BaseURL,
 			ToolTimeout:   parseDurationOr(cfg.Tools.ToolTimeout, 20*time.Second),
 			ParallelTools: cfg.Tools.ParallelTools,
 		})

--- a/pkg/agent/factory_ai_base_url_test.go
+++ b/pkg/agent/factory_ai_base_url_test.go
@@ -1,0 +1,71 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/config"
+	"github.com/VersusControl/versus-incident/pkg/core"
+	"github.com/VersusControl/versus-incident/pkg/storage"
+)
+
+// TestBuildAIs_ThreadsBaseURLIntoDetect asserts the factory wires
+// cfg.AI.BaseURL into the detect agent's chat client: a detect Run lands
+// on the configured endpoint, not api.openai.com. detect/analyze.Options
+// already honored BaseURL; the factory was the missing link that never set
+// it. An httptest server stands in for any OpenAI-compatible backend
+// (Ollama / vLLM / LocalAI / gateway).
+func TestBuildAIs_ThreadsBaseURLIntoDetect(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		content, _ := json.Marshal(map[string]any{
+			"title": "x", "summary": "y", "severity": "low", "confidence": 0.5,
+		})
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      "chatcmpl-test",
+			"object":  "chat.completion",
+			"created": time.Now().Unix(),
+			"model":   "test",
+			"choices": []map[string]any{{
+				"index":         0,
+				"finish_reason": "stop",
+				"message":       map[string]any{"role": "assistant", "content": string(content)},
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	cat, err := LoadCatalog(storage.NewMemory())
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+
+	cfg := config.AgentConfig{}
+	cfg.AI.Enable = true
+	cfg.AI.APIKey = "test-key"
+	cfg.AI.Model = "gpt-4o-mini"
+	cfg.AI.BaseURL = srv.URL
+
+	bundle := BuildAIs(cfg, cat, storage.NewMemory(), nil)
+	if bundle.Detect == nil {
+		t.Fatal("detect agent not built")
+	}
+
+	if _, err := bundle.Detect.Run(context.Background(), core.DetectTask{
+		Result: core.AgentResult{Template: "WARN <*> failed", Frequency: 1},
+	}); err != nil {
+		t.Fatalf("detect Run: %v", err)
+	}
+
+	if atomic.LoadInt32(&hits) == 0 {
+		t.Error("detect agent did not call the configured base_url")
+	}
+}

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -305,6 +305,13 @@ type AgentAIConfig struct {
 	Enable bool `mapstructure:"enable"`
 	// APIKey is the bearer token sent in the Authorization header.
 	APIKey string `mapstructure:"api_key"`
+	// BaseURL overrides the chat/completions endpoint. Empty uses the
+	// OpenAI default (api.openai.com/v1). Point it at any OpenAI-compatible
+	// server (Ollama, vLLM, LocalAI, an LLM gateway in front of Bedrock,
+	// or Gemini's OpenAI-compatible endpoint) to keep inference inside the
+	// operator's own network — a compliance requirement for self-hosted
+	// and regulated environments. Per-task overrides live on detect/analyze.
+	BaseURL string `mapstructure:"base_url"`
 	// Model is the model identifier, e.g. "gpt-4o-mini".
 	Model string `mapstructure:"model"`
 	// Temperature controls randomness (0.0–2.0). Default 0.2.
@@ -343,12 +350,17 @@ type AgentAIAnalyzeConfig struct {
 	// Model overrides the shared ai.model for analyze deep dives.
 	// Empty inherits ai.model.
 	Model string `mapstructure:"model"`
+	// BaseURL overrides the shared ai.base_url for analyze deep dives
+	// (e.g. a stronger model behind a different endpoint). Empty inherits
+	// ai.base_url.
+	BaseURL string `mapstructure:"base_url"`
 }
 
 // AgentAITaskConfig is the per-task override block. Zero values mean
 // "inherit the top-level AgentAIConfig field".
 type AgentAITaskConfig struct {
 	Model           string  `mapstructure:"model"`
+	BaseURL         string  `mapstructure:"base_url"`
 	Temperature     float64 `mapstructure:"temperature"`
 	MaxTokens       int     `mapstructure:"max_tokens"`
 	MaxCallsPerHour int     `mapstructure:"max_calls_per_hour"`
@@ -369,6 +381,9 @@ func (c AgentAIConfig) Resolve(task AgentAITaskConfig) AgentAIConfig {
 
 	if task.Model != "" {
 		out.Model = task.Model
+	}
+	if task.BaseURL != "" {
+		out.BaseURL = task.BaseURL
 	}
 	if task.Temperature != 0 {
 		out.Temperature = task.Temperature

--- a/pkg/config/clone_config.go
+++ b/pkg/config/clone_config.go
@@ -332,6 +332,7 @@ func cloneAgentConfig(src AgentConfig) AgentConfig {
 		AI: AgentAIConfig{
 			Enable:          src.AI.Enable,
 			APIKey:          src.AI.APIKey,
+			BaseURL:         src.AI.BaseURL,
 			Model:           src.AI.Model,
 			Temperature:     src.AI.Temperature,
 			MaxTokens:       src.AI.MaxTokens,
@@ -478,6 +479,7 @@ func cloneToolsConfig(src ToolsConfig) ToolsConfig {
 func cloneAgentAITaskConfig(src AgentAITaskConfig) AgentAITaskConfig {
 	return AgentAITaskConfig{
 		Model:           src.Model,
+		BaseURL:         src.BaseURL,
 		Temperature:     src.Temperature,
 		MaxTokens:       src.MaxTokens,
 		MaxCallsPerHour: src.MaxCallsPerHour,
@@ -489,6 +491,7 @@ func cloneAgentAITaskConfig(src AgentAITaskConfig) AgentAITaskConfig {
 // override only; the tool-loop knobs live on the shared tools block).
 func cloneAgentAIAnalyzeConfig(src AgentAIAnalyzeConfig) AgentAIAnalyzeConfig {
 	return AgentAIAnalyzeConfig{
-		Model: src.Model,
+		Model:   src.Model,
+		BaseURL: src.BaseURL,
 	}
 }

--- a/pkg/config/clone_config_test.go
+++ b/pkg/config/clone_config_test.go
@@ -94,3 +94,40 @@ func TestCloneConfigCarriesToolsConfig(t *testing.T) {
 		t.Fatalf("tools block = %+v, want %+v", dst.Agent.Tools, src.Agent.Tools)
 	}
 }
+
+// TestResolveCarriesBaseURL asserts the shared ai.base_url flows through
+// Resolve when a task does not override it, and that a per-task base_url
+// wins when set — the contract the factory relies on to point detect and
+// analyze at an OpenAI-compatible endpoint.
+func TestResolveCarriesBaseURL(t *testing.T) {
+	base := AgentAIConfig{APIKey: "k", BaseURL: "http://shared:11434/v1", Model: "m"}
+
+	if got := base.Resolve(AgentAITaskConfig{}); got.BaseURL != "http://shared:11434/v1" {
+		t.Errorf("Resolve dropped top-level base_url: %q", got.BaseURL)
+	}
+	if got := base.Resolve(AgentAITaskConfig{BaseURL: "http://detect:8080/v1"}); got.BaseURL != "http://detect:8080/v1" {
+		t.Errorf("Resolve ignored per-task base_url: %q", got.BaseURL)
+	}
+}
+
+// TestCloneConfigCarriesBaseURL asserts base_url survives a full
+// cloneConfig round-trip at every level (shared, detect, analyze) — the
+// config triple-touch landmine that silently drops per-request overrides
+// when a new field is added to the struct but not the deep-clone.
+func TestCloneConfigCarriesBaseURL(t *testing.T) {
+	src := &Config{}
+	src.Agent.AI.BaseURL = "http://shared/v1"
+	src.Agent.AI.Detect = AgentAITaskConfig{BaseURL: "http://detect/v1"}
+	src.Agent.AI.Analyze = AgentAIAnalyzeConfig{BaseURL: "http://analyze/v1"}
+
+	dst := cloneConfig(src)
+	if dst.Agent.AI.BaseURL != "http://shared/v1" {
+		t.Errorf("shared base_url lost: %q", dst.Agent.AI.BaseURL)
+	}
+	if dst.Agent.AI.Detect.BaseURL != "http://detect/v1" {
+		t.Errorf("detect base_url lost: %q", dst.Agent.AI.Detect.BaseURL)
+	}
+	if dst.Agent.AI.Analyze.BaseURL != "http://analyze/v1" {
+		t.Errorf("analyze base_url lost: %q", dst.Agent.AI.Analyze.BaseURL)
+	}
+}

--- a/src/agent/ai-detect-mode.md
+++ b/src/agent/ai-detect-mode.md
@@ -57,6 +57,7 @@ agent:
   ai:
     enable: true                       # opt in to live AI calls
     api_key: ${AGENT_AI_API_KEY}       # OpenAI-compatible bearer key
+    base_url: ${AGENT_AI_BASE_URL}     # optional: any OpenAI-compatible endpoint
     model: gpt-4o-mini                 # any chat-completions model
     temperature: 0.2
     max_tokens: 800
@@ -74,13 +75,28 @@ Every field is overridable by env var:
 |---|---|
 | `AGENT_AI_ENABLE` | `agent.ai.enable` |
 | `AGENT_AI_API_KEY` | `agent.ai.api_key` |
+| `AGENT_AI_BASE_URL` | `agent.ai.base_url` |
 | `AGENT_AI_MODEL` | `agent.ai.model` |
 
-The chat endpoint is hard-coded to
-`https://api.openai.com/v1/chat/completions`. If you point
-`AGENT_AI_API_KEY` at an OpenAI-compatible provider (Azure
-OpenAI, vLLM proxy, etc.), set `model` to a name your provider
-accepts.
+### Bring your own LLM (`base_url`)
+
+`base_url` points both the detect and analyze agents at any
+OpenAI-compatible chat-completions endpoint. Leave it empty to use the
+OpenAI default (`https://api.openai.com/v1`); set it to keep inference
+inside your own network:
+
+```yaml
+agent:
+  ai:
+    base_url: "http://ollama:11434/v1"   # Ollama / vLLM / LocalAI
+    model: "llama3.1"
+```
+
+Common targets: a local **Ollama** / **vLLM** / **LocalAI** server, an
+LLM gateway in front of **AWS Bedrock**, or Gemini's OpenAI-compatible
+endpoint. Set `model` to a name your provider accepts. The analyze agent
+can override the endpoint independently via `agent.ai.analyze.base_url`
+(e.g. a stronger model behind a different gateway).
 
 You almost always want a small **new-service grace** so the agent
 doesn't page on the first signal from a freshly-deployed


### PR DESCRIPTION
## Summary

Adds `agent.ai.base_url` (env `AGENT_AI_BASE_URL`) so the detect **and**
analyze chat agents can target any OpenAI-compatible endpoint — Ollama,
vLLM, LocalAI, an LLM gateway in front of AWS Bedrock, or Gemini's
OpenAI-compatible endpoint. Inference can stay inside the operator's own
network, which is a hard requirement for self-hosted and regulated
deployments.

## The missing link

`detect.Options` and `analyze.Options` **already** carry a `BaseURL` field
and forward it to the Eino chat model — but it was documented test-only and
the factory never set it from config. The embedder path already wires
`EmbeddingBaseURL`; the chat path was the gap. This PR closes it.

## Changes

- `AgentAIConfig.BaseURL` + per-task overrides `detect.base_url` /
  `analyze.base_url`, carried through `Resolve()` and the `clone_config`
  deep-clone (the config triple-touch: struct + clone + yaml).
- `factory_ai.go` threads the resolved `base_url` into both `detect.Options`
  and `analyze.Options`.
- `config/config.yaml`, Helm (`agent.ai.baseUrl` + `agent.ai.analyze.baseUrl`
  values + configmap rendering), and the detect-mode docs (replaces the
  now-obsolete "chat endpoint is hard-coded" note).

Empty `base_url` keeps the OpenAI default (`api.openai.com/v1`), so existing
deployments are unchanged.

## Testing

- **Config:** `Resolve` carries the shared `base_url` and lets a per-task
  value override it; `cloneConfig` preserves `base_url` at the shared,
  detect, and analyze levels (guards the triple-touch landmine).
- **Factory (httptest):** `BuildAIs` with `cfg.AI.BaseURL` set to a local
  test server, then a real detect `Run` — asserts the agent's chat client
  hits the configured endpoint, not `api.openai.com`.
- **Live:** verified against Gemini's OpenAI-compatible endpoint
  (`/v1beta/openai/chat/completions`) — the request authenticates and the
  endpoint accepts the OpenAI request shape (a real completion needs quota
  enabled on the key).
- `gofmt`, `go vet`, `go build ./...`, `go test -race ./pkg/config ./pkg/agent`
  green; `helm template` renders the `base_url` keys (and omits them when
  empty).

## Checklist

- [x] Table-driven / httptest tests for the new behavior
- [x] Config triple-touch (struct + clone_config + config.yaml)
- [x] Helm values + configmap mirrored
- [x] Backward compatible (empty `base_url` = OpenAI default)
- [x] House conventions (`feature:` prefix, import grouping); docs + CHANGELOG
