### PR TITLE
feature(agent): make catalog EWMA alpha configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   single-tenant build is unchanged by default.
 - **Helm** — `agent.tools.findRunbook.*` values + configmap wiring.
 
+#### AI SRE Agent — configurable EWMA baseline (`agent.catalog.ewma_alpha`)
+- **`ewma_alpha` catalog knob** (`pkg/config/agent.go`,
+  `pkg/agent/worker.go`) — the EWMA smoothing factor for each pattern's
+  baseline frequency was hardcoded to `0.2`; it is now configurable via
+  `agent.catalog.ewma_alpha` (default `0.2`, range `(0,1]`). The baseline
+  is what spike detection compares against, so this tunes spike
+  sensitivity. Carried through the `clone_config` deep-clone (config
+  triple-touch) and covered by a round-trip test.
+- **CONTRIBUTING** — documented the config triple-touch rule (struct +
+  `clone_config` + `config.yaml`) that this change follows, so future
+  config fields don't silently drop per-request overrides.
+
 ---
 
 ## [1.4.3] — 2026-05

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,18 @@ For Docker / Helm flows see the README.
 - **No phase references in code comments.** Roadmap phases belong in
   planning docs, not in code. Code comments describe what the code does
   today.
+- **Config fields are a triple-touch.** Adding a field to any config
+  struct in `pkg/config` means touching **three** places or it silently
+  breaks per-request query-param overrides (which run on a deep-cloned
+  config):
+  1. the struct field + `mapstructure:"snake_case"` tag in `pkg/config`,
+  2. the matching field in `cloneConfig` (and any `cloneAgent*` helper) in
+     `pkg/config/clone_config.go` — these are field-by-field copies, so an
+     omitted field is dropped from every cloned (overridden) request,
+  3. the documented default in `config/config.yaml`.
+  Add a `clone_config_test.go` assertion that the new field survives a
+  `cloneConfig` round-trip (see `TestCloneConfigCarries*`). Mirror the key
+  into the Helm chart only if its sibling block is already exposed there.
 
 For extension points (new alert channel, on-call provider, queue
 listener, signal source) follow the patterns in `pkg/common/` and

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -198,6 +198,11 @@ agent:
   catalog:
     persist_interval: 30s
     auto_promote_after: 50       # in detect mode, this many sightings = "known"
+    # EWMA smoothing factor for each pattern's baseline frequency
+    # (baseline = ewma_alpha*tick + (1-ewma_alpha)*baseline). Range (0,1];
+    # higher reacts faster to recent ticks, lower is steadier. This baseline
+    # is what spike_multiplier compares against. Default 0.2.
+    ewma_alpha: 0.2
     # Spike detection: a known pattern is re-flagged when its tick-level
     # frequency suddenly exceeds the EWMA (Exponentially Weighted Moving Average) baseline by `spike_multiplier`.
     # Two safety floors keep noise out:

--- a/pkg/agent/worker.go
+++ b/pkg/agent/worker.go
@@ -123,7 +123,11 @@ func NewWorker(opt WorkerOptions) (*Worker, error) {
 	w.pollInterval = parseDurationOr(opt.Cfg.PollInterval, 30*time.Second)
 	w.persistEvery = parseDurationOr(opt.Cfg.Catalog.PersistInterval, 30*time.Second)
 	w.lookback = parseDurationOr(opt.Cfg.Lookback, 5*time.Minute)
-	w.ewmaAlpha = 0.2 // configurable once spike detection lands
+	// EWMA smoothing factor for pattern baselines; 0 (unset) → 0.2 default.
+	w.ewmaAlpha = 0.2
+	if a := opt.Cfg.Catalog.EwmaAlpha; a > 0 {
+		w.ewmaAlpha = a
+	}
 	w.newServiceGrace = parseDurationOr(opt.Cfg.NewServiceGrace, 0)
 
 	return w, nil

--- a/pkg/agent/worker_ewma_test.go
+++ b/pkg/agent/worker_ewma_test.go
@@ -1,0 +1,37 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/VersusControl/versus-incident/pkg/config"
+	"github.com/VersusControl/versus-incident/pkg/storage"
+)
+
+// TestNewWorker_EwmaAlphaFromConfig asserts the worker reads the EWMA
+// smoothing factor from agent.catalog.ewma_alpha and falls back to 0.2
+// when unset (0). Previously the value was hardcoded to 0.2.
+func TestNewWorker_EwmaAlphaFromConfig(t *testing.T) {
+	mk := func(t *testing.T, alpha float64) *Worker {
+		t.Helper()
+		cat, err := LoadCatalog(storage.NewMemory())
+		if err != nil {
+			t.Fatalf("LoadCatalog: %v", err)
+		}
+		w, err := NewWorker(WorkerOptions{
+			Cfg:     config.AgentConfig{Catalog: config.AgentCatalogConfig{EwmaAlpha: alpha}},
+			Miner:   NewMiner(0.4, 4, 100),
+			Catalog: cat,
+		})
+		if err != nil {
+			t.Fatalf("NewWorker: %v", err)
+		}
+		return w
+	}
+
+	if got := mk(t, 0.35).ewmaAlpha; got != 0.35 {
+		t.Errorf("configured ewma_alpha = %v, want 0.35", got)
+	}
+	if got := mk(t, 0).ewmaAlpha; got != 0.2 {
+		t.Errorf("unset ewma_alpha default = %v, want 0.2", got)
+	}
+}

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -56,6 +56,13 @@ type AgentRedactionConfig struct {
 type AgentCatalogConfig struct {
 	PersistInterval  string `mapstructure:"persist_interval"`   // e.g. "30s"
 	AutoPromoteAfter int    `mapstructure:"auto_promote_after"` // 0 = never
+	// EwmaAlpha is the smoothing factor for each pattern's EWMA baseline
+	// frequency: baseline = alpha*tickCount + (1-alpha)*baseline. Higher
+	// reacts faster to recent ticks; lower is steadier. Range (0,1].
+	// 0 (unset) falls back to the 0.2 default. This baseline is what spike
+	// detection compares against (spike_multiplier), so tuning it changes
+	// spike sensitivity.
+	EwmaAlpha float64 `mapstructure:"ewma_alpha"`
 	// SpikeMultiplier flags a tick as a frequency spike when the tick
 	// count exceeds the pattern's prior EWMA baseline by this factor.
 	// 0 disables spike detection. Default 5.0.

--- a/pkg/config/clone_config.go
+++ b/pkg/config/clone_config.go
@@ -317,6 +317,7 @@ func cloneAgentConfig(src AgentConfig) AgentConfig {
 		Catalog: AgentCatalogConfig{
 			PersistInterval:       src.Catalog.PersistInterval,
 			AutoPromoteAfter:      src.Catalog.AutoPromoteAfter,
+			EwmaAlpha:             src.Catalog.EwmaAlpha,
 			SpikeMultiplier:       src.Catalog.SpikeMultiplier,
 			SpikeMinFrequency:     src.Catalog.SpikeMinFrequency,
 			SpikeMinBaselineCount: src.Catalog.SpikeMinBaselineCount,

--- a/pkg/config/clone_config_test.go
+++ b/pkg/config/clone_config_test.go
@@ -94,3 +94,16 @@ func TestCloneConfigCarriesToolsConfig(t *testing.T) {
 		t.Fatalf("tools block = %+v, want %+v", dst.Agent.Tools, src.Agent.Tools)
 	}
 }
+
+// TestCloneConfigCarriesEwmaAlpha asserts the catalog ewma_alpha survives
+// a cloneConfig round-trip — without the clone_config mirror, per-request
+// overrides would silently reset the baseline smoothing factor to zero
+// (→ the 0.2 fallback), changing spike sensitivity.
+func TestCloneConfigCarriesEwmaAlpha(t *testing.T) {
+	src := &Config{}
+	src.Agent.Catalog.EwmaAlpha = 0.35
+	dst := cloneConfig(src)
+	if dst.Agent.Catalog.EwmaAlpha != 0.35 {
+		t.Fatalf("ewma_alpha = %v, want 0.35", dst.Agent.Catalog.EwmaAlpha)
+	}
+}

--- a/src/agent/configuration.md
+++ b/src/agent/configuration.md
@@ -123,12 +123,14 @@ the schema and admin workflows.
 catalog:
   persist_interval: 30s
   auto_promote_after: 100
+  ewma_alpha: 0.2
 ```
 
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `persist_interval` | duration | `30s` | How often the in-memory catalog is flushed to `data/patterns.json`. |
 | `auto_promote_after` | int | `100` | A pattern seen this many times in `detect` mode is treated as known (won't alert). `0` disables the promotion. |
+| `ewma_alpha` | float | `0.2` | Smoothing factor for each pattern's EWMA baseline frequency (`baseline = ewma_alpha·tick + (1−ewma_alpha)·baseline`). Range `(0,1]`; higher reacts faster to recent ticks, lower is steadier. This baseline is what `spike_multiplier` compares against. `0` (unset) uses the default. |
 
 The storage backend itself is selected at the **root** of `config.yaml`
 (`storage.type`), not here. The on-disk filename is fixed


### PR DESCRIPTION
## Summary

Promotes the pattern-baseline EWMA smoothing factor from a hardcoded `0.2`
to a configurable `agent.catalog.ewma_alpha` (default `0.2`, range
`(0,1]`). Each pattern's baseline frequency is
`baseline = ewma_alpha·tick + (1−ewma_alpha)·baseline`; higher reacts
faster to recent ticks, lower is steadier. Since spike detection compares
the live frequency against this baseline (`spike_multiplier`), the knob
directly tunes spike sensitivity — previously un-tunable.

## Changes

- `AgentCatalogConfig.EwmaAlpha` (`ewma_alpha`), threaded into the worker
  with a `0.2` fallback when unset; `catalog.go` keeps its defensive
  `alpha <= 0` floor.
- Config triple-touch: struct + `clone_config` deep-clone +
  `config/config.yaml` default, with a `cloneConfig` round-trip test (an
  un-mirrored field silently resets to `0` → the fallback on every
  query-param-overridden request).
- Docs: `src/agent/configuration.md` catalog table + `CHANGELOG`.
- **CONTRIBUTING:** documents the config triple-touch rule itself, so
  future config fields don't repeat the omission.

## Not in Helm — deliberately

The chart exposes **no** `agent.catalog` tuning today (`spike_multiplier`,
`persist_interval`, `auto_promote_after` are all code-default only), so
`ewma_alpha` follows the same convention rather than being the lone catalog
knob in `values.yaml`. Happy to add the whole catalog block to the chart in
a follow-up if you'd prefer.

## Testing

- `TestNewWorker_EwmaAlphaFromConfig` — worker reads the configured value
  and defaults to `0.2` when unset.
- `TestCloneConfigCarriesEwmaAlpha` — survives a `cloneConfig` round-trip.
- `gofmt`, `go vet`, `go build ./...`, `go test -race ./pkg/config ./pkg/agent`
  green.

## Checklist

- [x] Table-driven / round-trip tests for the new behavior
- [x] Config triple-touch (struct + clone_config + config.yaml)
- [x] Backward compatible (unset = `0.2` default)
- [x] House conventions (`feature:` prefix); docs + CHANGELOG + CONTRIBUTING
