### PR TITLE
fix(agent): dedup detect-mode emits within a window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   single-tenant build is unchanged by default.
 - **Helm** — `agent.tools.findRunbook.*` values + configmap wiring.
 
+### Fixed
+
+#### AI SRE Agent — detect-mode emit deduplication
+- **Stop re-emitting an incident every tick for a sustained anomaly**
+  (`pkg/agent/dedup.go`, `pkg/agent/worker.go`) — a long-running anomaly
+  re-clusters into the same pattern on every poll, and the worker re-sent
+  (and re-notified) on each tick — even the cached path still called
+  `send()`. A new `DedupStore` gates emission per `(service, pattern)` for
+  `agent.emit_dedup_window` (default `1h`; `"0"` disables) — Redis
+  `SETNX EX` when available (holds across replicas), with an in-memory
+  fallback like the cursor store. Suppressed emits record
+  `outcome="deduped"` in the detect log; a failed send releases the window
+  so the next tick retries. Config triple-touch + Helm
+  (`agent.emitDedupWindow`).
+
 ---
 
 ## [1.4.3] — 2026-05

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -263,6 +263,7 @@ func startAgent(ctx context.Context, app *fiber.App, cfg c.AgentConfig, gatewayS
 	}
 
 	cursors := agent.NewCursorStore(rdb)
+	dedup := agent.NewDedupStore(rdb, cfg.EmitDedupWindow)
 
 	aiBundle := agent.BuildAIs(cfg, catalog, store, nil)
 	if aiBundle.Detect != nil {
@@ -277,6 +278,7 @@ func startAgent(ctx context.Context, app *fiber.App, cfg c.AgentConfig, gatewayS
 		Cfg:      cfg,
 		Sources:  sources,
 		Cursors:  cursors,
+		Dedup:    dedup,
 		Redactor: redactor,
 		Matcher:  matcher,
 		Miner:    miner,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -186,6 +186,10 @@ agent:
   lookback: 5m                    # initial backfill window on startup
   batch_max: 5000                 # safety cap per tick
   signal_max_bytes: 65536         # cap on Signal.Raw
+  # Collapse repeat detect-mode emissions for the same (service, pattern)
+  # into one incident per window — a sustained anomaly re-clusters every
+  # tick and would otherwise re-notify on every poll. "0" disables.
+  emit_dedup_window: 1h
 
 
   redaction:

--- a/helm/versus-incident/templates/configmap.yaml
+++ b/helm/versus-incident/templates/configmap.yaml
@@ -227,6 +227,9 @@ data:
       poll_interval: {{ .Values.agent.pollInterval | default "30s" }}
       lookback: {{ .Values.agent.lookback | default "5m" }}
       new_service_grace: {{ .Values.agent.newServiceGrace | default "30m" }}
+      {{- if .Values.agent.emitDedupWindow }}
+      emit_dedup_window: {{ .Values.agent.emitDedupWindow | quote }}
+      {{- end }}
       sources_path: /app/config/agent_sources.yaml
       ai:
         enable: {{ .Values.agent.ai.enable }}

--- a/helm/versus-incident/values.yaml
+++ b/helm/versus-incident/values.yaml
@@ -120,6 +120,9 @@ agent:
   pollInterval: 30s
   lookback: 5m
   newServiceGrace: 30m
+  # Collapse repeat detect-mode emissions for the same (service, pattern)
+  # into one incident per window. Empty → 1h default; "0" disables.
+  emitDedupWindow: 1h
 
   ai:
     # AI analyzer toggle. Required for detect mode to actually call an LLM.

--- a/pkg/agent/dedup.go
+++ b/pkg/agent/dedup.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+// defaultEmitDedupWindow is used when agent.emit_dedup_window is unset.
+const defaultEmitDedupWindow = time.Hour
+
+// DedupStore suppresses duplicate incident emissions for the same anomaly
+// within a time window. A sustained anomaly re-clusters into the same
+// pattern every tick, so without dedup the worker re-emits (and re-notifies,
+// and re-spends on the cached AI finding) every poll interval. Redis SETNX
+// makes the "first in the window" check atomic across replicas; an
+// in-memory map is the fallback when Redis is unavailable (single-replica
+// dev / training), mirroring CursorStore's degrade-don't-crash behavior.
+type DedupStore struct {
+	rdb       *redis.Client
+	keyPrefix string
+	window    time.Duration
+
+	mu  sync.Mutex
+	mem map[string]time.Time // key -> expiry (in-memory fallback)
+}
+
+// NewDedupStore parses the configured window — empty falls back to the 1h
+// default; "0" disables dedup (every emit allowed). Pass rdb=nil for
+// in-memory only. An unparseable window logs nothing and uses the default
+// (config validation belongs at load time, not here).
+func NewDedupStore(rdb *redis.Client, window string) *DedupStore {
+	w := defaultEmitDedupWindow
+	if window != "" {
+		if d, err := time.ParseDuration(window); err == nil {
+			w = d
+		}
+	}
+	return &DedupStore{
+		rdb:       rdb,
+		keyPrefix: "versus:agent:emit:",
+		window:    w,
+		mem:       make(map[string]time.Time),
+	}
+}
+
+// Allow reports whether an emit for key is the first within the window and
+// atomically marks it. false means a prior emit is still within the window
+// and the caller should suppress this one. A non-positive window disables
+// dedup (always true).
+func (s *DedupStore) Allow(ctx context.Context, key string) bool {
+	if s.window <= 0 {
+		return true
+	}
+	if s.rdb != nil {
+		ok, err := s.rdb.SetNX(ctx, s.keyPrefix+key, "1", s.window).Result()
+		if err == nil {
+			return ok
+		}
+		// Redis error → fall through to in-memory; never block emission on
+		// a transient Redis blip.
+	}
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sweepLocked(now)
+	if exp, ok := s.mem[key]; ok && exp.After(now) {
+		return false
+	}
+	s.mem[key] = now.Add(s.window)
+	return true
+}
+
+// Release clears the dedup mark for key so the next tick may emit again.
+// Called when a send fails — a failed emit must not consume the window.
+func (s *DedupStore) Release(ctx context.Context, key string) {
+	if s.window <= 0 {
+		return
+	}
+	if s.rdb != nil {
+		_ = s.rdb.Del(ctx, s.keyPrefix+key).Err()
+	}
+	s.mu.Lock()
+	delete(s.mem, key)
+	s.mu.Unlock()
+}
+
+// sweepLocked drops expired in-memory entries so the map stays bounded by
+// the number of currently-active patterns. Caller holds s.mu.
+func (s *DedupStore) sweepLocked(now time.Time) {
+	for k, exp := range s.mem {
+		if !exp.After(now) {
+			delete(s.mem, k)
+		}
+	}
+}

--- a/pkg/agent/dedup_test.go
+++ b/pkg/agent/dedup_test.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestDedupStore_AllowAndRelease(t *testing.T) {
+	ctx := context.Background()
+	s := NewDedupStore(nil, "1h")
+
+	if !s.Allow(ctx, "svc:p1") {
+		t.Fatal("first Allow should be true")
+	}
+	if s.Allow(ctx, "svc:p1") {
+		t.Error("second Allow within window should be false (deduped)")
+	}
+	if !s.Allow(ctx, "svc:p2") {
+		t.Error("different key should be allowed independently")
+	}
+
+	// Release clears the mark so the next emit is allowed again (the failed-
+	// send recovery path).
+	s.Release(ctx, "svc:p1")
+	if !s.Allow(ctx, "svc:p1") {
+		t.Error("Allow after Release should be true")
+	}
+}
+
+func TestDedupStore_WindowExpiry(t *testing.T) {
+	ctx := context.Background()
+	s := NewDedupStore(nil, "30ms")
+
+	if !s.Allow(ctx, "k") {
+		t.Fatal("first Allow should be true")
+	}
+	if s.Allow(ctx, "k") {
+		t.Fatal("within window should be false")
+	}
+	time.Sleep(45 * time.Millisecond)
+	if !s.Allow(ctx, "k") {
+		t.Error("after window expiry Allow should be true again")
+	}
+}
+
+func TestDedupStore_ZeroWindowDisables(t *testing.T) {
+	ctx := context.Background()
+	s := NewDedupStore(nil, "0")
+	for i := 0; i < 3; i++ {
+		if !s.Allow(ctx, "k") {
+			t.Fatalf("window=0 must never dedup (call %d)", i)
+		}
+	}
+}
+
+func TestNewDedupStore_DefaultsWindow(t *testing.T) {
+	if got := NewDedupStore(nil, "").window; got != defaultEmitDedupWindow {
+		t.Errorf("empty window = %v, want default %v", got, defaultEmitDedupWindow)
+	}
+	if got := NewDedupStore(nil, "garbage").window; got != defaultEmitDedupWindow {
+		t.Errorf("unparseable window = %v, want default %v", got, defaultEmitDedupWindow)
+	}
+	if got := NewDedupStore(nil, "15m").window; got != 15*time.Minute {
+		t.Errorf("window = %v, want 15m", got)
+	}
+}

--- a/pkg/agent/worker.go
+++ b/pkg/agent/worker.go
@@ -47,6 +47,7 @@ type Worker struct {
 	cfg      config.AgentConfig
 	sources  []core.SignalSource
 	cursors  *CursorStore // nil → in-memory fallback
+	dedup    *DedupStore  // emit dedup gate; never nil after NewWorker
 	redactor *Redactor
 	matcher  *RegexMatcher
 	miner    *Miner
@@ -79,6 +80,7 @@ type WorkerOptions struct {
 	Cfg      config.AgentConfig
 	Sources  []core.SignalSource
 	Cursors  *CursorStore // optional; pass nil for in-memory cursors
+	Dedup    *DedupStore  // optional; nil → in-memory store from cfg.emit_dedup_window
 	Redactor *Redactor
 	Matcher  *RegexMatcher
 	Miner    *Miner
@@ -106,6 +108,7 @@ func NewWorker(opt WorkerOptions) (*Worker, error) {
 		matcher:  opt.Matcher,
 		miner:    opt.Miner,
 		catalog:  opt.Catalog,
+		dedup:    opt.Dedup,
 		shadow:   opt.Shadow,
 		detect:   opt.Detect,
 		services: opt.Services,
@@ -118,6 +121,12 @@ func NewWorker(opt WorkerOptions) (*Worker, error) {
 	}
 	if w.catalog == nil {
 		return nil, fmt.Errorf("agent: catalog is required")
+	}
+	// Emit dedup is on by default even if a caller forgets to inject one:
+	// fall back to an in-memory store sized from config. startAgent injects
+	// a Redis-backed store so the window holds across replicas/restarts.
+	if w.dedup == nil {
+		w.dedup = NewDedupStore(nil, opt.Cfg.EmitDedupWindow)
 	}
 
 	w.pollInterval = parseDurationOr(opt.Cfg.PollInterval, 30*time.Second)
@@ -423,13 +432,7 @@ func (w *Worker) emitDetect(
 		log.Printf("%sagent[detect]: cache hit pattern=%s verdict=%s freq=%d%s",
 			colorGreen, patternID, verdict, len(signals), colorReset)
 		evt.Finding = cached
-		outcome := w.send(cached, result, source, service, "cached")
-		evt.Outcome = outcome
-		if outcome == "send_error" {
-			evt.Error = "emitter returned error (see logs)"
-		}
-		w.detect.Record(evt)
-		return outcome
+		return w.emit(ctx, evt, cached, result, source, service, "cached")
 	}
 
 	// 3. Rate limit guard.
@@ -458,11 +461,38 @@ func (w *Worker) emitDetect(
 	evt.RawResponse = call.RawResponse
 	evt.DurationMs = call.DurationMs
 
-	outcome := w.send(finding, result, source, service, "emitted")
-	evt.Outcome = outcome
+	return w.emit(ctx, evt, finding, result, source, service, "emitted")
+}
+
+// emit applies the dedup gate, sends, and records the audit event. A
+// sustained anomaly re-clusters into the same (service, pattern) every
+// tick; the gate collapses that into one incident per dedup window instead
+// of one per poll. A failed send releases the gate so the next tick retries
+// rather than being suppressed for the whole window.
+func (w *Worker) emit(
+	ctx context.Context,
+	evt *DetectEvent,
+	finding *core.AIFinding,
+	result core.AgentResult,
+	source, service, okLabel string,
+) string {
+	key := service + ":" + result.PatternID
+	if w.dedup != nil && !w.dedup.Allow(ctx, key) {
+		log.Printf("%sagent[detect]: deduped pattern=%s service=%s (already emitted within window)%s",
+			colorGreen, result.PatternID, service, colorReset)
+		evt.Outcome = "deduped"
+		w.detect.Record(evt)
+		return "deduped"
+	}
+
+	outcome := w.send(finding, result, source, service, okLabel)
 	if outcome == "send_error" {
 		evt.Error = "emitter returned error (see logs)"
+		if w.dedup != nil {
+			w.dedup.Release(ctx, key) // a failed emit must not consume the window
+		}
 	}
+	evt.Outcome = outcome
 	w.detect.Record(evt)
 	return outcome
 }

--- a/pkg/agent/worker_dedup_test.go
+++ b/pkg/agent/worker_dedup_test.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/VersusControl/versus-incident/pkg/core"
+)
+
+// TestWorker_EmitDedup_SuppressesRepeat drives the same (service, pattern)
+// through emitDetect twice and asserts the second emit is suppressed
+// ("deduped", emitter not called again) — the core fix for the per-tick
+// re-emit/re-notify loop. A distinct pattern is unaffected.
+func TestWorker_EmitDedup_SuppressesRepeat(t *testing.T) {
+	finding := &core.AIFinding{Title: "x", Severity: "high", Confidence: 0.9}
+	ag := &fakeAgent{finding: finding}
+	var emitted int
+	emitter := func(_ *core.AIFinding, _ core.AgentResult, _, _ string) error {
+		emitted++
+		return nil
+	}
+	w := newWorkerForTest(t, AIBundle{Detect: ag}, emitter)
+
+	sig := []core.Signal{{Message: "boom"}}
+	o1 := w.emitDetect(context.Background(), "test", "pid-1", "boom", "svc-x", sig, core.VerdictUnknown, 0)
+	o2 := w.emitDetect(context.Background(), "test", "pid-1", "boom", "svc-x", sig, core.VerdictUnknown, 0)
+
+	if o1 != "emitted" {
+		t.Errorf("first outcome = %q, want emitted", o1)
+	}
+	if o2 != "deduped" {
+		t.Errorf("second outcome = %q, want deduped", o2)
+	}
+	if emitted != 1 {
+		t.Errorf("emitter called %d times, want 1 (dedup must suppress the repeat)", emitted)
+	}
+
+	if o3 := w.emitDetect(context.Background(), "test", "pid-2", "boom", "svc-x", sig, core.VerdictUnknown, 0); o3 != "emitted" {
+		t.Errorf("distinct pattern outcome = %q, want emitted", o3)
+	}
+}
+
+// TestWorker_EmitDedup_FailedSendReleasesWindow asserts a failed send does
+// not consume the dedup window: the next tick retries instead of being
+// silently suppressed.
+func TestWorker_EmitDedup_FailedSendReleasesWindow(t *testing.T) {
+	ag := &fakeAgent{finding: &core.AIFinding{Title: "x", Severity: "high"}}
+	var calls int
+	emitter := func(_ *core.AIFinding, _ core.AgentResult, _, _ string) error {
+		calls++
+		return errors.New("telegram down")
+	}
+	w := newWorkerForTest(t, AIBundle{Detect: ag}, emitter)
+	sig := []core.Signal{{Message: "boom"}}
+
+	o1 := w.emitDetect(context.Background(), "test", "pid-1", "boom", "svc-x", sig, core.VerdictUnknown, 0)
+	o2 := w.emitDetect(context.Background(), "test", "pid-1", "boom", "svc-x", sig, core.VerdictUnknown, 0)
+	if o1 != "send_error" || o2 != "send_error" {
+		t.Errorf("outcomes = %q,%q; want send_error,send_error (failed send must not consume the window)", o1, o2)
+	}
+	if calls != 2 {
+		t.Errorf("emitter called %d times, want 2 (retry after release)", calls)
+	}
+}

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -22,6 +22,12 @@ type AgentConfig struct {
 	// (post-redaction) log message to discover the service name.
 	ServicePatterns []string `mapstructure:"service_patterns"`
 
+	// EmitDedupWindow collapses repeat detect-mode emissions for the same
+	// (service, pattern) into one incident per window — a sustained anomaly
+	// re-clusters every tick and would otherwise re-notify on every poll.
+	// Empty falls back to 1h; "0" disables dedup. e.g. "1h", "30m".
+	EmitDedupWindow string `mapstructure:"emit_dedup_window"`
+
 	Redaction AgentRedactionConfig `mapstructure:"redaction"`
 	Catalog   AgentCatalogConfig   `mapstructure:"catalog"`
 	Miner     AgentMinerConfig     `mapstructure:"miner"`

--- a/pkg/config/clone_config.go
+++ b/pkg/config/clone_config.go
@@ -309,6 +309,7 @@ func cloneAgentConfig(src AgentConfig) AgentConfig {
 		BatchMax:        src.BatchMax,
 		SignalMaxBytes:  src.SignalMaxBytes,
 		NewServiceGrace: src.NewServiceGrace,
+		EmitDedupWindow: src.EmitDedupWindow,
 		ServicePatterns: append([]string(nil), src.ServicePatterns...),
 		Redaction: AgentRedactionConfig{
 			Enable:    src.Redaction.Enable,

--- a/src/agent/ai-detect-mode.md
+++ b/src/agent/ai-detect-mode.md
@@ -115,7 +115,8 @@ Each event captures:
 - **Parsed finding** — severity, summary, category, confidence,
   suggestions.
 - **Outcome** — whether the incident was emitted, served from
-  cache, skipped (dry / quota), or errored.
+  cache, suppressed as a duplicate (`deduped`, see `emit_dedup_window`),
+  skipped (dry / quota), or errored.
 
 Look at it through the admin UI (the **Detect** page in the
 sidebar):
@@ -251,6 +252,11 @@ move accordingly.
   reuses the prior finding for free. Bump it during incident
   storms; lower it if you want fresher analysis on long-running
   issues.
+- **`emit_dedup_window`** — `cache_ttl` saves the AI call on a
+  repeat, but the cached finding was still *re-sent* every poll;
+  this window collapses those repeats into one incident per
+  `(service, pattern)` (subsequent ticks log `deduped`). Default
+  `1h`; set `"0"` to restore one-incident-per-tick behavior.
 - **`new_service_grace`** — silences a brand-new service for the
   configured duration. The window starts the first time the
   agent sees the service, and is persisted in `patterns.json` so

--- a/src/agent/configuration.md
+++ b/src/agent/configuration.md
@@ -28,6 +28,7 @@ agent:
   lookback: 5m
   batch_max: 1000
   signal_max_bytes: 8192
+  emit_dedup_window: 1h
   redaction:   { … }
   catalog:     { … }
   miner:       { … }
@@ -50,6 +51,7 @@ agent:
 | `lookback` | duration | `5m` | Initial backfill window on first start (when there's no cursor yet). |
 | `batch_max` | int | `1000` | Safety cap on signals processed per tick per source. |
 | `signal_max_bytes` | int | `8192` | Truncates a single signal's `Raw` payload above this size. |
+| `emit_dedup_window` | duration | `1h` | In **detect** mode, collapses repeat emissions for the same `(service, pattern)` into one incident per window — a sustained anomaly re-clusters every tick and would otherwise re-notify on every poll. `"0"` disables. Redis-backed when available (holds across replicas/restarts), in-memory otherwise. |
 
 ## Modes
 


### PR DESCRIPTION
## Problem

In **detect** mode a sustained anomaly re-clusters into the same pattern on
every poll, and the worker re-emitted an incident on **every tick** — even
the cache-hit path (which skips the AI call) still called `send()`. One
ongoing issue therefore produced a new incident + notification every
`poll_interval`, spamming channels and the incident store.

## Fix

A `DedupStore` gates emission per `(service, pattern)` for a configurable
window (`agent.emit_dedup_window`, default `1h`; `"0"` restores the old
one-per-tick behavior):

- **Redis `SETNX EX`** makes the "first emit in the window" check atomic
  across replicas; an **in-memory map** is the fallback when Redis is
  unavailable, mirroring the existing `CursorStore` degrade-don't-crash
  pattern.
- Both emit sites (cache-hit and fresh AI call) go through one `emit()`
  helper that applies the gate.
- Suppressed emits record `outcome="deduped"` in the detect log (visible in
  the Detect audit view).
- A **failed send releases the window** (`Release`) so the next tick
  retries rather than being suppressed for the whole window.

## Scope

This is the windowed-dedup correctness fix only. Full incident lifecycle
(burst re-arm on frequency escalation, auto-resolve with hysteresis) is
intentionally out of scope here.

## Changes

- `pkg/agent/dedup.go` — `DedupStore` (`Allow` / `Release` / lazy sweep).
- `pkg/agent/worker.go` — `emit()` gate; both send paths refactored through it.
- Config triple-touch: `AgentConfig.EmitDedupWindow` + `clone_config` +
  `config/config.yaml`; Helm `agent.emitDedupWindow` (values + configmap);
  docs (`configuration.md`, `ai-detect-mode.md`).

## Testing

- `dedup_test.go` — allow/release, window expiry, `"0"` disables, default
  parsing.
- `worker_dedup_test.go` — `emitDetect` suppresses the repeat (`deduped`,
  emitter called once) and retries after a failed send.
- `gofmt`, `go vet`, `go build ./...`, `go test -race ./pkg/agent ./pkg/config`
  green; `helm template` renders `emit_dedup_window` (omitted when empty).

## Checklist

- [x] Tests for the new behavior (unit + worker path)
- [x] Config triple-touch + Helm mirrored
- [x] Backward compatible (`"0"` disables; default fixes the spam)
- [x] Redis-with-memory-fallback; single-replica safe
- [x] House conventions (`fix:` prefix); docs + CHANGELOG
