### PR TITLE
feature(agent): pre-computed baseline-delta finding strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   single-tenant build is unchanged by default.
 - **Helm** — `agent.tools.findRunbook.*` values + configmap wiring.
 
+#### AI SRE Agent — baseline-delta finding strings
+- **Pre-computed spike magnitude** (`pkg/core` —
+  `AgentResult.BaselineDelta()`) — agent incidents and the detect prompt now
+  state a spike's magnitude as a ready phrase ("240 this tick vs baseline
+  6.1/tick (39× normal)") instead of leaving an operator — or the model — to
+  divide frequency by baseline. Exposed as the `BaselineDelta` template
+  field (rendered in all six default agent channel templates) and added to
+  the detect prompt as `baseline_delta`. Additive: the `Frequency` /
+  `Baseline` fields are unchanged for custom templates.
+
 ---
 
 ## [1.4.3] — 2026-05

--- a/config/agent_email.tmpl
+++ b/config/agent_email.tmpl
@@ -30,7 +30,7 @@
     <tr><td style="background:#f5f5f5;"><b>Confidence</b></td><td>{{ printf "%.2f" .Confidence }}</td></tr>
     {{- end }}
     {{- if .Frequency }}
-    <tr><td style="background:#f5f5f5;"><b>Frequency</b></td><td>{{ .Frequency }} (baseline {{ printf "%.2f" .Baseline }})</td></tr>
+    <tr><td style="background:#f5f5f5;"><b>Frequency</b></td><td>{{ .BaselineDelta }}</td></tr>
     {{- end }}
     {{- if .PatternID }}
     <tr><td style="background:#f5f5f5;"><b>Pattern</b></td><td><code>{{ .PatternID }}</code></td></tr>

--- a/config/agent_lark.tmpl
+++ b/config/agent_lark.tmpl
@@ -25,7 +25,7 @@
 {{ or .Summary "(no summary)" }}
 
 {{- if .Frequency }}
-**Frequency:** {{ .Frequency }} (baseline {{ printf "%.2f" .Baseline }})
+**Frequency:** {{ .BaselineDelta }}
 {{- end }}
 {{- if .PatternID }}
 **Pattern:** `{{ .PatternID }}`

--- a/config/agent_msteams.tmpl
+++ b/config/agent_msteams.tmpl
@@ -25,7 +25,7 @@
 {{ or .Summary "(no summary)" }}
 
 {{- if .Frequency }}
-**Frequency:** {{ .Frequency }} (baseline {{ printf "%.2f" .Baseline }})
+**Frequency:** {{ .BaselineDelta }}
 {{- end }}
 {{- if .PatternID }}
 **Pattern:** `{{ .PatternID }}`

--- a/config/agent_slack.tmpl
+++ b/config/agent_slack.tmpl
@@ -3,7 +3,7 @@
   Used when the incident originates from the AI SRE Agent (detect mode).
   Available fields: .AlertName .Summary .Severity .Category .Confidence
   .Suggestions .ServiceName .Source .PatternID .PatternTemplate
-  .Frequency .Baseline .Verdict .Logs .Status .AckURL
+  .Frequency .Baseline .BaselineDelta .Verdict .Logs .Status .AckURL
 */}}
 {{- $sevIcons := dict "critical" "🔴" "high" "🟠" "medium" "🟡" "low" "🟢" "info" "ℹ️" -}}
 {{- $sev := lower (or .Severity "info") -}}
@@ -28,7 +28,7 @@
 {{ or .Summary "(no summary)" }}
 
 {{- if .Frequency }}
-*Frequency:* {{ .Frequency }} (baseline {{ printf "%.2f" .Baseline }})
+*Frequency:* {{ .BaselineDelta }}
 {{- end }}
 {{- if .PatternID }}
 *Pattern:* `{{ .PatternID }}`

--- a/config/agent_telegram.tmpl
+++ b/config/agent_telegram.tmpl
@@ -25,7 +25,7 @@
 {{ or .Summary "(no summary)" }}
 
 {{- if .Frequency }}
-<b>Frequency:</b> {{ .Frequency }} (baseline {{ printf "%.2f" .Baseline }})
+<b>Frequency:</b> {{ .BaselineDelta }}
 {{- end }}
 {{- if .PatternID }}
 <b>Pattern:</b> <code>{{ .PatternID }}</code>

--- a/config/agent_viber.tmpl
+++ b/config/agent_viber.tmpl
@@ -25,7 +25,7 @@ Summary:
 {{ or .Summary "(no summary)" }}
 
 {{- if .Frequency }}
-Frequency: {{ .Frequency }} (baseline {{ printf "%.2f" .Baseline }})
+Frequency: {{ .BaselineDelta }}
 {{- end }}
 {{- if .PatternID }}
 Pattern: {{ .PatternID }}

--- a/pkg/agent/ai/detect/prompt.go
+++ b/pkg/agent/ai/detect/prompt.go
@@ -63,6 +63,11 @@ func BuildPrompt(r core.AgentResult, source, service string, samples []string) (
 	fmt.Fprintf(&b, "pattern_template: %s\n", r.Template)
 	fmt.Fprintf(&b, "tick_frequency: %d\n", r.Frequency)
 	fmt.Fprintf(&b, "ewma_baseline: %.3f\n", r.Baseline)
+	// Pre-computed magnitude so the model cites it verbatim instead of
+	// dividing frequency by baseline itself.
+	if d := r.BaselineDelta(); d != "" {
+		fmt.Fprintf(&b, "baseline_delta: %s\n", d)
+	}
 	if len(samples) > 0 {
 		b.WriteString("samples:\n")
 		for _, s := range samples {

--- a/pkg/core/agent_signal.go
+++ b/pkg/core/agent_signal.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -70,6 +71,34 @@ type AgentResult struct {
 	SampleSignals []Signal // representative signals (capped, post-redaction)
 	Frequency     int      // matches in the current tick / window
 	Baseline      float64  // EWMA baseline for the pattern (0 when unknown)
+}
+
+// BaselineDelta renders a human phrase comparing this tick's frequency to
+// the pattern's EWMA baseline, e.g. "240 this tick vs baseline 6.1/tick
+// (39× normal)". Channel templates and the detect prompt use it so the
+// magnitude is stated up front instead of asking an operator — or the
+// model — to do the division (the model never does arithmetic). Returns
+// "" when there is no frequency to describe.
+func (r AgentResult) BaselineDelta() string {
+	if r.Frequency <= 0 {
+		return ""
+	}
+	if r.Baseline <= 0 {
+		// New / unknown pattern: no baseline to compare against yet.
+		return fmt.Sprintf("%d this tick (no baseline yet)", r.Frequency)
+	}
+	mult := float64(r.Frequency) / r.Baseline
+	return fmt.Sprintf("%d this tick vs baseline %.1f/tick (%s normal)",
+		r.Frequency, r.Baseline, formatMultiple(mult))
+}
+
+// formatMultiple renders a ratio as "39×" (integer at 10× and above) or
+// "1.5×" (one decimal below 10×) so large spikes stay readable.
+func formatMultiple(m float64) string {
+	if m >= 10 {
+		return fmt.Sprintf("%.0f×", m)
+	}
+	return fmt.Sprintf("%.1f×", m)
 }
 
 // Detector consumes signals and emits AgentResults.

--- a/pkg/core/agent_signal_test.go
+++ b/pkg/core/agent_signal_test.go
@@ -1,0 +1,27 @@
+package core
+
+import "testing"
+
+func TestAgentResult_BaselineDelta(t *testing.T) {
+	cases := []struct {
+		name string
+		freq int
+		base float64
+		want string
+	}{
+		{"big spike rounds to integer", 240, 6.1, "240 this tick vs baseline 6.1/tick (39× normal)"},
+		{"small multiple keeps one decimal", 9, 6.0, "9 this tick vs baseline 6.0/tick (1.5× normal)"},
+		{"at threshold uses integer", 100, 10.0, "100 this tick vs baseline 10.0/tick (10× normal)"},
+		{"no baseline yet", 240, 0, "240 this tick (no baseline yet)"},
+		{"negative baseline treated as none", 5, -1, "5 this tick (no baseline yet)"},
+		{"zero frequency yields empty", 0, 6.1, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := AgentResult{Frequency: c.freq, Baseline: c.base}
+			if got := r.BaselineDelta(); got != c.want {
+				t.Errorf("BaselineDelta() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/services/agent.go
+++ b/pkg/services/agent.go
@@ -47,7 +47,10 @@ func CreateIncidentFromFinding(f *core.AIFinding, r core.AgentResult, source, se
 		"PatternTemplate": r.Template,
 		"Frequency":       r.Frequency,
 		"Baseline":        r.Baseline,
-		"Verdict":         r.Verdict.String(),
+		// BaselineDelta is the pre-computed human phrase ("39× normal") so
+		// templates state the spike magnitude without doing arithmetic.
+		"BaselineDelta": r.BaselineDelta(),
+		"Verdict":       r.Verdict.String(),
 
 		// Provenance
 		"ServiceName": service,

--- a/src/agent/ai-detect-mode.md
+++ b/src/agent/ai-detect-mode.md
@@ -109,7 +109,10 @@ entries are dropped automatically.
 Each event captures:
 
 - **Pattern context** — source, template, service, verdict,
-  frequency, baseline, sample log line.
+  frequency, baseline, sample log line. Channel templates also receive a
+  pre-computed `BaselineDelta` field (e.g. `240 this tick vs baseline
+  6.1/tick (39× normal)`) so the spike magnitude is stated without doing
+  arithmetic; the same phrase is fed to the detect prompt.
 - **AI call** — model, the prompt sent, the raw response, and how
   long it took.
 - **Parsed finding** — severity, summary, category, confidence,


### PR DESCRIPTION
## Summary

Agent incidents (and the detect prompt) showed raw `frequency` and
`ewma_baseline`, leaving an operator — or the model — to divide the two to
judge how abnormal a spike is. This adds `AgentResult.BaselineDelta()`, a
ready human phrase:

> `240 this tick vs baseline 6.1/tick (39× normal)`

New patterns with no baseline yet read `240 this tick (no baseline yet)`.

## Why

The magnitude ("39× normal") is the single most useful number on an agent
alert, and asking the LLM to compute it invites arithmetic mistakes in the
narrative. Computing it once in code and citing it everywhere keeps the
channel message and the model's reasoning consistent.

## Changes

- `pkg/core` — `AgentResult.BaselineDelta()` (one source of truth shared by
  the templates and the prompt; integer rounding at ≥10×, one decimal
  below).
- `pkg/services/agent.go` — additive `BaselineDelta` content key.
- `pkg/agent/ai/detect/prompt.go` — `baseline_delta` line so the model
  cites the phrase verbatim rather than dividing.
- All six default agent channel templates render it in place of the terse
  `(baseline X)` parenthetical. `Frequency` / `Baseline` keys are unchanged
  for custom templates.

## Testing

- `pkg/core` table-driven test: big spike rounds to an integer multiple, a
  small multiple keeps one decimal, the `10×` threshold, and the
  no-baseline / zero-frequency edges.
- `gofmt`, `go vet`, `go build ./...`,
  `go test -race ./pkg/core ./pkg/services ./pkg/agent/ai/detect` green.

## Checklist

- [x] Table-driven test for the new helper
- [x] Additive content key; existing fields unchanged
- [x] All six channel templates updated
- [x] House conventions (`feature:` prefix); docs + CHANGELOG
