### PR TITLE
feature(agent): per-source circuit breaker, health endpoints, stagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   single-tenant build is unchanged by default.
 - **Helm** — `agent.tools.findRunbook.*` values + configmap wiring.
 
+#### AI SRE Agent — per-source circuit breaker + health
+- **Circuit breaker** (`pkg/agent/health.go`, `pkg/agent/worker.go`) — a
+  failing signal source was retried every tick, hammering a downed backend
+  forever. A per-source breaker now backs off exponentially (from
+  `poll_interval` up to `agent.source_backoff_max`, default `15m`) and
+  recovers on its own once a pull succeeds — no restart. Source pulls within
+  a tick are also **staggered** (the long-promised behavior that was never
+  implemented) so N sources don't hit their backends simultaneously.
+- **Source-health admin endpoints** (gated by `X-Gateway-Secret`):
+  - `GET /api/agent/sources/health` — per-source state (`ok` /
+    `backing_off` / `paused`), failures, last error, next-eligible time.
+  - `POST /api/agent/sources/:name/pause` and `/resume` — manual hold.
+  - `DELETE /api/agent/sources/:name/cursor` — drop a stuck cursor so the
+    source re-backfills from `lookback`.
+- Config triple-touch (`agent.source_backoff_max`) + Helm
+  (`agent.sourceBackoffMax`) + docs. (Sharing the breaker with the analyze
+  `get_related_logs` reader and gap-window tracking are follow-ups.)
+
 ---
 
 ## [1.4.3] — 2026-05

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -298,7 +298,7 @@ func startAgent(ctx context.Context, app *fiber.App, cfg c.AgentConfig, gatewayS
 		return nil, fmt.Errorf("agent: gateway_secret is not configured — /api/agent/* admin endpoints require a secret")
 	}
 	api := app.Group("/api")
-	controllers.NewAgentController(catalog, shadowLog, detectLog, aiBundle.Runbooks != nil).Register(api)
+	controllers.NewAgentController(catalog, shadowLog, detectLog, worker.Health(), cursors, aiBundle.Runbooks != nil).Register(api)
 	controllers.NewRunbookAdminController(aiBundle.Runbooks).Register(api)
 
 	return catalog, nil

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -186,6 +186,9 @@ agent:
   lookback: 5m                    # initial backfill window on startup
   batch_max: 5000                 # safety cap per tick
   signal_max_bytes: 65536         # cap on Signal.Raw
+  # A source that keeps failing is retried on an exponential backoff
+  # (starting at poll_interval) up to this ceiling, not every tick.
+  source_backoff_max: 15m
 
 
   redaction:

--- a/helm/versus-incident/templates/configmap.yaml
+++ b/helm/versus-incident/templates/configmap.yaml
@@ -227,6 +227,9 @@ data:
       poll_interval: {{ .Values.agent.pollInterval | default "30s" }}
       lookback: {{ .Values.agent.lookback | default "5m" }}
       new_service_grace: {{ .Values.agent.newServiceGrace | default "30m" }}
+      {{- if .Values.agent.sourceBackoffMax }}
+      source_backoff_max: {{ .Values.agent.sourceBackoffMax | quote }}
+      {{- end }}
       sources_path: /app/config/agent_sources.yaml
       ai:
         enable: {{ .Values.agent.ai.enable }}

--- a/helm/versus-incident/values.yaml
+++ b/helm/versus-incident/values.yaml
@@ -120,6 +120,8 @@ agent:
   pollInterval: 30s
   lookback: 5m
   newServiceGrace: 30m
+  # Per-source circuit-breaker backoff ceiling. Empty → 15m default.
+  sourceBackoffMax: 15m
 
   ai:
     # AI analyzer toggle. Required for detect mode to actually call an LLM.

--- a/pkg/agent/cursors.go
+++ b/pkg/agent/cursors.go
@@ -58,3 +58,17 @@ func (s *CursorStore) Set(ctx context.Context, source string, t time.Time) error
 	}
 	return s.rdb.Set(ctx, s.keyPrefix+source, t.UTC().Format(time.RFC3339Nano), 0).Err()
 }
+
+// Delete drops a source's cursor so the next pull re-backfills from the
+// lookback window. Admin use: recover a source stuck behind a cursor that
+// points past a log-retention boundary. Redis errors are returned; the
+// in-memory entry is always removed.
+func (s *CursorStore) Delete(ctx context.Context, source string) error {
+	s.mu.Lock()
+	delete(s.mem, source)
+	s.mu.Unlock()
+	if s.rdb == nil {
+		return nil
+	}
+	return s.rdb.Del(ctx, s.keyPrefix+source).Err()
+}

--- a/pkg/agent/health.go
+++ b/pkg/agent/health.go
@@ -1,0 +1,187 @@
+package agent
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// SourceHealth is a point-in-time snapshot of one source's breaker, returned
+// by GET /api/agent/sources/health.
+type SourceHealth struct {
+	Name                string     `json:"name"`
+	State               string     `json:"state"` // "ok" | "backing_off" | "paused"
+	ConsecutiveFailures int        `json:"consecutive_failures"`
+	LastError           string     `json:"last_error,omitempty"`
+	LastErrorAt         *time.Time `json:"last_error_at,omitempty"`
+	LastSuccessAt       *time.Time `json:"last_success_at,omitempty"`
+	NextEligibleAt      *time.Time `json:"next_eligible_at,omitempty"`
+	Paused              bool       `json:"paused"`
+}
+
+type srcHealth struct {
+	failures      int
+	lastErr       string
+	lastErrAt     time.Time
+	lastSuccessAt time.Time
+	nextEligible  time.Time
+	paused        bool
+}
+
+// HealthTracker is a per-source circuit breaker. A source that keeps failing
+// is pulled progressively less often (exponential backoff, base·2^(n-1)
+// capped at backoffMax) instead of being hammered every tick, and recovers
+// on its own once a pull succeeds — no restart required. State is exposed so
+// operators can see why a source went quiet, and pause/resume it manually.
+// Safe for concurrent use.
+type HealthTracker struct {
+	mu         sync.Mutex
+	base       time.Duration // first backoff step (≈ the poll interval)
+	backoffMax time.Duration
+	sources    map[string]*srcHealth
+}
+
+// NewHealthTracker builds a tracker. base defaults to 30s, backoffMax to 15m.
+func NewHealthTracker(base, backoffMax time.Duration) *HealthTracker {
+	if base <= 0 {
+		base = 30 * time.Second
+	}
+	if backoffMax <= 0 {
+		backoffMax = 15 * time.Minute
+	}
+	return &HealthTracker{base: base, backoffMax: backoffMax, sources: make(map[string]*srcHealth)}
+}
+
+// caller holds h.mu.
+func (h *HealthTracker) get(name string) *srcHealth {
+	s := h.sources[name]
+	if s == nil {
+		s = &srcHealth{}
+		h.sources[name] = s
+	}
+	return s
+}
+
+// Allow reports whether the source may be pulled now: not paused and past
+// its next-eligible time. A healthy source is always allowed.
+func (h *HealthTracker) Allow(name string, now time.Time) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s := h.get(name)
+	if s.paused {
+		return false
+	}
+	return !now.Before(s.nextEligible)
+}
+
+// RecordSuccess clears the breaker for a source.
+func (h *HealthTracker) RecordSuccess(name string, now time.Time) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s := h.get(name)
+	s.failures = 0
+	s.lastErr = ""
+	s.lastSuccessAt = now
+	s.nextEligible = time.Time{}
+}
+
+// RecordFailure increments the failure count and pushes next-eligible out by
+// an exponential backoff capped at backoffMax.
+func (h *HealthTracker) RecordFailure(name string, now time.Time, err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s := h.get(name)
+	s.failures++
+	if err != nil {
+		s.lastErr = err.Error()
+	}
+	s.lastErrAt = now
+
+	shift := s.failures - 1
+	if shift > 20 {
+		shift = 20 // cap before the shift to avoid int64 overflow
+	}
+	backoff := h.base << uint(shift)
+	if backoff <= 0 || backoff > h.backoffMax {
+		backoff = h.backoffMax
+	}
+	s.nextEligible = now.Add(backoff)
+}
+
+// Register seeds a source so it appears in Snapshot from boot (before its
+// first pull) and is addressable by Pause/Resume. Idempotent. The worker
+// calls this for every configured source at startup, keyed by the same
+// name (SignalSource.Name()) used by the breaker and the cursor store.
+func (h *HealthTracker) Register(name string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.get(name)
+}
+
+// Pause holds a known source open until Resume. Returns false when the name
+// is unknown — Pause does NOT create an entry, so a typo'd name can't
+// conjure a phantom source into the health view. Use the name exactly as
+// shown by Snapshot (SignalSource.Name(), e.g. "file:app-file").
+func (h *HealthTracker) Pause(name string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s, ok := h.sources[name]
+	if !ok {
+		return false
+	}
+	s.paused = true
+	return true
+}
+
+// Resume clears a manual pause and resets the breaker so the next tick
+// pulls. Returns false when the name is unknown.
+func (h *HealthTracker) Resume(name string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s, ok := h.sources[name]
+	if !ok {
+		return false
+	}
+	s.paused = false
+	s.failures = 0
+	s.nextEligible = time.Time{}
+	return true
+}
+
+// Snapshot returns the health of every known source, sorted by name.
+func (h *HealthTracker) Snapshot(now time.Time) []SourceHealth {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]SourceHealth, 0, len(h.sources))
+	for name, s := range h.sources {
+		sh := SourceHealth{
+			Name:                name,
+			ConsecutiveFailures: s.failures,
+			LastError:           s.lastErr,
+			Paused:              s.paused,
+		}
+		switch {
+		case s.paused:
+			sh.State = "paused"
+		case now.Before(s.nextEligible):
+			sh.State = "backing_off"
+		default:
+			sh.State = "ok"
+		}
+		if !s.lastErrAt.IsZero() {
+			t := s.lastErrAt
+			sh.LastErrorAt = &t
+		}
+		if !s.lastSuccessAt.IsZero() {
+			t := s.lastSuccessAt
+			sh.LastSuccessAt = &t
+		}
+		if now.Before(s.nextEligible) {
+			t := s.nextEligible
+			sh.NextEligibleAt = &t
+		}
+		out = append(out, sh)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}

--- a/pkg/agent/health_test.go
+++ b/pkg/agent/health_test.go
@@ -1,0 +1,103 @@
+package agent
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestHealthTracker_BreakerBackoff(t *testing.T) {
+	h := NewHealthTracker(time.Minute, 15*time.Minute)
+	t0 := time.Now()
+
+	if !h.Allow("s", t0) {
+		t.Fatal("a fresh source should be allowed")
+	}
+
+	h.RecordFailure("s", t0, errors.New("boom")) // 1st failure → 1m backoff
+	if h.Allow("s", t0.Add(59*time.Second)) {
+		t.Error("should back off within the window after a failure")
+	}
+	if !h.Allow("s", t0.Add(61*time.Second)) {
+		t.Error("should be eligible once the backoff window passes")
+	}
+
+	h.RecordFailure("s", t0, errors.New("boom")) // 2nd failure → 2m backoff
+	if h.Allow("s", t0.Add(119*time.Second)) {
+		t.Error("second consecutive failure should double the backoff")
+	}
+	if !h.Allow("s", t0.Add(121*time.Second)) {
+		t.Error("should be eligible after the 2m window")
+	}
+
+	h.RecordSuccess("s", t0)
+	if !h.Allow("s", t0) {
+		t.Error("a success must reset the breaker")
+	}
+}
+
+func TestHealthTracker_BackoffCap(t *testing.T) {
+	h := NewHealthTracker(time.Minute, 5*time.Minute)
+	t0 := time.Now()
+	for i := 0; i < 12; i++ {
+		h.RecordFailure("s", t0, errors.New("x"))
+	}
+	if h.Allow("s", t0.Add(4*time.Minute+59*time.Second)) {
+		t.Error("backoff should still hold just under the cap")
+	}
+	if !h.Allow("s", t0.Add(5*time.Minute+time.Second)) {
+		t.Error("backoff must be capped at backoffMax (5m)")
+	}
+}
+
+func TestHealthTracker_PauseResume(t *testing.T) {
+	h := NewHealthTracker(time.Minute, time.Hour)
+	t0 := time.Now()
+	h.Register("s")
+
+	if !h.Pause("s") {
+		t.Error("Pause of a known source should return true")
+	}
+	if h.Allow("s", t0) {
+		t.Error("a paused source must not be allowed")
+	}
+	if !h.Resume("s") {
+		t.Error("Resume of a known source should return true")
+	}
+	if !h.Allow("s", t0) {
+		t.Error("a resumed source should be allowed again")
+	}
+
+	// Unknown names are rejected, not auto-created (no phantom sources).
+	if h.Pause("typo") {
+		t.Error("Pause of an unknown source should return false")
+	}
+	for _, s := range h.Snapshot(t0) {
+		if s.Name == "typo" {
+			t.Error("a rejected Pause must not create a phantom source")
+		}
+	}
+}
+
+func TestHealthTracker_Snapshot(t *testing.T) {
+	h := NewHealthTracker(time.Minute, time.Hour)
+	t0 := time.Now()
+	h.RecordSuccess("ok", t0)
+	h.RecordFailure("bad", t0, errors.New("down"))
+	h.Register("held")
+	h.Pause("held")
+
+	states := map[string]string{}
+	for _, s := range h.Snapshot(t0) {
+		states[s.Name] = s.State
+	}
+	if states["ok"] != "ok" {
+		t.Errorf("ok.State = %q, want ok", states["ok"])
+	}
+	if states["bad"] != "backing_off" {
+		t.Errorf("bad.State = %q, want backing_off", states["bad"])
+	}
+	if states["held"] != "paused" {
+		t.Errorf("held.State = %q, want paused", states["held"])
+	}
+}

--- a/pkg/agent/worker.go
+++ b/pkg/agent/worker.go
@@ -46,7 +46,8 @@ func init() {
 type Worker struct {
 	cfg      config.AgentConfig
 	sources  []core.SignalSource
-	cursors  *CursorStore // nil → in-memory fallback
+	cursors  *CursorStore   // nil → in-memory fallback
+	health   *HealthTracker // per-source circuit breaker; never nil after NewWorker
 	redactor *Redactor
 	matcher  *RegexMatcher
 	miner    *Miner
@@ -78,7 +79,8 @@ type Emitter func(f *core.AIFinding, r core.AgentResult, source, service string)
 type WorkerOptions struct {
 	Cfg      config.AgentConfig
 	Sources  []core.SignalSource
-	Cursors  *CursorStore // optional; pass nil for in-memory cursors
+	Cursors  *CursorStore   // optional; pass nil for in-memory cursors
+	Health   *HealthTracker // optional; nil → one built from cfg (base=poll, cap=source_backoff_max)
 	Redactor *Redactor
 	Matcher  *RegexMatcher
 	Miner    *Miner
@@ -106,6 +108,7 @@ func NewWorker(opt WorkerOptions) (*Worker, error) {
 		matcher:  opt.Matcher,
 		miner:    opt.Miner,
 		catalog:  opt.Catalog,
+		health:   opt.Health,
 		shadow:   opt.Shadow,
 		detect:   opt.Detect,
 		services: opt.Services,
@@ -125,9 +128,22 @@ func NewWorker(opt WorkerOptions) (*Worker, error) {
 	w.lookback = parseDurationOr(opt.Cfg.Lookback, 5*time.Minute)
 	w.ewmaAlpha = 0.2 // configurable once spike detection lands
 	w.newServiceGrace = parseDurationOr(opt.Cfg.NewServiceGrace, 0)
+	// Per-source circuit breaker: backoff steps from the poll interval up to
+	// source_backoff_max (default 15m). Built here when not injected so the
+	// breaker is always active.
+	if w.health == nil {
+		w.health = NewHealthTracker(
+			w.pollInterval,
+			parseDurationOr(opt.Cfg.SourceBackoffMax, 15*time.Minute),
+		)
+	}
 
 	return w, nil
 }
+
+// Health exposes the per-source circuit breaker so the admin controller can
+// surface and control source health.
+func (w *Worker) Health() *HealthTracker { return w.health }
 
 // Run drives the worker until ctx is canceled. It is intended to be called
 // in a goroutine from cmd/main.go.
@@ -139,8 +155,15 @@ func (w *Worker) Run(ctx context.Context) {
 	log.Printf("agent: starting worker mode=%s sources=%d poll=%s",
 		mode, len(w.sources), w.pollInterval)
 
-	// Stagger initial pull so multiple sources don't hammer their backends
-	// at the same instant on startup.
+	// Seed every source into the health tracker so it shows in the health
+	// endpoint from boot and is addressable by pause/resume before its first
+	// pull. Keyed by Name() — the same key the breaker and cursor store use.
+	if w.health != nil {
+		for _, s := range w.sources {
+			w.health.Register(s.Name())
+		}
+	}
+
 	tick := time.NewTicker(w.pollInterval)
 	defer tick.Stop()
 
@@ -200,24 +223,52 @@ func (w *Worker) Run(ctx context.Context) {
 // tick runs one poll across every source. Errors from one source never
 // affect the others — the worker keeps moving.
 func (w *Worker) tick(ctx context.Context, mode string) {
+	// Stagger source pulls so N sources don't hit their backends at the same
+	// instant (the long-promised behavior that was never implemented). Spread
+	// them across up to half the poll interval; a single source starts now.
+	var step time.Duration
+	if n := len(w.sources); n > 1 {
+		step = (w.pollInterval / 2) / time.Duration(n)
+	}
+
 	var wg sync.WaitGroup
-	for _, src := range w.sources {
+	for i, src := range w.sources {
 		wg.Add(1)
-		go func(s core.SignalSource) {
+		go func(idx int, s core.SignalSource) {
 			defer wg.Done()
+			if d := time.Duration(idx) * step; d > 0 {
+				select {
+				case <-time.After(d):
+				case <-ctx.Done():
+					return
+				}
+			}
 			w.tickSource(ctx, s, mode)
-		}(src)
+		}(i, src)
 	}
 	wg.Wait()
 }
 
 func (w *Worker) tickSource(ctx context.Context, src core.SignalSource, mode string) {
+	// Circuit breaker: skip a source that is paused or still backing off from
+	// repeated failures, instead of hammering a downed backend every tick.
+	if w.health != nil && !w.health.Allow(src.Name(), time.Now()) {
+		return
+	}
+
 	since := w.loadCursor(ctx, src.Name())
 
 	signals, newCursor, err := src.Pull(ctx, since)
 	if err != nil {
 		log.Printf("agent: pull from %s failed: %v", src.Name(), err)
+		if w.health != nil {
+			w.health.RecordFailure(src.Name(), time.Now(), err)
+		}
 		return
+	}
+	// A successful pull (even an empty one) closes the breaker.
+	if w.health != nil {
+		w.health.RecordSuccess(src.Name(), time.Now())
 	}
 	if len(signals) == 0 {
 		return

--- a/pkg/agent/worker_health_test.go
+++ b/pkg/agent/worker_health_test.go
@@ -1,0 +1,76 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/core"
+	"github.com/VersusControl/versus-incident/pkg/storage"
+)
+
+type failingSource struct {
+	name  string
+	calls *int32
+}
+
+func (f failingSource) Name() string { return f.name }
+func (f failingSource) Pull(context.Context, time.Time) ([]core.Signal, time.Time, error) {
+	atomic.AddInt32(f.calls, 1)
+	return nil, time.Time{}, errors.New("backend down")
+}
+
+// TestWorker_TickSource_BreakerSkipsFailingSource asserts a source that
+// fails is not pulled again on the next tick while its breaker is open —
+// the fix for the retry-every-tick hammering of a downed backend.
+func TestWorker_TickSource_BreakerSkipsFailingSource(t *testing.T) {
+	cat, err := LoadCatalog(storage.NewMemory())
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	var calls int32
+	w, err := NewWorker(WorkerOptions{
+		Miner:   NewMiner(0.4, 4, 100),
+		Catalog: cat,
+		// Long backoff so the second tick is firmly inside the open window.
+		Health: NewHealthTracker(time.Hour, time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("NewWorker: %v", err)
+	}
+	src := failingSource{name: "es", calls: &calls}
+
+	w.tickSource(context.Background(), src, "training") // fails → breaker opens
+	w.tickSource(context.Background(), src, "training") // open → skipped
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("Pull called %d times, want 1 (breaker must skip the 2nd tick)", got)
+	}
+
+	// A manual resume re-enables pulling.
+	w.Health().Resume("es")
+	w.tickSource(context.Background(), src, "training")
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("Pull called %d times after resume, want 2", got)
+	}
+}
+
+func TestCursorStore_Delete(t *testing.T) {
+	ctx := context.Background()
+	cs := NewCursorStore(nil) // in-memory
+	now := time.Now()
+	if err := cs.Set(ctx, "es", now); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if _, ok := cs.Get(ctx, "es"); !ok {
+		t.Fatal("cursor should be present after Set")
+	}
+	if err := cs.Delete(ctx, "es"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok := cs.Get(ctx, "es"); ok {
+		t.Error("cursor should be gone after Delete")
+	}
+}

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -22,6 +22,12 @@ type AgentConfig struct {
 	// (post-redaction) log message to discover the service name.
 	ServicePatterns []string `mapstructure:"service_patterns"`
 
+	// SourceBackoffMax caps the per-source circuit-breaker backoff. A source
+	// that keeps failing is retried on an exponential backoff (starting at
+	// the poll interval) up to this ceiling, instead of every tick. Empty
+	// falls back to 15m. e.g. "15m", "1h".
+	SourceBackoffMax string `mapstructure:"source_backoff_max"`
+
 	Redaction AgentRedactionConfig `mapstructure:"redaction"`
 	Catalog   AgentCatalogConfig   `mapstructure:"catalog"`
 	Miner     AgentMinerConfig     `mapstructure:"miner"`

--- a/pkg/config/clone_config.go
+++ b/pkg/config/clone_config.go
@@ -302,14 +302,15 @@ func cloneRedisConfig(src RedisConfig) RedisConfig {
 // Helper function to deep clone the AgentConfig struct
 func cloneAgentConfig(src AgentConfig) AgentConfig {
 	cloned := AgentConfig{
-		Enable:          src.Enable,
-		Mode:            src.Mode,
-		PollInterval:    src.PollInterval,
-		Lookback:        src.Lookback,
-		BatchMax:        src.BatchMax,
-		SignalMaxBytes:  src.SignalMaxBytes,
-		NewServiceGrace: src.NewServiceGrace,
-		ServicePatterns: append([]string(nil), src.ServicePatterns...),
+		Enable:           src.Enable,
+		Mode:             src.Mode,
+		PollInterval:     src.PollInterval,
+		Lookback:         src.Lookback,
+		BatchMax:         src.BatchMax,
+		SignalMaxBytes:   src.SignalMaxBytes,
+		NewServiceGrace:  src.NewServiceGrace,
+		SourceBackoffMax: src.SourceBackoffMax,
+		ServicePatterns:  append([]string(nil), src.ServicePatterns...),
 		Redaction: AgentRedactionConfig{
 			Enable:    src.Redaction.Enable,
 			RedactIPs: src.Redaction.RedactIPs,

--- a/pkg/controllers/agent.go
+++ b/pkg/controllers/agent.go
@@ -1,6 +1,9 @@
 package controllers
 
 import (
+	"context"
+	"time"
+
 	"github.com/VersusControl/versus-incident/pkg/agent"
 	"github.com/VersusControl/versus-incident/pkg/agent/ai/analyze"
 	"github.com/VersusControl/versus-incident/pkg/agent/ai/detect"
@@ -18,16 +21,20 @@ type AgentController struct {
 	catalog         *agent.Catalog
 	shadow          *agent.ShadowLog
 	detect          *agent.DetectLog
+	health          *agent.HealthTracker
+	cursors         *agent.CursorStore
 	runbooksEnabled bool
 }
 
 // NewAgentController wires the catalog, shadow log, and detect log into a
 // controller. Pass `cat=nil` if the agent is disabled — in that case every
 // endpoint will return 503. `sl` may be nil to disable the shadow endpoints,
-// and `dl` may be nil to disable the detect-log endpoints. `runbooksEnabled`
-// tells the status endpoint whether the runbooks subsystem is available.
-func NewAgentController(cat *agent.Catalog, sl *agent.ShadowLog, dl *agent.DetectLog, runbooksEnabled bool) *AgentController {
-	return &AgentController{catalog: cat, shadow: sl, detect: dl, runbooksEnabled: runbooksEnabled}
+// and `dl` may be nil to disable the detect-log endpoints. `health` and
+// `cur` power the source-health endpoints (nil disables them).
+// `runbooksEnabled` tells the status endpoint whether the runbooks subsystem
+// is available.
+func NewAgentController(cat *agent.Catalog, sl *agent.ShadowLog, dl *agent.DetectLog, health *agent.HealthTracker, cur *agent.CursorStore, runbooksEnabled bool) *AgentController {
+	return &AgentController{catalog: cat, shadow: sl, detect: dl, health: health, cursors: cur, runbooksEnabled: runbooksEnabled}
 }
 
 // Register attaches the agent admin endpoints to the given fiber group.
@@ -46,6 +53,10 @@ func NewAgentController(cat *agent.Catalog, sl *agent.ShadowLog, dl *agent.Detec
 //	POST   /shadow/flush     force-flush the shadow log to disk
 //	GET    /services         list known services with grace status
 //	POST   /services/:name/grace  control grace period (end / restart)
+//	GET    /sources/health   per-source circuit-breaker state
+//	POST   /sources/:name/pause   hold a source open (stop pulling)
+//	POST   /sources/:name/resume  clear a pause and reset the breaker
+//	DELETE /sources/:name/cursor  drop a source's cursor (re-backfill)
 //	GET    /detect           list detect-mode AI calls (newest first)
 //	GET    /detect/stats     aggregate counts for the detect log
 //	GET    /detect/:id       get one detect-mode AI call (full prompt + response)
@@ -66,6 +77,10 @@ func (a *AgentController) Register(router fiber.Router) {
 	g.Post("/shadow/flush", a.flushShadow)
 	g.Get("/services", a.listServices)
 	g.Post("/services/:name/grace", a.controlServiceGrace)
+	g.Get("/sources/health", a.sourcesHealth)
+	g.Post("/sources/:name/pause", a.pauseSource)
+	g.Post("/sources/:name/resume", a.resumeSource)
+	g.Delete("/sources/:name/cursor", a.deleteSourceCursor)
 	g.Get("/detect", a.listDetect)
 	g.Get("/detect/stats", a.detectStats)
 	g.Get("/detect/:id", a.getDetect)
@@ -149,6 +164,52 @@ func (a *AgentController) flush(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
 	return c.JSON(fiber.Map{"ok": true, "patterns": a.catalog.Len()})
+}
+
+// sourcesHealth returns the per-source circuit-breaker state.
+func (a *AgentController) sourcesHealth(c *fiber.Ctx) error {
+	if a.health == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "source health not available"})
+	}
+	return c.JSON(fiber.Map{"sources": a.health.Snapshot(time.Now())})
+}
+
+// pauseSource holds a source open — the worker stops pulling it until resume.
+func (a *AgentController) pauseSource(c *fiber.Ctx) error {
+	if a.health == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "source health not available"})
+	}
+	name := c.Params("name")
+	if !a.health.Pause(name) {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "unknown source (use the name from /sources/health)"})
+	}
+	return c.JSON(fiber.Map{"ok": true, "paused": name})
+}
+
+// resumeSource clears a manual pause and resets the breaker so the next tick
+// pulls the source again.
+func (a *AgentController) resumeSource(c *fiber.Ctx) error {
+	if a.health == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "source health not available"})
+	}
+	name := c.Params("name")
+	if !a.health.Resume(name) {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "unknown source (use the name from /sources/health)"})
+	}
+	return c.JSON(fiber.Map{"ok": true, "resumed": name})
+}
+
+// deleteSourceCursor drops a source's resume cursor so its next pull
+// re-backfills from the lookback window (recovers a source stuck behind a
+// cursor past the backend's log retention).
+func (a *AgentController) deleteSourceCursor(c *fiber.Ctx) error {
+	if a.cursors == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "cursor store not available"})
+	}
+	if err := a.cursors.Delete(context.Background(), c.Params("name")); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+	return c.SendStatus(fiber.StatusNoContent)
 }
 
 // listShadow returns every shadow-mode event sorted most-recent first.

--- a/src/agent/configuration.md
+++ b/src/agent/configuration.md
@@ -28,6 +28,7 @@ agent:
   lookback: 5m
   batch_max: 1000
   signal_max_bytes: 8192
+  source_backoff_max: 15m
   redaction:   { … }
   catalog:     { … }
   miner:       { … }
@@ -50,6 +51,22 @@ agent:
 | `lookback` | duration | `5m` | Initial backfill window on first start (when there's no cursor yet). |
 | `batch_max` | int | `1000` | Safety cap on signals processed per tick per source. |
 | `signal_max_bytes` | int | `8192` | Truncates a single signal's `Raw` payload above this size. |
+| `source_backoff_max` | duration | `15m` | Per-source circuit-breaker ceiling. A source that keeps failing is retried on an exponential backoff (starting at `poll_interval`) up to this cap, then recovers automatically once a pull succeeds — no restart. |
+
+### Source health
+
+The worker keeps a per-source circuit breaker. These admin endpoints
+(all require `X-Gateway-Secret`) expose and control it:
+
+| Method & path | Effect |
+|---|---|
+| `GET /api/agent/sources/health` | Per-source state (`ok` / `backing_off` / `paused`), consecutive failures, last error, next-eligible time. |
+| `POST /api/agent/sources/:name/pause` | Stop pulling a source (e.g. during backend maintenance). |
+| `POST /api/agent/sources/:name/resume` | Clear a pause and reset the breaker. |
+| `DELETE /api/agent/sources/:name/cursor` | Drop the source's resume cursor so its next pull re-backfills from `lookback` (recovers a cursor stuck past the backend's log retention). |
+
+Pulls are also **staggered** within a tick so multiple sources don't hit
+their backends at the same instant.
 
 ## Modes
 


### PR DESCRIPTION
Addresses #117.

## Problem

- A signal source that kept failing was pulled again on **every tick** —
  hammering a downed backend forever with no backoff.
- The worker's "stagger initial pull so sources don't hit backends at the
  same instant" comment described behavior that **was never implemented** —
  all sources fired simultaneously.
- There was no way to see why a source went quiet, or to pause one.

## Fix

- **Per-source circuit breaker** (`pkg/agent/health.go`). Repeated failures
  back off exponentially — starting at `poll_interval`, doubling, capped at
  `agent.source_backoff_max` (default `15m`). A single successful pull (even
  an empty one) closes the breaker, so a source **recovers on its own with
  no restart**. `tickSource` checks the breaker before pulling and records
  the outcome.
- **Real staggering**: `tick()` now spreads source pulls across up to half
  the poll interval instead of launching them all at once.
- **Source-health admin endpoints** (gated by `X-Gateway-Secret`), keyed by
  the source name as shown in the health view:
  - `GET /api/agent/sources/health` — per-source `ok` / `backing_off` /
    `paused`, consecutive failures, last error, next-eligible time. Sources
    are **seeded at startup** so they appear before their first pull.
  - `POST /api/agent/sources/:name/pause` | `/resume` — manual hold. An
    unknown name returns **404** rather than creating a phantom source.
  - `DELETE /api/agent/sources/:name/cursor` — drop a stuck resume cursor so
    the source re-backfills from `lookback` (added `CursorStore.Delete`).

## Scope

This is the breaker + visibility + control core. Two items from the broader
plan are deliberately deferred to keep the PR focused: sharing the breaker
with the analyze `get_related_logs` reader (so an open breaker short-circuits
that tool), and gap-window tracking (which later feeds burn-rate coverage).

## Testing

- **Unit:** breaker backoff / cap / reset, pause/resume + unknown-name
  rejection (no phantom sources), snapshot states; `CursorStore.Delete`.
- **Worker:** a failing source is pulled once, then skipped while the
  breaker is open, then pulled again after `resume`.
- **Live (built binary):** with a file source and `poll_interval: 2s` —
  `/sources/health` shows the source from boot; pausing the wrong name
  returns 404 with no phantom entry; pausing the correct name flips it to
  `paused`; the unauthenticated request returns 401.
- `gofmt`, `go vet`, `go build ./...`,
  `go test -race ./pkg/agent ./pkg/config ./pkg/controllers` green;
  `helm template` renders `source_backoff_max`.

## Checklist

- [x] Unit + worker + live verification
- [x] Config triple-touch + Helm mirrored
- [x] Endpoints authenticated; unknown source → 404
- [x] House conventions (`feature:` prefix); docs + CHANGELOG
