### PR TITLE
fix(agent): skip on-call escalation when the workflow is not initialized

### DIFF
--- a/pkg/core/oncall.go
+++ b/pkg/core/oncall.go
@@ -66,6 +66,15 @@ func GetOnCallWorkflow() *OnCallWorkflow {
 	return onCallWorkflow
 }
 
+// IsOnCallInitialized reports whether InitOnCallWorkflow has already run.
+// Callers that may enable on-call dynamically (e.g. the per-incident
+// oncall_enable query-param override the AI SRE agent uses for high /
+// critical findings) check this first to avoid GetOnCallWorkflow's panic
+// when on-call was never initialized at startup.
+func IsOnCallInitialized() bool {
+	return onCallWorkflow != nil
+}
+
 // triggerProvider triggers the on-call provider
 func (w *OnCallWorkflow) triggerProvider(ctx context.Context, incidentID string, cfg *config.OnCallConfig) error {
 	if err := w.provider.TriggerOnCall(ctx, incidentID, cfg); err != nil {

--- a/pkg/services/incident.go
+++ b/pkg/services/incident.go
@@ -96,7 +96,16 @@ func CreateIncident(teamID string, content *map[string]interface{}, params ...*m
 	// AND there are no channels configured at all (nothing to escalate
 	// off of).
 	var oncallErr error
-	if !resolved && cfg.OnCall.Enable {
+	if !resolved && cfg.OnCall.Enable && !core.IsOnCallInitialized() {
+		// On-call can be turned on per-incident via the oncall_enable query
+		// param (the AI SRE agent sets it for high/critical findings). When
+		// the workflow was never initialized at startup — oncall.enable and
+		// oncall.initialized_only both false — GetOnCallWorkflow would panic
+		// and take down the request/agent goroutine. Skip with a clear
+		// warning instead of crashing.
+		log.Printf("incident %s: on-call escalation requested but the workflow is not initialized (set oncall.enable or oncall.initialized_only at startup to use it); skipping escalation", incident.ID)
+	}
+	if !resolved && cfg.OnCall.Enable && core.IsOnCallInitialized() {
 		workflow := core.GetOnCallWorkflow()
 		if err := workflow.Start(incident.ID, cfg.OnCall); err != nil {
 			oncallErr = err


### PR DESCRIPTION
## Problem

`CreateIncidentFromFinding` sets the `oncall_enable=true` query-param override for **high/critical** AI findings. When on-call is disabled at startup (`oncall.enable` and `oncall.initialized_only` both false), `InitOnCallWorkflow` is never called, so `core.GetOnCallWorkflow()` **panics** — taking down the agent tick goroutine on the first detect-mode emit of a high/critical pattern.

```
panic: on-call workflow not initialized - call InitOnCallWorkflow first
  pkg/core/oncall.go:64 GetOnCallWorkflow
  pkg/services/incident.go:100 CreateIncident
  pkg/agent.(*Worker).emitDetect
```

## Fix

- Add `core.IsOnCallInitialized()`.
- Guard the escalation in `CreateIncident`: when on-call is requested but the workflow was never initialized, log a warning and skip escalation instead of crashing. Channel fan-out (which runs first) is unaffected, so the alert still reaches Telegram/Slack/etc.

## Verified

Reproduced on minikube (agent detect mode + Gemini, on-call disabled): before the fix the pod crash-looped on the first emit; after, the agent emits the incident to Telegram and logs `... on-call escalation requested but the workflow is not initialized ... skipping escalation`. `go test ./pkg/services/... ./pkg/core/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
