### PR TITLE
feat(agent): pluggable LLM provider (openai / gemini)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -234,6 +234,10 @@ agent:
   ai:
     enable: false                   # master switch (env: AGENT_AI_ENABLE)
     api_key: ${AGENT_AI_API_KEY}
+    # provider: LLM backend for the chat agents — "openai" (default) or
+    # "gemini". Maps to the right OpenAI-compatible endpoint internally, so
+    # there's no need to specify a base URL. Empty = openai.
+    provider: ${AGENT_AI_PROVIDER}
     model: "gpt-5.4-mini"
     # temperature: 0.0–2.0 (default 0.2). Set a NEGATIVE value (e.g. -1) to
     # omit temperature so the provider uses its own default.

--- a/helm/versus-incident/templates/configmap.yaml
+++ b/helm/versus-incident/templates/configmap.yaml
@@ -231,14 +231,22 @@ data:
       ai:
         enable: {{ .Values.agent.ai.enable }}
         api_key: ${AGENT_AI_API_KEY}
+        {{- if .Values.agent.ai.provider }}
+        provider: {{ .Values.agent.ai.provider | quote }}
+        {{- end }}
         model: {{ .Values.agent.ai.model | default "gpt-4o-mini" | quote }}
         temperature: {{ .Values.agent.ai.temperature | default 0.2 }}
         max_tokens: {{ .Values.agent.ai.maxTokens | default 512 }}
         max_calls_per_hour: {{ .Values.agent.ai.maxCallsPerHour | default 60 }}
         cache_ttl: {{ .Values.agent.ai.cacheTtl | default "1h" | quote }}
-        {{- if .Values.agent.ai.analyze.model }}
+        {{- if or .Values.agent.ai.analyze.model .Values.agent.ai.analyze.provider }}
         analyze:
+          {{- if .Values.agent.ai.analyze.model }}
           model: {{ .Values.agent.ai.analyze.model | quote }}
+          {{- end }}
+          {{- if .Values.agent.ai.analyze.provider }}
+          provider: {{ .Values.agent.ai.analyze.provider | quote }}
+          {{- end }}
         {{- end }}
     {{- end }}
 

--- a/helm/versus-incident/values.yaml
+++ b/helm/versus-incident/values.yaml
@@ -129,6 +129,9 @@ agent:
     # OpenAI API key. Stored in the chart Secret and exposed as
     # AGENT_AI_API_KEY env var.
     apiKey: ""
+    # LLM backend: "openai" (default) or "gemini". Maps to the right
+    # OpenAI-compatible endpoint internally — no base URL needed. Not a secret.
+    provider: ""
     model: "gpt-4o-mini"
     # Randomness control. Set -1 to omit temperature entirely for
     # beta-limited / reasoning models (gpt-5.*, o-series) that fix it
@@ -145,6 +148,8 @@ agent:
       # Override the shared ai.model for analyze deep dives. Empty inherits
       # the top-level model above.
       model: ""
+      # Override the shared ai.provider for analyze deep dives. Empty inherits.
+      provider: ""
 
   # Per-tool configuration for the analyze tools (rendered into tools.yaml).
   # This is DATA config only, never a registration allow-list — tools are

--- a/pkg/agent/factory_ai.go
+++ b/pkg/agent/factory_ai.go
@@ -60,6 +60,7 @@ func BuildAIs(cfg config.AgentConfig, catalog *Catalog, store storage.Provider, 
 	detectCfg := cfg.AI.Resolve(cfg.AI.Detect)
 	detectAgent, err := detect.New(context.Background(), detectCfg, detect.Options{
 		HTTPClient: httpClient,
+		BaseURL:    config.ProviderBaseURL(detectCfg.Provider),
 	})
 	if err != nil {
 		log.Printf("agent: detect agent disabled: %v", err)
@@ -77,7 +78,10 @@ func BuildAIs(cfg config.AgentConfig, catalog *Catalog, store storage.Provider, 
 	var analyzeRate *ai.RateLimiter
 	var runbookMgr *runbook.Manager
 	{
-		analyzeBaseCfg := cfg.AI.Resolve(config.AgentAITaskConfig{Model: cfg.AI.Analyze.Model})
+		analyzeBaseCfg := cfg.AI.Resolve(config.AgentAITaskConfig{
+			Model:    cfg.AI.Analyze.Model,
+			Provider: cfg.AI.Analyze.Provider,
+		})
 
 		// Independent source set + redactor for the read-only
 		// get_related_logs tool. Built separately from the worker's
@@ -138,6 +142,7 @@ func BuildAIs(cfg config.AgentConfig, catalog *Catalog, store storage.Provider, 
 		tools := analyzetools.Default(store, newCatalogAdapter(catalog), reader, redactor, serviceMatcher, graph, changes, embedder, runbookSearcher)
 		a, aErr := analyze.New(context.Background(), analyzeBaseCfg, tools, analyze.Options{
 			HTTPClient:    httpClient,
+			BaseURL:       config.ProviderBaseURL(analyzeBaseCfg.Provider),
 			ToolTimeout:   parseDurationOr(cfg.Tools.ToolTimeout, 20*time.Second),
 			ParallelTools: cfg.Tools.ParallelTools,
 		})

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -1,5 +1,7 @@
 package config
 
+import "strings"
+
 // -----------------------------------------------------------------------------
 // Agent mode (AI incident detection)
 // -----------------------------------------------------------------------------
@@ -305,6 +307,10 @@ type AgentAIConfig struct {
 	Enable bool `mapstructure:"enable"`
 	// APIKey is the bearer token sent in the Authorization header.
 	APIKey string `mapstructure:"api_key"`
+	// Provider selects the LLM backend: "openai" (default) or "gemini".
+	// It maps to an OpenAI-compatible endpoint internally (see
+	// ProviderBaseURL) so operators pick a short name instead of a long URL.
+	Provider string `mapstructure:"provider"`
 	// Model is the model identifier, e.g. "gpt-4o-mini".
 	Model string `mapstructure:"model"`
 	// Temperature controls randomness (0.0–2.0). Default 0.2.
@@ -343,12 +349,16 @@ type AgentAIAnalyzeConfig struct {
 	// Model overrides the shared ai.model for analyze deep dives.
 	// Empty inherits ai.model.
 	Model string `mapstructure:"model"`
+	// Provider overrides the shared ai.provider for analyze deep dives.
+	// Empty inherits ai.provider.
+	Provider string `mapstructure:"provider"`
 }
 
 // AgentAITaskConfig is the per-task override block. Zero values mean
 // "inherit the top-level AgentAIConfig field".
 type AgentAITaskConfig struct {
 	Model           string  `mapstructure:"model"`
+	Provider        string  `mapstructure:"provider"`
 	Temperature     float64 `mapstructure:"temperature"`
 	MaxTokens       int     `mapstructure:"max_tokens"`
 	MaxCallsPerHour int     `mapstructure:"max_calls_per_hour"`
@@ -370,6 +380,9 @@ func (c AgentAIConfig) Resolve(task AgentAITaskConfig) AgentAIConfig {
 	if task.Model != "" {
 		out.Model = task.Model
 	}
+	if task.Provider != "" {
+		out.Provider = task.Provider
+	}
 	if task.Temperature != 0 {
 		out.Temperature = task.Temperature
 	}
@@ -383,4 +396,17 @@ func (c AgentAIConfig) Resolve(task AgentAITaskConfig) AgentAIConfig {
 		out.CacheTTL = task.CacheTTL
 	}
 	return out
+}
+
+// ProviderBaseURL maps an LLM provider id to its OpenAI-compatible chat
+// completions base URL, consumed by the shared eino OpenAI client. Both
+// "openai" and "gemini" expose OpenAI-compatible APIs, so only the base URL
+// changes. "" / "openai" / unknown return "" — the OpenAI default endpoint.
+func ProviderBaseURL(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "gemini":
+		return "https://generativelanguage.googleapis.com/v1beta/openai"
+	default:
+		return ""
+	}
 }

--- a/pkg/config/clone_config.go
+++ b/pkg/config/clone_config.go
@@ -332,6 +332,7 @@ func cloneAgentConfig(src AgentConfig) AgentConfig {
 		AI: AgentAIConfig{
 			Enable:          src.AI.Enable,
 			APIKey:          src.AI.APIKey,
+			Provider:        src.AI.Provider,
 			Model:           src.AI.Model,
 			Temperature:     src.AI.Temperature,
 			MaxTokens:       src.AI.MaxTokens,
@@ -478,6 +479,7 @@ func cloneToolsConfig(src ToolsConfig) ToolsConfig {
 func cloneAgentAITaskConfig(src AgentAITaskConfig) AgentAITaskConfig {
 	return AgentAITaskConfig{
 		Model:           src.Model,
+		Provider:        src.Provider,
 		Temperature:     src.Temperature,
 		MaxTokens:       src.MaxTokens,
 		MaxCallsPerHour: src.MaxCallsPerHour,
@@ -489,6 +491,7 @@ func cloneAgentAITaskConfig(src AgentAITaskConfig) AgentAITaskConfig {
 // override only; the tool-loop knobs live on the shared tools block).
 func cloneAgentAIAnalyzeConfig(src AgentAIAnalyzeConfig) AgentAIAnalyzeConfig {
 	return AgentAIAnalyzeConfig{
-		Model: src.Model,
+		Model:    src.Model,
+		Provider: src.Provider,
 	}
 }

--- a/pkg/config/provider_test.go
+++ b/pkg/config/provider_test.go
@@ -1,0 +1,37 @@
+package config
+
+import "testing"
+
+// TestProviderBaseURL asserts the provider→endpoint mapping: openai (and
+// empty/unknown) use the OpenAI default (""), gemini maps to its
+// OpenAI-compatible endpoint, and matching is case/space-insensitive.
+func TestProviderBaseURL(t *testing.T) {
+	const gemini = "https://generativelanguage.googleapis.com/v1beta/openai"
+	cases := map[string]string{
+		"":         "",
+		"openai":   "",
+		"OpenAI":   "",
+		"unknown":  "",
+		"gemini":   gemini,
+		"Gemini":   gemini,
+		" gemini ": gemini,
+	}
+	for in, want := range cases {
+		if got := ProviderBaseURL(in); got != want {
+			t.Errorf("ProviderBaseURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestResolveProviderOverride asserts a per-task provider overrides the
+// shared default, and an empty task provider inherits it.
+func TestResolveProviderOverride(t *testing.T) {
+	base := AgentAIConfig{Provider: "openai", Model: "m"}
+
+	if got := base.Resolve(AgentAITaskConfig{Provider: "gemini"}).Provider; got != "gemini" {
+		t.Fatalf("task override: got %q want gemini", got)
+	}
+	if got := base.Resolve(AgentAITaskConfig{}).Provider; got != "openai" {
+		t.Fatalf("inherit: got %q want openai", got)
+	}
+}


### PR DESCRIPTION
## What

Replaces the verbose `agent.ai.base_url` (#245) with a friendly `agent.ai.provider` enum — **`openai`** (default) or **`gemini`** — so operators pick a short name instead of a long URL.

`config.ProviderBaseURL(provider)` maps the provider to its OpenAI-compatible chat-completions endpoint internally (both backends are OpenAI-compatible, so only the base URL changes). Wired through detect + analyze (with a per-task `agent.ai.analyze.provider` override), `config.yaml` (env `AGENT_AI_PROVIDER`), and the Helm chart. Empty = `openai`, so existing deployments are unchanged.

```yaml
agent:
  ai:
    enable: true
    provider: gemini              # openai | gemini
    model: gemini-2.5-flash-lite
    api_key: ${AGENT_AI_API_KEY}
```

## Why

`base_url` meant pasting a long endpoint (`https://generativelanguage.googleapis.com/v1beta/openai`). A provider name is shorter, less error-prone and self-documenting; adding a backend is one `case` in `ProviderBaseURL`.

## Supersedes #245

Same goal (bring-your-own LLM / Gemini), cleaner surface — closing #245 in favour of this.

## Verified

- `go test ./pkg/config/...` — provider→endpoint map + per-task override.
- `helm lint` clean; `helm template --set agent.ai.provider=gemini` renders `provider: "gemini"` with **no** `base_url`.
- Runtime path is identical to the previously-verified base_url wiring (the OpenAI-compatible URL now comes from `ProviderBaseURL`), which ran the full **detect → Gemini → Telegram** loop on minikube.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
