### PR TITLE
agent: deterministic no-LLM emit-on-spike alerting mode

### DIFF
--- a/pkg/agent/worker.go
+++ b/pkg/agent/worker.go
@@ -630,6 +630,35 @@ func (w *Worker) emitDetect(
 	// no resolver so this collapses to the original `w.ai.Detect == nil`
 	// check — byte-for-byte unchanged.
 	if w.ai.Detect == nil || !w.effectiveAIEnabled(ctx) {
+		// Deterministic (no-LLM) alerting mode: a known pattern that suddenly
+		// spikes is emitted from the spike statistics alone — no model call.
+		// "Silence is the feature": only known-pattern spikes speak, and they
+		// speak deterministically.
+		if w.cfg.Catalog.EmitOnSpike && verdict == core.VerdictSpike {
+			multiple := 0.0
+			if prevBaseline > 0 {
+				multiple = float64(len(signals)) / prevBaseline
+			}
+			finding := &core.AIFinding{
+				Title: fmt.Sprintf("Frequency spike: %s", truncateString(template, 80)),
+				Summary: fmt.Sprintf(
+					"Known pattern spiked to %d/tick vs learned baseline %.2f (%.1fx). "+
+						"Deterministic detector — no LLM in the verdict path.",
+					len(signals), prevBaseline, multiple),
+				Severity:   "high",
+				Category:   "anomaly",
+				Confidence: 1.0,
+				SampleIDs:  []string{patternID},
+			}
+			evt.Finding = finding
+			outcome := w.send(finding, result, source, service, "emitted-stat")
+			evt.Outcome = outcome
+			if outcome == "send_error" {
+				evt.Error = "emitter returned error (see logs)"
+			}
+			w.detect.Record(evt)
+			return outcome
+		}
 		log.Printf("%sagent[detect:dry]: pattern=%s service=%s verdict=%s freq=%d (ai.enable=false)%s",
 			colorGreen, patternID, service, verdict, len(signals), colorReset)
 		evt.Outcome = "dry"

--- a/pkg/agent/worker_emit_spike_test.go
+++ b/pkg/agent/worker_emit_spike_test.go
@@ -1,0 +1,93 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/VersusControl/versus-incident/pkg/config"
+	"github.com/VersusControl/versus-incident/pkg/core"
+	"github.com/VersusControl/versus-incident/pkg/storage"
+)
+
+// newSpikeWorker builds a Worker with the deterministic emit-on-spike mode
+// configured and NO AI agent (AIBundle{} => Detect == nil), plus a capturing
+// emitter — the exact setup for the no-LLM alerting path.
+func newSpikeWorker(t *testing.T, emitOnSpike bool, emitter Emitter) *Worker {
+	t.Helper()
+	cat, err := LoadCatalog(storage.NewMemory())
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	w, err := NewWorker(WorkerOptions{
+		Sources: []core.SignalSource{stubSource{name: "test"}},
+		Miner:   NewMiner(0.4, 4, 100),
+		Catalog: cat,
+		AI:      AIBundle{}, // Detect == nil => AI off
+		Emitter: emitter,
+		Cfg:     config.AgentConfig{Catalog: config.AgentCatalogConfig{EmitOnSpike: emitOnSpike}},
+	})
+	if err != nil {
+		t.Fatalf("NewWorker: %v", err)
+	}
+	return w
+}
+
+// A VerdictSpike with AI off + emit_on_spike=true emits a deterministic
+// incident (no model call).
+func TestWorker_EmitOnSpike_EmitsWithoutAI(t *testing.T) {
+	var got struct {
+		n int
+		f *core.AIFinding
+	}
+	emitter := func(f *core.AIFinding, _ core.AgentResult, _, _ string) error {
+		got.n++
+		got.f = f
+		return nil
+	}
+	w := newSpikeWorker(t, true, emitter)
+
+	signals := []core.Signal{{Message: "flood", Source: "svc"}, {Message: "flood", Source: "svc"}}
+	outcome := w.emitDetect(context.Background(), "test", "pid", "flood", "svc", signals, core.VerdictSpike, 1.0)
+
+	if outcome != "emitted-stat" {
+		t.Fatalf("outcome = %q, want emitted-stat", outcome)
+	}
+	if got.n != 1 {
+		t.Fatalf("emitter called %d times, want 1", got.n)
+	}
+	if got.f == nil || !strings.Contains(got.f.Title, "Frequency spike") {
+		t.Fatalf("finding = %+v, want a Frequency spike title", got.f)
+	}
+	if !strings.Contains(got.f.Summary, "no LLM") {
+		t.Fatalf("summary should note the no-LLM path, got %q", got.f.Summary)
+	}
+}
+
+// With emit_on_spike=false (default) a spike + no AI stays dry — behaviour
+// preserved.
+func TestWorker_EmitOnSpike_DisabledStaysDry(t *testing.T) {
+	called := 0
+	emitter := func(*core.AIFinding, core.AgentResult, string, string) error { called++; return nil }
+	w := newSpikeWorker(t, false, emitter)
+
+	out := w.emitDetect(context.Background(), "t", "p", "x", "s",
+		[]core.Signal{{Message: "x"}}, core.VerdictSpike, 1.0)
+	if out != "dry" || called != 0 {
+		t.Fatalf("out=%q called=%d, want dry / 0", out, called)
+	}
+}
+
+// Even with emit_on_spike=true, a non-spike verdict (Unknown) stays dry —
+// only known-pattern spikes speak. Silence is the feature.
+func TestWorker_EmitOnSpike_OnlySpikesEmit(t *testing.T) {
+	called := 0
+	emitter := func(*core.AIFinding, core.AgentResult, string, string) error { called++; return nil }
+	w := newSpikeWorker(t, true, emitter)
+
+	out := w.emitDetect(context.Background(), "t", "p", "x", "s",
+		[]core.Signal{{Message: "x"}}, core.VerdictUnknown, 0)
+	if out != "dry" || called != 0 {
+		t.Fatalf("out=%q called=%d, want dry / 0", out, called)
+	}
+}

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -68,6 +68,13 @@ type AgentCatalogConfig struct {
 	// a pattern before spike detection considers it. Avoids treating a
 	// barely-seen pattern's first big tick as a spike. Default 20.
 	SpikeMinBaselineCount int `mapstructure:"spike_min_baseline_count"`
+	// EmitOnSpike enables the deterministic (no-LLM) alerting mode: when the
+	// AI analyzer is disabled, a VerdictSpike still emits an incident built
+	// from the spike statistics (template, observed rate, learned baseline,
+	// multiple-over-baseline) instead of being dropped. This is the
+	// "silence is the feature; alert only on known-pattern spikes, no LLM"
+	// path. Default false (preserves the existing dry-detect behaviour).
+	EmitOnSpike bool `mapstructure:"emit_on_spike"`
 }
 
 // CatalogBlobName is the storage blob key used by the agent catalog.


### PR DESCRIPTION
@
## What

Adds an `emit_on_spike` agent-catalog config flag that turns on a **deterministic, no-LLM alerting mode**: when the AI analyzer is disabled, a `VerdictSpike` now emits an incident built purely from the spike statistics (template, observed rate, learned EWMA baseline, multiple-over-baseline) via the existing `services` emitter — instead of being dropped in dry-detect.

## Why

Today, the spike **verdict** is already produced deterministically (`logBrain.Classify` → `core.VerdictSpike`, no model call), but with the AI off the worker only classifies + logs and never emits. This wires the last mile so a known pattern that suddenly floods can page on-call **without any LLM in the path** — the "silence is the feature; only known-pattern spikes speak, and they speak deterministically" model. Useful for cost-sensitive / air-gapped / low-latency deployments.

## Behaviour

- `spike ⇔ tickFreq > SpikeMultiplier × baseline` (existing `isSpike`, unchanged).
- Only `VerdictSpike` emits; `VerdictUnknown` / `VerdictKnownPattern` stay dry.
- **Default `false`** — existing dry-detect behaviour is byte-for-byte preserved.

## Tests

`pkg/agent/worker_emit_spike_test.go` (+3): emits on spike with AI off; stays dry when disabled; only spikes emit (not Unknown). Full `go test ./pkg/agent/` and `go build ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@