### PR TITLE
feat: list pagination, and signed ack tokens

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,6 +76,12 @@ func main() {
 	// alert + record acks).
 	services.SetStorage(store)
 
+	// Resolve the HMAC key used to sign and verify acknowledgment-link tokens.
+	// Generated once and persisted via storage so every replica signs the same
+	// key and links survive restarts; falls back to gateway_secret, then an
+	// ephemeral in-memory key. Never logged.
+	services.InitAckSigningKey(store, cfg)
+
 	// Wire the incident-report feature (OSS default). The renderer is the
 	// pure-Go in-binary PNG card renderer; an enterprise build may swap it
 	// via services.SetReportRenderer behind the same core.ReportRenderer

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -99,7 +99,7 @@ oncall:
   # /api/incidents?oncall_wait_minutes=0 => Set the number of minutes to wait for acknowledgment before triggering on-call. Set to `0` to trigger immediately
   initialized_only: false  # Initialize on-call feature but don't enable by default, requires 'oncall_enable=true' in query parameters
   enable: false # Use this to enable or disable on-call for all alerts
-  wait_minutes: 3 # If you set it to 0, it means there's no need to check for an acknowledgment, and the on-call will trigger immediately
+  wait_minutes: 3 # If you set it to 0, it means there's no need to check for an acknowledgment, and the on-call will trigger immediately. The acknowledgment link sent with each alert expires after this window (no link is sent when this is 0).
   provider: aws_incident_manager # Valid values: "aws_incident_manager", "pagerduty", "servicenow" or "incident_io"
 
   aws_incident_manager: # Used when provider is "aws_incident_manager"

--- a/pkg/controllers/ack.go
+++ b/pkg/controllers/ack.go
@@ -1,7 +1,9 @@
 package controllers
 
 import (
+	"errors"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/VersusControl/versus-incident/pkg/core"
@@ -11,6 +13,15 @@ import (
 
 func HandleAck(c *fiber.Ctx) error {
 	incidentID := c.Params("incidentID")
+
+	// The ack link must carry a signed.
+	exp, _ := strconv.ParseInt(c.Query("exp"), 10, 64)
+	if err := services.VerifyAckToken(services.AckSigningKey(), incidentID, exp, c.Query("sig"), time.Now()); err != nil {
+		if errors.Is(err, services.ErrAckTokenExpired) {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "ack link expired"})
+		}
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid ack link"})
+	}
 
 	// On-call is disabled by default. Skip the singleton entirely when it
 	// isn't initialized so an unauthenticated request can't panic (and take

--- a/pkg/controllers/ack_test.go
+++ b/pkg/controllers/ack_test.go
@@ -1,13 +1,29 @@
 package controllers
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/VersusControl/versus-incident/pkg/core"
+	"github.com/VersusControl/versus-incident/pkg/services"
 
 	"github.com/gofiber/fiber/v2"
 )
+
+// ackTestKey is the signing key installed for the ack handler tests so they can
+// mint valid tokens the same way the running service does.
+var ackTestKey = []byte("ack-test-signing-key-0123456789ab")
+
+// installAckKey installs a known signing key for the duration of a test and
+// restores the previous one on cleanup.
+func installAckKey(t *testing.T) {
+	t.Helper()
+	prev := services.AckSigningKey()
+	services.SetAckSigningKey(ackTestKey)
+	t.Cleanup(func() { services.SetAckSigningKey(prev) })
+}
 
 // ackTestApp mounts HandleAck on the public ack route the same way the router
 // registers it, so requests exercise the real handler path.
@@ -17,14 +33,23 @@ func ackTestApp() *fiber.App {
 	return app
 }
 
-// TestHandleAck_UninitializedReturns503 proves the DoS fix: an unauthenticated
-// ack request with on-call never initialized (the default) returns a clean
-// 503 instead of panicking and taking down the process.
+// signedAckPath builds the ack URL path (with exp + sig query) for id, valid
+// for the given TTL from now, using the installed test key.
+func signedAckPath(id string, ttl time.Duration) string {
+	exp := time.Now().Add(ttl).Unix()
+	sig := services.SignAckToken(ackTestKey, id, exp)
+	return fmt.Sprintf("/api/ack/%s?exp=%d&sig=%s", id, exp, sig)
+}
+
+// TestHandleAck_UninitializedReturns503 proves the DoS fix: an ack request with
+// a VALID token but on-call never initialized (the default) returns a clean 503
+// instead of panicking and taking down the process.
 func TestHandleAck_UninitializedReturns503(t *testing.T) {
+	installAckKey(t)
 	core.SetOnCallWorkflow(nil)
 
 	app := ackTestApp()
-	resp, err := app.Test(httptest.NewRequest("GET", "/api/ack/anything", nil))
+	resp, err := app.Test(httptest.NewRequest("GET", signedAckPath("anything", time.Hour), nil))
 	if err != nil {
 		t.Fatalf("app.Test: %v", err)
 	}
@@ -36,11 +61,38 @@ func TestHandleAck_UninitializedReturns503(t *testing.T) {
 }
 
 // TestHandleAck_InitializedProceeds proves that when the workflow IS installed
-// the handler skips the 503 guard and delegates to Ack. With a workflow that
-// has no Redis client, Ack reports it isn't fully wired, so the handler returns
-// the existing 500 error path — the key point being it is NOT the 503 guard and
-// it does NOT panic.
+// and the token is valid the handler skips the 503 guard and delegates to Ack.
+// With a workflow that has no Redis client, Ack reports it isn't fully wired,
+// so the handler returns the existing 500 error path — the key point being it
+// is NOT the 503 guard, NOT the 401 auth guard, and it does NOT panic.
 func TestHandleAck_InitializedProceeds(t *testing.T) {
+	installAckKey(t)
+	core.SetOnCallWorkflow(core.NewOnCallWorkflow(nil, nil))
+	t.Cleanup(func() { core.SetOnCallWorkflow(nil) })
+
+	app := ackTestApp()
+	resp, err := app.Test(httptest.NewRequest("GET", signedAckPath("i-123", time.Hour), nil))
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == fiber.StatusServiceUnavailable {
+		t.Fatalf("did not expect the 503 uninitialized guard once the workflow is installed")
+	}
+	if resp.StatusCode == fiber.StatusUnauthorized {
+		t.Fatalf("did not expect the 401 auth guard for a valid token")
+	}
+	if resp.StatusCode != fiber.StatusInternalServerError {
+		t.Fatalf("expected %d from the Ack error path, got %d", fiber.StatusInternalServerError, resp.StatusCode)
+	}
+}
+
+// TestHandleAck_MissingTokenRejected proves the auth check runs FIRST: a
+// request with no token is rejected 401 BEFORE the on-call 503 guard, even
+// though on-call is uninitialized.
+func TestHandleAck_MissingTokenRejected(t *testing.T) {
+	installAckKey(t)
 	core.SetOnCallWorkflow(core.NewOnCallWorkflow(nil, nil))
 	t.Cleanup(func() { core.SetOnCallWorkflow(nil) })
 
@@ -51,10 +103,50 @@ func TestHandleAck_InitializedProceeds(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == fiber.StatusServiceUnavailable {
-		t.Fatalf("did not expect the 503 uninitialized guard once the workflow is installed")
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Fatalf("expected %d for a missing token, got %d", fiber.StatusUnauthorized, resp.StatusCode)
 	}
-	if resp.StatusCode != fiber.StatusInternalServerError {
-		t.Fatalf("expected %d from the Ack error path, got %d", fiber.StatusInternalServerError, resp.StatusCode)
+}
+
+// TestHandleAck_ExpiredTokenRejected proves an expired but correctly-signed
+// token is rejected 403 without acking.
+func TestHandleAck_ExpiredTokenRejected(t *testing.T) {
+	installAckKey(t)
+	core.SetOnCallWorkflow(core.NewOnCallWorkflow(nil, nil))
+	t.Cleanup(func() { core.SetOnCallWorkflow(nil) })
+
+	app := ackTestApp()
+	resp, err := app.Test(httptest.NewRequest("GET", signedAckPath("i-123", -time.Hour), nil))
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusForbidden {
+		t.Fatalf("expected %d for an expired token, got %d", fiber.StatusForbidden, resp.StatusCode)
+	}
+}
+
+// TestHandleAck_TamperedTokenRejected proves a token whose id was swapped (a
+// valid signature for a DIFFERENT incident) is rejected 401 — the IDOR fix.
+func TestHandleAck_TamperedTokenRejected(t *testing.T) {
+	installAckKey(t)
+	core.SetOnCallWorkflow(core.NewOnCallWorkflow(nil, nil))
+	t.Cleanup(func() { core.SetOnCallWorkflow(nil) })
+
+	// Sign for one incident, then request a different one with that signature.
+	exp := time.Now().Add(time.Hour).Unix()
+	sig := services.SignAckToken(ackTestKey, "other-incident", exp)
+	path := fmt.Sprintf("/api/ack/i-123?exp=%d&sig=%s", exp, sig)
+
+	app := ackTestApp()
+	resp, err := app.Test(httptest.NewRequest("GET", path, nil))
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Fatalf("expected %d for a tampered token, got %d", fiber.StatusUnauthorized, resp.StatusCode)
 	}
 }

--- a/pkg/controllers/analyses_admin_test.go
+++ b/pkg/controllers/analyses_admin_test.go
@@ -1,0 +1,133 @@
+package controllers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/services"
+	"github.com/VersusControl/versus-incident/pkg/storage"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// nonPagerStore wraps a Provider through the interface type so the optional
+// storage.AnalysisPager methods are NOT promoted — a value of this type never
+// satisfies AnalysisPager even when its dynamic backend does. It forces the
+// listAllAnalyses fallback path (bounded ListAnalyses), mirroring the redis
+// stub that has no pager capability.
+type nonPagerStore struct {
+	storage.Provider
+}
+
+func seedControllerAnalyses(t *testing.T, store storage.Provider, n int) {
+	t.Helper()
+	base := time.Now().UTC().Add(-time.Hour)
+	for i := 0; i < n; i++ {
+		rec := &storage.AnalysisRecord{
+			ID:          "an-" + string(rune('a'+i)),
+			IncidentID:  "inc-1",
+			RequestedAt: base.Add(time.Duration(i) * time.Minute),
+			Status:      "ok",
+		}
+		if err := store.SaveAnalysis(rec); err != nil {
+			t.Fatalf("SaveAnalysis %d: %v", i, err)
+		}
+	}
+}
+
+// analysesResp is the paged list response shape the endpoint returns.
+type analysesResp struct {
+	Analyses   []storage.AnalysisRecord `json:"analyses"`
+	Total      int                      `json:"total"`
+	Offset     int                      `json:"offset"`
+	PageSize   int                      `json:"page_size"`
+	NextOffset *int                     `json:"next_offset"`
+}
+
+func getAnalyses(t *testing.T, app *fiber.App, url string) analysesResp {
+	t.Helper()
+	resp, err := app.Test(httptest.NewRequest("GET", url, nil))
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	var got analysesResp
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", body, err)
+	}
+	return got
+}
+
+// TestListAllAnalysesPaged proves the pager path serves a bounded page plus the
+// whole-set total, newest first, with offset continuation.
+func TestListAllAnalysesPaged(t *testing.T) {
+	t.Cleanup(func() { services.SetStorage(nil) })
+	store := storage.NewMemory()
+	seedControllerAnalyses(t, store, 5)
+	services.SetStorage(store)
+
+	ctrl := NewIncidentAdminController()
+	app := fiber.New()
+	app.Get("/analyses", ctrl.listAllAnalyses)
+
+	// First page of 2 rows: total is the whole set (5), next_offset points past
+	// this page since it is full.
+	got := getAnalyses(t, app, "/analyses?page_size=2")
+	if got.Total != 5 {
+		t.Fatalf("total = %d, want 5", got.Total)
+	}
+	if len(got.Analyses) != 2 {
+		t.Fatalf("page rows = %d, want 2", len(got.Analyses))
+	}
+	if got.PageSize != 2 {
+		t.Fatalf("page_size = %d, want 2", got.PageSize)
+	}
+	if got.NextOffset == nil || *got.NextOffset != 2 {
+		t.Fatalf("next_offset = %v, want 2", got.NextOffset)
+	}
+	// Newest first: the last-seeded id leads.
+	if got.Analyses[0].ID != "an-e" {
+		t.Fatalf("first row = %q, want an-e (newest)", got.Analyses[0].ID)
+	}
+
+	// Last page (offset 4) is underfull, so next_offset is null (end reached).
+	last := getAnalyses(t, app, "/analyses?page_size=2&offset=4")
+	if len(last.Analyses) != 1 {
+		t.Fatalf("last page rows = %d, want 1", len(last.Analyses))
+	}
+	if last.NextOffset != nil {
+		t.Fatalf("next_offset = %v, want null at end", last.NextOffset)
+	}
+}
+
+// TestListAllAnalysesFallback proves a backend without the pager capability
+// still serves a bounded list via ListAnalyses, and reports a total.
+func TestListAllAnalysesFallback(t *testing.T) {
+	t.Cleanup(func() { services.SetStorage(nil) })
+	inner := storage.NewMemory()
+	seedControllerAnalyses(t, inner, 3)
+	store := nonPagerStore{Provider: inner}
+	if _, ok := interface{}(store).(storage.AnalysisPager); ok {
+		t.Fatal("nonPagerStore unexpectedly satisfies AnalysisPager")
+	}
+	services.SetStorage(store)
+
+	ctrl := NewIncidentAdminController()
+	app := fiber.New()
+	app.Get("/analyses", ctrl.listAllAnalyses)
+
+	got := getAnalyses(t, app, "/analyses")
+	if len(got.Analyses) != 3 {
+		t.Fatalf("fallback rows = %d, want 3", len(got.Analyses))
+	}
+	if got.Total != 3 {
+		t.Fatalf("fallback total = %d, want 3", got.Total)
+	}
+}

--- a/pkg/controllers/incidents_admin.go
+++ b/pkg/controllers/incidents_admin.go
@@ -337,6 +337,24 @@ func parsePageSize(v string) int {
 	return n
 }
 
+// parseAnalysisPageSize resolves the requested page size for the bounded
+// analyses read: the storage default (1000) when unset, clamped to
+// [1, maxIncidentPageSize] otherwise so a single request stays bounded — the
+// analyses twin of parsePageSize.
+func parseAnalysisPageSize(v string) int {
+	if v == "" {
+		return storage.DefaultAnalysisPageSize
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return storage.DefaultAnalysisPageSize
+	}
+	if n > maxIncidentPageSize {
+		return maxIncidentPageSize
+	}
+	return n
+}
+
 // pageOffset resolves the starting row offset and the 1-based page number for
 // a bounded list/search read from the two accepted params. An explicit
 // zero-based offset cursor (what the UI's infinite scroll sends via
@@ -423,7 +441,33 @@ func pagedIncidentResponse(recs []*storage.IncidentRecord, counts storage.Incide
 	return resp
 }
 
-// incidentListResponse is the shared post-processing for the list and
+// pagedAnalysisResponse builds the analyses list response from the CHEAP total
+// count and ONE bounded page of rows. It preserves the existing `analyses`
+// array and adds total + offset-based continuation (offset / next_offset /
+// page / page_size), mirroring pagedIncidentResponse: the UI shows the true
+// total, renders the first page, and fetches the next chunk only on demand. A
+// full page (len == size) implies at least one more page; an underfull page is
+// the last one.
+func pagedAnalysisResponse(recs []*storage.AnalysisRecord, total, offset, size, page int) fiber.Map {
+	out := recs
+	if out == nil {
+		out = []*storage.AnalysisRecord{}
+	}
+	resp := fiber.Map{
+		"analyses":  out,
+		"total":     total,
+		"offset":    offset,
+		"page":      page,
+		"page_size": size,
+	}
+	if len(recs) == size {
+		resp["next_offset"] = offset + len(recs)
+	} else {
+		resp["next_offset"] = nil
+	}
+	return resp
+}
+
 // search endpoints. It computes per-origin counts over the FULL result
 // set (so the top-bar shows both feeds regardless of the active tab),
 // applies the optional origin filter, then paginates. pageParam /
@@ -624,19 +668,37 @@ func (i *IncidentAdminController) listAnalyses(c *fiber.Ctx) error {
 func (i *IncidentAdminController) listAllAnalyses(c *fiber.Ctx) error {
 	store := services.Storage()
 	if store == nil {
-		return c.JSON(fiber.Map{"analyses": []any{}})
+		return c.JSON(fiber.Map{"analyses": []any{}, "total": 0})
 	}
-	limit := 0
-	if v := c.Query("limit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			limit = n
+	// Preferred path: the backend implements the pager capability, so we render
+	// a page from ONE bounded query plus ONE cheap count query and never load
+	// the whole vs_analyses table. Postgres (unbounded) and the file/memory
+	// backends (already capped) all implement it.
+	if pager, ok := store.(storage.AnalysisPager); ok {
+		total, err := pager.CountAnalyses()
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 		}
+		size := parseAnalysisPageSize(c.Query("page_size"))
+		offset, page := pageOffset(c.Query("page"), c.Query("offset"), size)
+		recs, err := pager.ListAnalysesPage(offset, size)
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		}
+		return c.JSON(pagedAnalysisResponse(recs, total, offset, size, page))
+	}
+	// Fallback for backends without the pager capability (the redis stub): a
+	// BOUNDED read so it can never load the whole table. Legacy shape (just
+	// analyses) — the caller-supplied limit is clamped to the default page.
+	limit := parseLimit(c.Query("limit"))
+	if limit <= 0 || limit > storage.DefaultAnalysisPageSize {
+		limit = storage.DefaultAnalysisPageSize
 	}
 	recs, err := store.ListAnalyses(limit)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
-	return c.JSON(fiber.Map{"analyses": recs})
+	return c.JSON(fiber.Map{"analyses": recs, "total": len(recs)})
 }
 
 func (i *IncidentAdminController) getAnalysis(c *fiber.Ctx) error {

--- a/pkg/services/acktoken.go
+++ b/pkg/services/acktoken.go
@@ -1,0 +1,171 @@
+package services
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/config"
+	"github.com/VersusControl/versus-incident/pkg/storage"
+)
+
+// The ack link delivered through an alert channel authorizes acknowledging an
+// incident, so it must not be forgeable from the incident id alone. Each link
+// carries an expiry and an HMAC signature over (incidentID, exp); the ack
+// endpoint recomputes the HMAC with the same key and rejects anything that is
+// missing, expired, or tampered. This closes the ack IDOR: knowing an id is no
+// longer enough to ack it.
+
+var (
+	// ErrAckTokenMissing is returned when no signature (or no signing key) is
+	// present, so the request carries nothing to verify.
+	ErrAckTokenMissing = errors.New("ack token missing")
+	// ErrAckTokenExpired is returned when exp is at or before now.
+	ErrAckTokenExpired = errors.New("ack token expired")
+	// ErrAckTokenInvalid is returned when the HMAC does not match.
+	ErrAckTokenInvalid = errors.New("ack token invalid")
+)
+
+const (
+	// ackSigningKeyBlob is the fixed blob key the generate-once ack signing key
+	// is persisted under. Lives beside any other generated secrets under the
+	// secrets/ namespace.
+	ackSigningKeyBlob = "secrets/ack-signing-key"
+	// ackSigningKeyLen is the length in bytes of the generated HMAC key.
+	ackSigningKeyLen = 32
+)
+
+// ackSigningKey is the process-wide HMAC key used to sign and verify ack
+// tokens. Set once at startup by InitAckSigningKey. Never logged.
+var ackSigningKey []byte
+
+// SetAckSigningKey installs the HMAC key used to sign and verify ack tokens.
+// Called once from main after storage is wired; tests set it directly.
+func SetAckSigningKey(k []byte) { ackSigningKey = k }
+
+// AckSigningKey returns the installed ack signing key, or nil when none has
+// been configured (in which case ack verification fails closed).
+func AckSigningKey() []byte { return ackSigningKey }
+
+// SignAckToken returns base64url(HMAC-SHA256(key, incidentID + "." + exp)).
+// It is pure — the signature depends only on its arguments — so it is the
+// single point both the URL builder and the verifier compute the MAC.
+func SignAckToken(key []byte, incidentID string, exp int64) string {
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(incidentID + "." + strconv.FormatInt(exp, 10)))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// VerifyAckToken checks that sig is a valid, unexpired signature over
+// (incidentID, exp) under key, relative to now. It fails closed:
+//   - no key configured or an empty signature ⇒ ErrAckTokenMissing
+//   - HMAC mismatch (tampered id/exp/sig)      ⇒ ErrAckTokenInvalid
+//   - exp at or before now                     ⇒ ErrAckTokenExpired
+//
+// The signature is verified BEFORE the expiry is trusted, so a forged exp
+// cannot extend a link's life — a changed exp changes the MAC and is rejected.
+// The comparison is constant-time (hmac.Equal) to avoid a timing oracle.
+func VerifyAckToken(key []byte, incidentID string, exp int64, sig string, now time.Time) error {
+	if len(key) == 0 || sig == "" {
+		return ErrAckTokenMissing
+	}
+	expected := SignAckToken(key, incidentID, exp)
+	if !hmac.Equal([]byte(expected), []byte(sig)) {
+		return ErrAckTokenInvalid
+	}
+	if exp <= now.Unix() {
+		return ErrAckTokenExpired
+	}
+	return nil
+}
+
+// AckURL builds the acknowledgment link injected into an alert's content. When
+// a signing key is configured it embeds an expiry and signature so the endpoint
+// can authenticate the request; without a key (verification cannot succeed
+// anyway) it emits the bare path so the shape is unchanged. The URL is rendered
+// verbatim by channel templates, so no template change is needed.
+//
+// ttl is the link's lifetime, chosen by the caller — for an incident that is
+// the effective on-call acknowledgment wait window, so the link stays valid
+// exactly as long as an ack can still forestall escalation.
+func AckURL(cfg *config.Config, incidentID string, ttl time.Duration) string {
+	key := AckSigningKey()
+	if len(key) == 0 {
+		return fmt.Sprintf("%s/api/ack/%s", cfg.PublicHost, incidentID)
+	}
+	exp := time.Now().Add(ttl).Unix()
+	sig := SignAckToken(key, incidentID, exp)
+	return fmt.Sprintf("%s/api/ack/%s?exp=%d&sig=%s", cfg.PublicHost, incidentID, exp, sig)
+}
+
+// InitAckSigningKey resolves the HMAC key used to sign and verify ack tokens,
+// installs it process-wide, and returns it. Resolution order, HA-consistent:
+//
+//  1. Generate a random 32-byte key and persist it generate-once via the
+//     storage.BlobCreator seam under ackSigningKeyBlob. Exactly one instance
+//     wins the create; every instance then adopts the surviving bytes, so all
+//     replicas sign with the same key and links survive restarts.
+//  2. If the backend does not implement BlobCreator, fall back to
+//     config.GatewaySecret when set (stable across restarts, operator-owned).
+//  3. Otherwise generate an ephemeral in-memory key and warn that ack links
+//     will not survive a restart.
+//
+// The key is never logged.
+func InitAckSigningKey(store storage.Provider, cfg *config.Config) []byte {
+	if key := generateAndPersistAckKey(store); key != nil {
+		SetAckSigningKey(key)
+		return key
+	}
+	if cfg != nil {
+		if s := strings.TrimSpace(cfg.GatewaySecret); s != "" {
+			SetAckSigningKey([]byte(s))
+			return []byte(s)
+		}
+	}
+	key := make([]byte, ackSigningKeyLen)
+	if _, err := rand.Read(key); err != nil {
+		log.Printf("ack: failed to generate an ephemeral signing key: %v", err)
+	}
+	log.Printf("ack: WARNING using an in-memory ack signing key — ack links will not survive a restart; configure a database storage backend or gateway_secret for a stable key")
+	SetAckSigningKey(key)
+	return key
+}
+
+// generateAndPersistAckKey elects a single generated key across every instance
+// sharing the store via CreateBlobIfAbsent, returning the surviving bytes. It
+// returns nil when the backend does not implement BlobCreator or the
+// create/read path fails, so the caller can fall back.
+func generateAndPersistAckKey(store storage.Provider) []byte {
+	bc, ok := store.(storage.BlobCreator)
+	if !ok {
+		return nil
+	}
+	candidate := make([]byte, ackSigningKeyLen)
+	if _, err := rand.Read(candidate); err != nil {
+		log.Printf("ack: failed to generate a signing key: %v", err)
+		return nil
+	}
+	written, err := bc.CreateBlobIfAbsent(ackSigningKeyBlob, candidate)
+	if err != nil {
+		log.Printf("ack: failed to persist the signing key: %v", err)
+		return nil
+	}
+	if written {
+		return candidate
+	}
+	// Another instance (or a prior boot) already wrote the key; adopt the
+	// surviving bytes so every replica signs identically.
+	surviving, err := store.ReadBlob(ackSigningKeyBlob)
+	if err != nil || len(surviving) == 0 {
+		log.Printf("ack: failed to read the persisted signing key: %v", err)
+		return nil
+	}
+	return surviving
+}

--- a/pkg/services/acktoken_test.go
+++ b/pkg/services/acktoken_test.go
@@ -1,0 +1,213 @@
+package services
+
+import (
+	"bytes"
+	neturl "net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/config"
+	"github.com/VersusControl/versus-incident/pkg/storage"
+)
+
+var testAckKey = []byte("unit-test-signing-key-0123456789ab")
+
+func TestSignAckToken_Deterministic(t *testing.T) {
+	a := SignAckToken(testAckKey, "inc-1", 1000)
+	b := SignAckToken(testAckKey, "inc-1", 1000)
+	if a != b {
+		t.Fatalf("signature not deterministic: %q != %q", a, b)
+	}
+	// A different id or exp yields a different signature.
+	if SignAckToken(testAckKey, "inc-2", 1000) == a {
+		t.Fatal("signature did not change with a different incident id")
+	}
+	if SignAckToken(testAckKey, "inc-1", 1001) == a {
+		t.Fatal("signature did not change with a different exp")
+	}
+	if SignAckToken([]byte("other-key-0123456789abcdef012345"), "inc-1", 1000) == a {
+		t.Fatal("signature did not change with a different key")
+	}
+}
+
+func TestVerifyAckToken_Valid(t *testing.T) {
+	now := time.Unix(1000, 0)
+	exp := now.Add(time.Hour).Unix()
+	sig := SignAckToken(testAckKey, "inc-1", exp)
+	if err := VerifyAckToken(testAckKey, "inc-1", exp, sig, now); err != nil {
+		t.Fatalf("valid token rejected: %v", err)
+	}
+}
+
+func TestVerifyAckToken_Missing(t *testing.T) {
+	now := time.Unix(1000, 0)
+	exp := now.Add(time.Hour).Unix()
+	if err := VerifyAckToken(testAckKey, "inc-1", exp, "", now); err != ErrAckTokenMissing {
+		t.Fatalf("empty sig: got %v, want ErrAckTokenMissing", err)
+	}
+	sig := SignAckToken(testAckKey, "inc-1", exp)
+	if err := VerifyAckToken(nil, "inc-1", exp, sig, now); err != ErrAckTokenMissing {
+		t.Fatalf("nil key: got %v, want ErrAckTokenMissing", err)
+	}
+}
+
+func TestVerifyAckToken_Expired(t *testing.T) {
+	now := time.Unix(1000, 0)
+	exp := now.Add(-time.Second).Unix()
+	sig := SignAckToken(testAckKey, "inc-1", exp)
+	if err := VerifyAckToken(testAckKey, "inc-1", exp, sig, now); err != ErrAckTokenExpired {
+		t.Fatalf("expired token: got %v, want ErrAckTokenExpired", err)
+	}
+	// Exactly at now is treated as expired (exp <= now).
+	expNow := now.Unix()
+	sigNow := SignAckToken(testAckKey, "inc-1", expNow)
+	if err := VerifyAckToken(testAckKey, "inc-1", expNow, sigNow, now); err != ErrAckTokenExpired {
+		t.Fatalf("token expiring now: got %v, want ErrAckTokenExpired", err)
+	}
+}
+
+func TestVerifyAckToken_Tampered(t *testing.T) {
+	now := time.Unix(1000, 0)
+	exp := now.Add(time.Hour).Unix()
+	sig := SignAckToken(testAckKey, "inc-1", exp)
+
+	// Swapped incident id (the IDOR attempt): the signature no longer matches.
+	if err := VerifyAckToken(testAckKey, "inc-2", exp, sig, now); err != ErrAckTokenInvalid {
+		t.Fatalf("swapped id: got %v, want ErrAckTokenInvalid", err)
+	}
+	// Extended exp with the original signature: rejected before expiry is trusted.
+	if err := VerifyAckToken(testAckKey, "inc-1", exp+3600, sig, now); err != ErrAckTokenInvalid {
+		t.Fatalf("extended exp: got %v, want ErrAckTokenInvalid", err)
+	}
+	// Garbled signature.
+	if err := VerifyAckToken(testAckKey, "inc-1", exp, sig+"x", now); err != ErrAckTokenInvalid {
+		t.Fatalf("garbled sig: got %v, want ErrAckTokenInvalid", err)
+	}
+}
+
+func TestAckURL_SignedWhenKeyPresent(t *testing.T) {
+	prev := AckSigningKey()
+	SetAckSigningKey(testAckKey)
+	t.Cleanup(func() { SetAckSigningKey(prev) })
+
+	cfg := &config.Config{PublicHost: "https://versus.example"}
+	url := AckURL(cfg, "inc-1", 30*time.Minute)
+	// The URL must carry both query params so the endpoint can verify it.
+	if !bytes.Contains([]byte(url), []byte("https://versus.example/api/ack/inc-1?exp=")) {
+		t.Fatalf("unexpected ack url: %q", url)
+	}
+	if !bytes.Contains([]byte(url), []byte("&sig=")) {
+		t.Fatalf("ack url missing signature: %q", url)
+	}
+}
+
+func TestAckURL_BarePathWhenNoKey(t *testing.T) {
+	prev := AckSigningKey()
+	SetAckSigningKey(nil)
+	t.Cleanup(func() { SetAckSigningKey(prev) })
+
+	cfg := &config.Config{PublicHost: "https://versus.example"}
+	if got, want := AckURL(cfg, "inc-1", 30*time.Minute), "https://versus.example/api/ack/inc-1"; got != want {
+		t.Fatalf("bare ack url = %q, want %q", got, want)
+	}
+}
+
+func TestAckURL_ExpReflectsTTL(t *testing.T) {
+	prev := AckSigningKey()
+	SetAckSigningKey(testAckKey)
+	t.Cleanup(func() { SetAckSigningKey(prev) })
+
+	cfg := &config.Config{PublicHost: "https://versus.example"}
+	ttl := 3 * time.Minute
+	before := time.Now().Add(ttl).Unix()
+	url := AckURL(cfg, "inc-1", ttl)
+	after := time.Now().Add(ttl).Unix()
+
+	u, err := neturl.Parse(url)
+	if err != nil {
+		t.Fatalf("parse ack url: %v", err)
+	}
+	exp, err := strconv.ParseInt(u.Query().Get("exp"), 10, 64)
+	if err != nil {
+		t.Fatalf("parse exp: %v", err)
+	}
+	if exp < before || exp > after {
+		t.Fatalf("exp = %d, want within [%d,%d] (now + ttl)", exp, before, after)
+	}
+	// The embedded exp must verify under the same key.
+	if err := VerifyAckToken(testAckKey, "inc-1", exp, u.Query().Get("sig"), time.Now()); err != nil {
+		t.Fatalf("VerifyAckToken on generated url: %v", err)
+	}
+}
+
+func TestInitAckSigningKey_GeneratesAndPersists(t *testing.T) {
+	prev := AckSigningKey()
+	t.Cleanup(func() { SetAckSigningKey(prev) })
+
+	store := storage.NewMemory()
+	key := InitAckSigningKey(store, &config.Config{})
+	if len(key) != ackSigningKeyLen {
+		t.Fatalf("generated key len = %d, want %d", len(key), ackSigningKeyLen)
+	}
+	// It was persisted, so a second init (a restart / another replica) adopts
+	// the SAME surviving key rather than generating a fresh one.
+	key2 := InitAckSigningKey(store, &config.Config{})
+	if !bytes.Equal(key, key2) {
+		t.Fatal("second init did not adopt the persisted key")
+	}
+	if !bytes.Equal(AckSigningKey(), key) {
+		t.Fatal("InitAckSigningKey did not install the key process-wide")
+	}
+}
+
+func TestInitAckSigningKey_FallsBackToGatewaySecret(t *testing.T) {
+	prev := AckSigningKey()
+	t.Cleanup(func() { SetAckSigningKey(prev) })
+
+	// A backend that does not implement BlobCreator forces the gateway-secret
+	// fallback. noBlobCreator wraps memory but hides the capability.
+	store := noBlobCreator{storage.NewMemory()}
+	key := InitAckSigningKey(store, &config.Config{GatewaySecret: "shared-secret"})
+	if string(key) != "shared-secret" {
+		t.Fatalf("fallback key = %q, want the gateway secret", string(key))
+	}
+}
+
+// noBlobCreator wraps a Provider while hiding BlobCreator so the generate-once
+// path is skipped, forcing the gateway-secret fallback.
+type noBlobCreator struct{ inner storage.Provider }
+
+func (n noBlobCreator) ReadBlob(name string) ([]byte, error) { return n.inner.ReadBlob(name) }
+func (n noBlobCreator) WriteBlob(name string, data []byte) error {
+	return n.inner.WriteBlob(name, data)
+}
+func (n noBlobCreator) ListBlobs(prefix string) ([]storage.Blob, error) {
+	return n.inner.ListBlobs(prefix)
+}
+func (n noBlobCreator) SaveIncident(rec *storage.IncidentRecord) error {
+	return n.inner.SaveIncident(rec)
+}
+func (n noBlobCreator) UpdateIncidentAck(id string, ackedAt time.Time) error {
+	return n.inner.UpdateIncidentAck(id, ackedAt)
+}
+func (n noBlobCreator) GetIncident(id string) (*storage.IncidentRecord, error) {
+	return n.inner.GetIncident(id)
+}
+func (n noBlobCreator) ListIncidents(limit int) ([]*storage.IncidentRecord, error) {
+	return n.inner.ListIncidents(limit)
+}
+func (n noBlobCreator) SaveAnalysis(rec *storage.AnalysisRecord) error {
+	return n.inner.SaveAnalysis(rec)
+}
+func (n noBlobCreator) GetAnalysis(id string) (*storage.AnalysisRecord, error) {
+	return n.inner.GetAnalysis(id)
+}
+func (n noBlobCreator) ListAnalysesByIncident(incidentID string, limit int) ([]*storage.AnalysisRecord, error) {
+	return n.inner.ListAnalysesByIncident(incidentID, limit)
+}
+func (n noBlobCreator) ListAnalyses(limit int) ([]*storage.AnalysisRecord, error) {
+	return n.inner.ListAnalyses(limit)
+}
+func (n noBlobCreator) DeleteAnalysis(id string) error { return n.inner.DeleteAnalysis(id) }
+func (n noBlobCreator) Close() error                   { return n.inner.Close() }

--- a/pkg/services/incident.go
+++ b/pkg/services/incident.go
@@ -70,8 +70,15 @@ func CreateIncident(teamID string, content *map[string]interface{}, params ...*m
 		contentClone[k] = v
 	}
 
-	if !resolved && cfg.OnCall.Enable {
-		ackURL := fmt.Sprintf("%s/api/ack/%s", cfg.PublicHost, incident.ID)
+	// The ack link only has value until on-call escalates, so its lifetime is
+	// the effective on-call acknowledgment wait window for THIS incident
+	// (cfg.OnCall.WaitMinutes already reflects any oncall_wait_minutes override
+	// applied during config resolution above). When that window is zero on-call
+	// triggers immediately, so an ack can never forestall escalation — a
+	// dead/instantly-expired link is worse than none, so we emit no AckURL.
+	if !resolved && cfg.OnCall.Enable && cfg.OnCall.WaitMinutes > 0 {
+		ttl := time.Duration(cfg.OnCall.WaitMinutes) * time.Minute
+		ackURL := AckURL(cfg, incident.ID, ttl)
 		contentClone["AckURL"] = ackURL
 
 		incident.Content = &contentClone

--- a/pkg/services/incident_autoresolve_test.go
+++ b/pkg/services/incident_autoresolve_test.go
@@ -18,6 +18,9 @@ func autoResolveTestConfig(t *testing.T) {
 
 	prev := *cfg // shallow snapshot is enough for the scalar flags we touch
 	cfg.OnCall.Enable = true
+	// A positive wait window is what makes the ack link meaningful (and what
+	// gates its injection); keep it non-zero so AckURL is emitted.
+	cfg.OnCall.WaitMinutes = 3
 	cfg.Alert.Slack.Enable = false
 	cfg.Alert.Telegram.Enable = false
 	cfg.Alert.Viber.Enable = false

--- a/pkg/storage/analysis_pager_test.go
+++ b/pkg/storage/analysis_pager_test.go
@@ -1,0 +1,121 @@
+package storage_test
+
+// analysis_pager_test.go — the bounded analyses-list seam
+// (storage.AnalysisPager): a cheap total count computed WITHOUT loading rows,
+// plus a most-recent-first page with offset continuation. It backs the fix for
+// the /analyses endpoint that used to load the whole vs_analyses table to
+// render one page.
+//
+// Memory and file backends run unconditionally (they implement the capability
+// over their capped in-memory slice); Postgres is gated on TEST_POSTGRES_DSN.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/storage"
+)
+
+// seedAnalyses stores n analyses with strictly increasing requested_at so the
+// newest-first order is deterministic. Returns the ids in creation order
+// (oldest first), so the newest-first expectation is the reverse.
+func seedAnalyses(t *testing.T, p storage.Provider, n int) []string {
+	t.Helper()
+	base := time.Now().UTC().Add(-time.Hour)
+	ids := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		id := "an-" + string(rune('a'+i))
+		rec := &storage.AnalysisRecord{
+			ID:          id,
+			IncidentID:  "inc-1",
+			RequestedAt: base.Add(time.Duration(i) * time.Minute),
+			Status:      "ok",
+		}
+		if err := p.SaveAnalysis(rec); err != nil {
+			t.Fatalf("SaveAnalysis %d: %v", i, err)
+		}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func analysisPagerBackends() map[string]func(*testing.T) storage.Provider {
+	return map[string]func(*testing.T) storage.Provider{
+		"memory":   newMemoryPager,
+		"file":     newFilePager,
+		"postgres": func(t *testing.T) storage.Provider { return newTestPostgres(t) },
+	}
+}
+
+// TestAnalysisPagerCount proves CountAnalyses returns the whole-set total
+// without materializing rows, on every backend implementing the capability.
+func TestAnalysisPagerCount(t *testing.T) {
+	for name, mk := range analysisPagerBackends() {
+		t.Run(name, func(t *testing.T) {
+			p := mk(t)
+			seedAnalyses(t, p, 5)
+
+			pager, ok := p.(storage.AnalysisPager)
+			if !ok {
+				t.Fatalf("%s backend does not implement storage.AnalysisPager", name)
+			}
+			n, err := pager.CountAnalyses()
+			if err != nil {
+				t.Fatalf("CountAnalyses: %v", err)
+			}
+			if n != 5 {
+				t.Fatalf("CountAnalyses = %d, want 5", n)
+			}
+		})
+	}
+}
+
+// TestAnalysisPagerPageNewestFirst proves the page read returns rows newest
+// first and that offset continuation neither drops nor duplicates a row across
+// page boundaries.
+func TestAnalysisPagerPageNewestFirst(t *testing.T) {
+	for name, mk := range analysisPagerBackends() {
+		t.Run(name, func(t *testing.T) {
+			p := mk(t)
+			ids := seedAnalyses(t, p, 5) // oldest→newest
+			pager := p.(storage.AnalysisPager)
+
+			// Walk the whole set two rows at a time and reassemble the ids.
+			var got []string
+			for offset := 0; offset < 5; offset += 2 {
+				page, err := pager.ListAnalysesPage(offset, 2)
+				if err != nil {
+					t.Fatalf("ListAnalysesPage offset=%d: %v", offset, err)
+				}
+				for _, r := range page {
+					got = append(got, r.ID)
+				}
+			}
+			// Expected: newest first — the reverse of creation order.
+			want := []string{ids[4], ids[3], ids[2], ids[1], ids[0]}
+			if len(got) != len(want) {
+				t.Fatalf("reassembled %d ids, want %d (%v)", len(got), len(want), got)
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("row %d = %q, want %q (full %v)", i, got[i], want[i], got)
+				}
+			}
+		})
+	}
+}
+
+// TestAnalysisPagerDefaultPageSize proves limit<=0 falls back to the bounded
+// DefaultAnalysisPageSize rather than an unbounded read.
+func TestAnalysisPagerDefaultPageSize(t *testing.T) {
+	p := storage.NewMemory()
+	seedAnalyses(t, p, 3)
+	pager := p.(storage.AnalysisPager)
+	page, err := pager.ListAnalysesPage(0, 0)
+	if err != nil {
+		t.Fatalf("ListAnalysesPage: %v", err)
+	}
+	if len(page) != 3 {
+		t.Fatalf("default-size page returned %d rows, want 3", len(page))
+	}
+}

--- a/pkg/storage/file.go
+++ b/pkg/storage/file.go
@@ -522,6 +522,42 @@ func (p *fileProvider) ListAnalyses(limit int) ([]*AnalysisRecord, error) {
 	return out, nil
 }
 
+// CountAnalyses implements the optional storage.AnalysisPager capability. The
+// file backend keeps a rolling in-memory cap, so a len() is the whole count.
+func (p *fileProvider) CountAnalyses() (int, error) {
+	p.analysesMu.RLock()
+	defer p.analysesMu.RUnlock()
+	return len(p.analyses), nil
+}
+
+// ListAnalysesPage implements the optional storage.AnalysisPager capability:
+// one bounded, newest-first page over the in-memory slice, skipping offset
+// rows and returning at most limit rows.
+func (p *fileProvider) ListAnalysesPage(offset, limit int) ([]*AnalysisRecord, error) {
+	if limit <= 0 {
+		limit = DefaultAnalysisPageSize
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	p.analysesMu.RLock()
+	defer p.analysesMu.RUnlock()
+	out := make([]*AnalysisRecord, 0, limit)
+	skipped := 0
+	for i := len(p.analyses) - 1; i >= 0; i-- {
+		if skipped < offset {
+			skipped++
+			continue
+		}
+		cp := *p.analyses[i]
+		out = append(out, &cp)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
 func (p *fileProvider) DeleteAnalysis(id string) error {
 	p.analysesMu.Lock()
 	defer p.analysesMu.Unlock()

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -266,6 +266,42 @@ func (m *memoryProvider) ListAnalyses(limit int) ([]*AnalysisRecord, error) {
 	return out, nil
 }
 
+// CountAnalyses implements the optional storage.AnalysisPager capability. The
+// in-memory history is small, so a len() is the whole count.
+func (m *memoryProvider) CountAnalyses() (int, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.analyses), nil
+}
+
+// ListAnalysesPage implements the optional storage.AnalysisPager capability:
+// one bounded, newest-first page over the in-memory slice, skipping offset
+// rows and returning at most limit rows.
+func (m *memoryProvider) ListAnalysesPage(offset, limit int) ([]*AnalysisRecord, error) {
+	if limit <= 0 {
+		limit = DefaultAnalysisPageSize
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]*AnalysisRecord, 0, limit)
+	skipped := 0
+	for i := len(m.analyses) - 1; i >= 0; i-- {
+		if skipped < offset {
+			skipped++
+			continue
+		}
+		cp := *m.analyses[i]
+		out = append(out, &cp)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
 func (m *memoryProvider) DeleteAnalysis(id string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/storage/postgres.go
+++ b/pkg/storage/postgres.go
@@ -897,6 +897,39 @@ func (p *postgresProvider) ListAnalyses(limit int) ([]*AnalysisRecord, error) {
 	return scanAnalysisRows(rows)
 }
 
+// CountAnalyses implements the optional storage.AnalysisPager capability: the
+// total number of stored analyses in one COUNT query, without shipping a row
+// to Go so a large vs_analyses never has to be loaded to render a count.
+func (p *postgresProvider) CountAnalyses() (int, error) {
+	var n int
+	if err := p.db.QueryRow(`SELECT COUNT(*) FROM vs_analyses`).Scan(&n); err != nil {
+		return 0, fmt.Errorf("storage: count analyses: %w", err)
+	}
+	return n, nil
+}
+
+// ListAnalysesPage implements the optional storage.AnalysisPager capability:
+// one bounded, newest-first page pushed entirely into SQL (ORDER BY
+// requested_at DESC LIMIT/OFFSET), so a large vs_analyses is never fetched
+// whole to render one page.
+func (p *postgresProvider) ListAnalysesPage(offset, limit int) ([]*AnalysisRecord, error) {
+	if limit <= 0 {
+		limit = DefaultAnalysisPageSize
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	rows, err := p.db.Query(
+		`SELECT data FROM vs_analyses ORDER BY requested_at DESC LIMIT $1 OFFSET $2`,
+		limit, offset,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list analyses page: %w", err)
+	}
+	defer rows.Close()
+	return scanAnalysisRows(rows)
+}
+
 func scanAnalysisRows(rows *sql.Rows) ([]*AnalysisRecord, error) {
 	var out []*AnalysisRecord
 	for rows.Next() {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -187,6 +187,13 @@ type Blob struct {
 // the total from the cheap count and loads further pages only on demand.
 const DefaultIncidentPageSize = 1000
 
+// DefaultAnalysisPageSize is the bounded page the analyses list read returns
+// when the caller does not request a specific size: the most-recent 1000
+// analyze-mode runs. It is the analyses twin of DefaultIncidentPageSize —
+// vs_analyses grows unbounded on Postgres, so the list serves one cheap count
+// plus one bounded page rather than the whole table.
+const DefaultAnalysisPageSize = 1000
+
 // IncidentCounts is the cheap, whole-set tally the list surfaces show: how
 // many UNRESOLVED (open) incidents are AI-detected vs inbound webhook/alert,
 // and the open grand total. Counts reflect OPEN WORK — resolved incidents are
@@ -232,6 +239,27 @@ type IncidentPager interface {
 	// returns all origins. limit <= 0 uses DefaultIncidentPageSize; a
 	// negative offset is treated as 0.
 	ListIncidentsPage(origin string, offset, limit int) ([]*IncidentRecord, error)
+}
+
+// AnalysisPager is an optional capability a backend may implement on top of
+// Provider to serve the analyses list without ever loading the whole table.
+// It is the analyses twin of IncidentPager: it splits the two things the list
+// endpoint needs — a cheap count and a bounded page — so a large backend
+// (Postgres, unbounded vs_analyses) pushes both into SQL (COUNT(*) and ORDER
+// BY requested_at DESC LIMIT/OFFSET). File and memory backends implement it
+// over their already-capped in-memory slice (a len() count and a slice
+// window). Backends that cannot (the redis/database stubs) do not implement
+// it; callers type-assert and fall back to a bounded ListAnalyses, exactly
+// like IncidentPager.
+type AnalysisPager interface {
+	// CountAnalyses returns the total number of stored analyses, computed
+	// without materializing rows.
+	CountAnalyses() (int, error)
+	// ListAnalysesPage returns one bounded page of analyses, newest first by
+	// requested_at, skipping the first offset rows and returning at most limit
+	// rows. limit <= 0 uses DefaultAnalysisPageSize; a negative offset is
+	// treated as 0.
+	ListAnalysesPage(offset, limit int) ([]*AnalysisRecord, error)
 }
 
 // IncidentSearchPager is an optional capability a backend may implement on

--- a/src/_sidebar.md
+++ b/src/_sidebar.md
@@ -90,3 +90,6 @@
   - [vs Datadog Watchdog](/compare/datadog-watchdog)
   - [vs Keep](/compare/keep)
   - [vs Alertmanager](/compare/alertmanager)
+
+- Migration
+  - [v1.4.13](/migration/migration-v1.4.13.md)

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -540,6 +540,20 @@ export interface AnalysisRecord {
   error?: string;
 }
 
+// AnalysisIndex is the paged analyses list response: one bounded, most-recent
+// page of analyses plus the whole-set `total` computed cheaply on the server
+// (never by loading every row). `offset` is where this page began and
+// `next_offset` is where the caller resumes to load the next chunk (null when
+// this page reached the end).
+export interface AnalysisIndex {
+  analyses: AnalysisRecord[];
+  total: number;
+  offset?: number;
+  next_offset?: number | null;
+  page?: number;
+  page_size?: number;
+}
+
 // ---------- Team / member management ----------
 
 // MemberMeta mirrors pkg/teams.MemberMeta — typed per-channel ids.
@@ -1703,6 +1717,25 @@ export const api = {
     return request<{ analyses: AnalysisRecord[] }>(
       `/api/admin/analyses${qs}`,
     ).then((r) => r.analyses ?? []);
+  },
+  // listAllAnalysesIndex is the Analyses-page variant: it returns one bounded,
+  // most-recent page of analyses PLUS the whole-set total in a single request,
+  // so the first render is fast even on a large vs_analyses table. Pass
+  // `offset` to load the next chunk on demand; the response's `next_offset` is
+  // where to resume (null at the end). `pageSize` overrides the server default.
+  listAllAnalysesIndex: (opts?: {
+    offset?: number;
+    pageSize?: number;
+    page?: number;
+  }) => {
+    const p = new URLSearchParams();
+    if (opts?.offset) p.set("offset", String(opts.offset));
+    if (opts?.pageSize) p.set("page_size", String(opts.pageSize));
+    if (opts?.page) p.set("page", String(opts.page));
+    const qs = p.toString();
+    return request<AnalysisIndex>(
+      `/api/admin/analyses${qs ? `?${qs}` : ""}`,
+    );
   },
   getAnalysis: (analysisID: string) =>
     request<AnalysisRecord>(`/api/admin/analyses/${analysisID}`),

--- a/ui/src/pages/AnalysesListPage.test.tsx
+++ b/ui/src/pages/AnalysesListPage.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
 import { AnalysesListPage } from "./AnalysesListPage";
-import { api, type AnalysisRecord } from "@/lib/api";
+import { api, type AnalysisRecord, type AnalysisIndex } from "@/lib/api";
 
 // The analyses table rows do NOT navigate — only the per-row eye opens a peek,
 // whose footer button links to the analysis detail page.
@@ -14,7 +14,7 @@ vi.mock("@/lib/api", async (importActual) => {
     ...actual,
     api: {
       ...actual.api,
-      listAllAnalyses: vi.fn(),
+      listAllAnalysesIndex: vi.fn(),
       listIncidents: vi.fn(),
     },
   };
@@ -29,6 +29,21 @@ function rec(overrides: Partial<AnalysisRecord> = {}): AnalysisRecord {
     requested_at: new Date().toISOString(),
     status: "ok",
     finding: { Title: "Root cause found" },
+    ...overrides,
+  };
+}
+
+// idx builds a single-page AnalysisIndex response (server-shaped), used to
+// stub the paged /analyses endpoint the page now calls.
+function idx(
+  analyses: AnalysisRecord[],
+  overrides: Partial<AnalysisIndex> = {},
+): AnalysisIndex {
+  return {
+    analyses,
+    total: analyses.length,
+    offset: 0,
+    next_offset: null,
     ...overrides,
   };
 }
@@ -60,7 +75,7 @@ function renderPage() {
 
 describe("AnalysesListPage row actions", () => {
   beforeEach(() => {
-    vi.mocked(api.listAllAnalyses).mockResolvedValue([rec()]);
+    vi.mocked(api.listAllAnalysesIndex).mockResolvedValue(idx([rec()]));
     vi.mocked(api.listIncidents).mockResolvedValue([]);
   });
 
@@ -79,5 +94,59 @@ describe("AnalysesListPage row actions", () => {
     expect(
       screen.getByRole("link", { name: /Open full page/ }),
     ).toBeTruthy();
+  });
+});
+
+describe("AnalysesListPage server pagination", () => {
+  beforeEach(() => {
+    vi.mocked(api.listIncidents).mockResolvedValue([]);
+  });
+
+  it("shows the whole-set total, not just the loaded page, and loads more", async () => {
+    // First page: 2 of 5 rows, resume cursor at offset 2. The second page
+    // carries the remaining 3 and closes the cursor (next_offset null).
+    // Drive the stub off the requested offset so it is robust to how many
+    // times react-query invokes the query function.
+    vi.mocked(api.listAllAnalysesIndex).mockImplementation((opts) => {
+      if ((opts?.offset ?? 0) >= 2) {
+        return Promise.resolve(
+          idx([rec({ id: "a3" }), rec({ id: "a4" }), rec({ id: "a5" })], {
+            total: 5,
+            offset: 2,
+            next_offset: null,
+            page_size: 2,
+          }),
+        );
+      }
+      return Promise.resolve(
+        idx([rec({ id: "a1" }), rec({ id: "a2" })], {
+          total: 5,
+          offset: 0,
+          next_offset: 2,
+          page_size: 2,
+        }),
+      );
+    });
+
+    renderPage();
+
+    // The subtitle reflects the true total (5), not the two rows loaded.
+    expect(await screen.findByText("5 stored")).toBeTruthy();
+    // Only the first bounded page is on screen up front.
+    expect(await screen.findByLabelText("View analysis a1")).toBeTruthy();
+    expect(screen.queryByLabelText("View analysis a3")).toBeNull();
+
+    // The load-more control names the total; clicking it pulls the next page.
+    const more = await screen.findByTestId("analysis-load-more");
+    const btn = more.querySelector("button") as HTMLButtonElement;
+    expect(btn.textContent).toContain("5");
+    fireEvent.click(btn);
+
+    expect(await screen.findByLabelText("View analysis a5")).toBeTruthy();
+    // The second page was requested from the server's resume cursor (offset 2),
+    // proving the client asked for a bounded next chunk rather than everything.
+    const calls = vi.mocked(api.listAllAnalysesIndex).mock.calls;
+    expect(calls[0][0]).toEqual({ offset: 0 });
+    expect(calls.some((c) => c[0]?.offset === 2)).toBe(true);
   });
 });

--- a/ui/src/pages/AnalysesListPage.tsx
+++ b/ui/src/pages/AnalysesListPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
-import { Eye, Search, X } from "lucide-react";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { Eye, Loader2, Search, X } from "lucide-react";
 import { api, type AnalysisRecord } from "@/lib/api";
 import { fmtAbs, fmtRel, formatDuration, incidentTitle } from "@/lib/format";
 import { useTableKeys } from "@/lib/hooks";
@@ -39,11 +39,34 @@ export function AnalysesListPage() {
   const incidentFilter = params.get("incident");
   const q = params.get("q") ?? "";
 
-  const analysesQ = useQuery({
+  const analysesQ = useInfiniteQuery({
     queryKey: ["analyses-all"],
-    queryFn: () => api.listAllAnalyses(),
+    queryFn: ({ pageParam }) =>
+      api.listAllAnalysesIndex({ offset: pageParam }),
+    initialPageParam: 0,
+    // next_offset is the resume cursor; null/undefined means no more rows.
+    getNextPageParam: (last) => last.next_offset ?? undefined,
   });
-  const { data, isLoading, isError, error, refetch, isRefetching } = analysesQ;
+  const {
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isRefetching,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = analysesQ;
+
+  // Accumulate the loaded pages into a single list; total comes from the first
+  // page (the true whole-set count, never data.length). The server ships only
+  // the most-recent page, so a large vs_analyses never loads whole up front.
+  const data = useMemo<AnalysisRecord[] | undefined>(() => {
+    const pages = analysesQ.data?.pages;
+    if (!pages || pages.length === 0) return undefined;
+    return pages.flatMap((p) => p.analyses);
+  }, [analysesQ.data]);
+  const total = analysesQ.data?.pages[0]?.total;
 
   const incidentsQ = useQuery({
     queryKey: ["incidents"],
@@ -120,7 +143,7 @@ export function AnalysesListPage() {
     <>
       <TopBar
         title="Analyses"
-        subtitle={data ? `${data.length} stored` : undefined}
+        subtitle={total !== undefined ? `${total} stored` : undefined}
       />
 
       <main className="flex-1 overflow-auto p-6">
@@ -346,6 +369,27 @@ export function AnalysesListPage() {
                 </table>
               </div>
               <Pagination state={pg} />
+              {(isFetchingNextPage || hasNextPage) && (
+                <div
+                  className="flex items-center justify-center gap-1.5 border-t border-ink-600 px-3 py-2 text-2xs text-ink-400"
+                  data-testid="analysis-load-more"
+                >
+                  {isFetchingNextPage ? (
+                    <>
+                      <Loader2 size={12} className="animate-spin" />
+                      Loading more…
+                    </>
+                  ) : (
+                    <button
+                      type="button"
+                      className="text-brand-300 hover:underline"
+                      onClick={() => fetchNextPage()}
+                    >
+                      Load more ({total?.toLocaleString() ?? ""} total)
+                    </button>
+                  )}
+                </div>
+              )}
             </div>
           </>
         )}


### PR DESCRIPTION
Stop the list APIs from loading whole tables, and authenticate the ack endpoint with a signed link.

Performance
- Incident list is server-side paginated (ORDER BY created_at DESC LIMIT/OFFSET)
  with a cheap unresolved-only count, instead of loading the full table per page.
- Analyses list gets the same via a new AnalysisPager (CountAnalyses +
  ListAnalysesPage) on the Postgres/file/memory backends.

Security — ack endpoint
- GET /api/ack/:id now requires a signed, expiring HMAC-SHA256 token
  (?exp=&sig=) carried in the channel link; HandleAck verifies it constant-time,
  signature-before-expiry, before acking — closes the ack IDOR.
- Signing key is generated once and persisted (CreateBlobIfAbsent); falls back
  to gateway_secret, else ephemeral + warn.
- Token lifetime is oncall.wait_minutes (the ack only matters until escalation);
  no ack link is emitted when wait_minutes <= 0. Removed ack_token_ttl.
- HandleAck returns 503 instead of panicking when on-call is uninitialized;
  added Fiber recover middleware as defense-in-depth.

Fixes
- Fix OSS UI build break (IncidentsPage: `data` possibly undefined).

Docs
- scripts/postgres/migrate_incident_columns.sql: one-time backfill from `data`,
  then DROP COLUMN data.
- src/migration/migration-v1.4.13.md: operator migration guide.

Tests updated across storage/controllers/services/config and the UI.