### PR TITLE
perf(agent): pattern/service catalog lists

### DIFF
--- a/pkg/agent/catalog.go
+++ b/pkg/agent/catalog.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -343,6 +344,151 @@ func (c *Catalog) Len() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return len(c.patterns)
+}
+
+// PatternsPage returns one bounded page of patterns plus the whole-set total,
+// mirroring the incidents/analyses pager: on a backend that pushes paging into
+// SQL (a store implementing CatalogPager, e.g. the Postgres catalog store) the
+// page and count are served without loading the whole catalog; otherwise the
+// bounded working set is read once (a store's Snapshot, or the default
+// in-memory map) and sliced. The page is ordered by Count descending with id
+// as a stable tie-break — the same order All() sorts by — filtered to
+// opts.Search when set. total is the count AFTER the search filter, so the UI
+// drives load-more off the true match count.
+func (c *Catalog) PatternsPage(opts CatalogPageOptions) ([]*Pattern, int, error) {
+	if s := catalogStore(); s != nil {
+		if pager, ok := s.(CatalogPager); ok {
+			return pager.ListPatternsPage(opts)
+		}
+		// A store without the paged capability: read its unified snapshot once
+		// and page it in Go. On a snapshot error fall through to the local
+		// in-memory view, exactly as All() does.
+		if all, _, err := s.Snapshot(); err != nil {
+			log.Printf("agent: catalog snapshot failed, serving local view: %v", err)
+		} else {
+			page, total := pagePatterns(all, opts)
+			return page, total, nil
+		}
+	}
+	c.mu.RLock()
+	all := make([]*Pattern, 0, len(c.patterns))
+	for _, p := range c.patterns {
+		cp := *p
+		if p.Tags != nil {
+			cp.Tags = append([]string(nil), p.Tags...)
+		}
+		all = append(all, &cp)
+	}
+	c.mu.RUnlock()
+	page, total := pagePatterns(all, opts)
+	return page, total, nil
+}
+
+// pagePatterns filters (by case-insensitive substring on template/id/service),
+// sorts (Count desc, id asc) and slices a materialized pattern set into one
+// page, returning the page and the post-filter total. It is the in-memory twin
+// of the paged SQL: same order, same search columns, so the file/in-memory
+// backend and the Snapshot fallback page identically to the Postgres store.
+func pagePatterns(all []*Pattern, opts CatalogPageOptions) ([]*Pattern, int) {
+	if q := strings.ToLower(strings.TrimSpace(opts.Search)); q != "" {
+		kept := make([]*Pattern, 0, len(all))
+		for _, p := range all {
+			if strings.Contains(strings.ToLower(p.Template), q) ||
+				strings.Contains(strings.ToLower(p.ID), q) ||
+				strings.Contains(strings.ToLower(p.Service), q) {
+				kept = append(kept, p)
+			}
+		}
+		all = kept
+	}
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].Count != all[j].Count {
+			return all[i].Count > all[j].Count
+		}
+		return all[i].ID < all[j].ID
+	})
+	total := len(all)
+	page := all[sliceBounds(total, opts):sliceEnd(total, opts)]
+	return page, total
+}
+
+// ServicesPage returns one bounded page of services plus the whole-set total.
+// It is the service twin of PatternsPage: a CatalogPager store pushes the page
+// and count into SQL, otherwise the bounded service working set is read once
+// and sliced. The page is ordered by FirstSeen ascending with name as a stable
+// tie-break, filtered to opts.Search (a case-insensitive substring on the
+// service name) when set.
+func (c *Catalog) ServicesPage(opts CatalogPageOptions) ([]ServiceRow, int, error) {
+	if s := catalogStore(); s != nil {
+		if pager, ok := s.(CatalogPager); ok {
+			return pager.ListServicesPage(opts)
+		}
+		if _, services, err := s.Snapshot(); err != nil {
+			log.Printf("agent: catalog snapshot failed, serving local services view: %v", err)
+		} else {
+			page, total := pageServices(services, opts)
+			return page, total, nil
+		}
+	}
+	c.mu.RLock()
+	services := make(map[string]ServiceInfo, len(c.services))
+	for name, info := range c.services {
+		services[name] = *info
+	}
+	c.mu.RUnlock()
+	page, total := pageServices(services, opts)
+	return page, total, nil
+}
+
+// pageServices filters (by case-insensitive substring on the name), sorts
+// (FirstSeen asc, name asc) and slices a service map into one ordered page,
+// returning the page and the post-filter total — the in-memory twin of the
+// paged service SQL.
+func pageServices(all map[string]ServiceInfo, opts CatalogPageOptions) ([]ServiceRow, int) {
+	q := strings.ToLower(strings.TrimSpace(opts.Search))
+	rows := make([]ServiceRow, 0, len(all))
+	for name, info := range all {
+		if q != "" && !strings.Contains(strings.ToLower(name), q) {
+			continue
+		}
+		rows = append(rows, ServiceRow{Name: name, Info: info})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if !rows[i].Info.FirstSeen.Equal(rows[j].Info.FirstSeen) {
+			return rows[i].Info.FirstSeen.Before(rows[j].Info.FirstSeen)
+		}
+		return rows[i].Name < rows[j].Name
+	})
+	total := len(rows)
+	page := rows[sliceBounds(total, opts):sliceEnd(total, opts)]
+	return page, total
+}
+
+// sliceBounds / sliceEnd resolve the [offset, offset+limit) window against a
+// materialized total, clamping a non-positive limit to DefaultCatalogPageSize,
+// a negative offset to 0, and an out-of-range window to the empty tail — the
+// same bounds the paged SQL applies via LIMIT/OFFSET.
+func sliceBounds(total int, opts CatalogPageOptions) int {
+	offset := opts.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > total {
+		offset = total
+	}
+	return offset
+}
+
+func sliceEnd(total int, opts CatalogPageOptions) int {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = DefaultCatalogPageSize
+	}
+	end := sliceBounds(total, opts) + limit
+	if end > total {
+		end = total
+	}
+	return end
 }
 
 // Upsert records an observation against patternID. If the pattern is new it

--- a/pkg/agent/catalog_page_test.go
+++ b/pkg/agent/catalog_page_test.go
@@ -1,0 +1,286 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/VersusControl/versus-incident/pkg/storage"
+)
+
+// catalog_page_test.go — parity coverage for the bounded catalog list reads
+// (Catalog.PatternsPage / Catalog.ServicesPage). Three backends must page
+// identically: the default in-memory map, a base CatalogStore that only
+// implements Snapshot (the Go-side fold), and the live Postgres pager (gated on
+// TEST_POSTGRES_DSN). All three order patterns by Count desc / id asc and
+// services by FirstSeen asc / name asc, return the whole-(filtered-)set total,
+// and clamp the window.
+
+// snapshotOnlyStore is a CatalogStore that serves a fixed read view via
+// Snapshot but deliberately does NOT implement CatalogPager, so it exercises
+// the Catalog's Snapshot-fold fallback (the file-backend / non-pager path).
+type snapshotOnlyStore struct {
+	patterns []*Pattern
+	services map[string]ServiceInfo
+}
+
+func (s *snapshotOnlyStore) Load() (map[string]*Pattern, map[string]*ServiceInfo, error) {
+	return nil, nil, nil
+}
+func (s *snapshotOnlyStore) Persist(map[string]*Pattern, map[string]*ServiceInfo) error { return nil }
+func (s *snapshotOnlyStore) Snapshot() ([]*Pattern, map[string]ServiceInfo, error) {
+	return s.patterns, s.services, nil
+}
+func (s *snapshotOnlyStore) Curate(CatalogEdit) error { return nil }
+
+// TestPatternsPage_InMemory proves the default in-memory backend serves a
+// bounded page (not the whole catalog) ordered by Count desc, reports the true
+// total, and honours the search filter.
+func TestPatternsPage_InMemory(t *testing.T) {
+	SetCatalogStore(nil)
+	c, err := LoadCatalog(storage.NewMemory())
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	// Seed five patterns with descending counts so the ordering is unambiguous.
+	c.Upsert("p1", "checkout timeout", "src", 5, 0.2, "default", "checkout")
+	c.Upsert("p2", "payment declined", "src", 4, 0.2, "default", "payments")
+	c.Upsert("p3", "orders slow", "src", 3, 0.2, "default", "orders")
+	c.Upsert("p4", "cache miss", "src", 2, 0.2, "default", "cache")
+	c.Upsert("p5", "dns flake", "src", 1, 0.2, "default", "dns")
+
+	page, total, err := c.PatternsPage(CatalogPageOptions{Offset: 0, Limit: 2})
+	if err != nil {
+		t.Fatalf("PatternsPage: %v", err)
+	}
+	if total != 5 {
+		t.Fatalf("total = %d, want 5 (whole-set count regardless of page size)", total)
+	}
+	if len(page) != 2 {
+		t.Fatalf("page len = %d, want 2 (bounded, not the whole catalog)", len(page))
+	}
+	if page[0].ID != "p1" || page[1].ID != "p2" {
+		t.Fatalf("page order = [%s %s], want [p1 p2] (Count desc)", page[0].ID, page[1].ID)
+	}
+
+	// Second window continues the same order without overlap.
+	next, _, err := c.PatternsPage(CatalogPageOptions{Offset: 2, Limit: 2})
+	if err != nil {
+		t.Fatalf("PatternsPage offset 2: %v", err)
+	}
+	if len(next) != 2 || next[0].ID != "p3" || next[1].ID != "p4" {
+		t.Fatalf("second window = %v, want [p3 p4]", ids(next))
+	}
+
+	// Search filters both page and total to the matching set.
+	hits, hitTotal, err := c.PatternsPage(CatalogPageOptions{Limit: 10, Search: "payment"})
+	if err != nil {
+		t.Fatalf("PatternsPage search: %v", err)
+	}
+	if hitTotal != 1 || len(hits) != 1 || hits[0].ID != "p2" {
+		t.Fatalf("search 'payment' = %v total=%d, want [p2] total=1", ids(hits), hitTotal)
+	}
+}
+
+// TestServicesPage_InMemory proves the service list is bounded, totalled, and
+// name-searchable on the default in-memory backend.
+func TestServicesPage_InMemory(t *testing.T) {
+	SetCatalogStore(nil)
+	c, err := LoadCatalog(storage.NewMemory())
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	for _, name := range []string{"checkout", "payments", "orders"} {
+		c.RegisterService(name)
+	}
+
+	page, total, err := c.ServicesPage(CatalogPageOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("ServicesPage: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("total = %d, want 3", total)
+	}
+	if len(page) != 2 {
+		t.Fatalf("page len = %d, want 2 (bounded)", len(page))
+	}
+
+	hits, hitTotal, err := c.ServicesPage(CatalogPageOptions{Limit: 10, Search: "check"})
+	if err != nil {
+		t.Fatalf("ServicesPage search: %v", err)
+	}
+	if hitTotal != 1 || len(hits) != 1 || hits[0].Name != "checkout" {
+		t.Fatalf("search 'check' = %v total=%d, want [checkout] total=1", svcNames(hits), hitTotal)
+	}
+}
+
+// TestPatternsPage_SnapshotFallback proves a base CatalogStore (Snapshot only,
+// no CatalogPager) is paged by folding Snapshot in Go, with the SAME Count-desc
+// order and true total the pager path returns.
+func TestPatternsPage_SnapshotFallback(t *testing.T) {
+	store := &snapshotOnlyStore{
+		patterns: []*Pattern{
+			{ID: "a", Template: "alpha", Count: 1},
+			{ID: "b", Template: "bravo", Count: 9},
+			{ID: "c", Template: "charlie", Count: 5},
+		},
+	}
+	SetCatalogStore(store)
+	t.Cleanup(func() { SetCatalogStore(nil) })
+	c, err := LoadCatalog(storage.NewMemory())
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+
+	page, total, err := c.PatternsPage(CatalogPageOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("PatternsPage: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("total = %d, want 3", total)
+	}
+	if len(page) != 2 || page[0].ID != "b" || page[1].ID != "c" {
+		t.Fatalf("fallback page = %v, want [b c] (Count desc)", ids(page))
+	}
+}
+
+// TestServicesPage_SnapshotFallback proves the Snapshot-fold service page is
+// ordered by FirstSeen asc / name asc — the deterministic order the UI relies
+// on to accumulate stable windows.
+func TestServicesPage_SnapshotFallback(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	store := &snapshotOnlyStore{
+		services: map[string]ServiceInfo{
+			"late":   {FirstSeen: base.Add(2 * time.Hour)},
+			"early":  {FirstSeen: base},
+			"middle": {FirstSeen: base.Add(time.Hour)},
+		},
+	}
+	SetCatalogStore(store)
+	t.Cleanup(func() { SetCatalogStore(nil) })
+	c, err := LoadCatalog(storage.NewMemory())
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+
+	page, total, err := c.ServicesPage(CatalogPageOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("ServicesPage: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("total = %d, want 3", total)
+	}
+	if got := svcNames(page); got[0] != "early" || got[1] != "middle" || got[2] != "late" {
+		t.Fatalf("service order = %v, want [early middle late] (FirstSeen asc)", got)
+	}
+}
+
+// TestPGCatalog_ListPatternsPage_OrgScopedAndOrdered proves the live Postgres
+// pager applies the SAME org scope Snapshot does (a pattern under a different
+// org never appears), orders by fleet count desc, and reports the whole-set
+// total independent of the page window.
+func TestPGCatalog_ListPatternsPage_OrgScopedAndOrdered(t *testing.T) {
+	cat, db := newPGCatalog(t)
+
+	cat.Upsert("hot", "hot template", "src", 9, 0.2, "default", "checkout")
+	cat.Upsert("warm", "warm template", "src", 4, 0.2, "default", "orders")
+	cat.Upsert("cool", "cool template", "src", 1, 0.2, "default", "cache")
+	if err := cat.Persist(); err != nil {
+		t.Fatalf("Persist default org: %v", err)
+	}
+
+	// A pattern owned by a DIFFERENT org must be invisible to the default
+	// store's pager — the tenant-isolation guarantee Snapshot enforces.
+	other := NewPostgresCatalogStore(db, "tenant-other", 0)
+	other.Persist(
+		map[string]*Pattern{
+			"foreign": {ID: "foreign", OrgID: "tenant-other", Template: "foreign template", Count: 100},
+		},
+		nil,
+	)
+
+	pager, ok := catalogStore().(CatalogPager)
+	if !ok {
+		t.Fatal("postgres catalog store must implement CatalogPager")
+	}
+
+	page, total, err := pager.ListPatternsPage(CatalogPageOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("ListPatternsPage: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("total = %d, want 3 (default org only, foreign excluded)", total)
+	}
+	if len(page) != 2 || page[0].ID != "hot" || page[1].ID != "warm" {
+		t.Fatalf("page = %v, want [hot warm] (count desc)", ids(page))
+	}
+	for _, p := range page {
+		if p.ID == "foreign" {
+			t.Fatal("foreign-org pattern leaked into default-org page")
+		}
+		if p.OrgID != storage.DefaultOrgID {
+			t.Fatalf("page pattern OrgID = %q, want %q", p.OrgID, storage.DefaultOrgID)
+		}
+	}
+
+	// The second window continues without overlap; total is unchanged.
+	tail, tailTotal, err := pager.ListPatternsPage(CatalogPageOptions{Offset: 2, Limit: 2})
+	if err != nil {
+		t.Fatalf("ListPatternsPage tail: %v", err)
+	}
+	if tailTotal != 3 {
+		t.Fatalf("tail total = %d, want 3", tailTotal)
+	}
+	if len(tail) != 1 || tail[0].ID != "cool" {
+		t.Fatalf("tail = %v, want [cool]", ids(tail))
+	}
+}
+
+// TestPGCatalog_ListServicesPage_OrgScopedAndOrdered proves the live Postgres
+// service pager is org-scoped, ordered by first_seen, and totalled.
+func TestPGCatalog_ListServicesPage_OrgScopedAndOrdered(t *testing.T) {
+	cat, db := newPGCatalog(t)
+
+	cat.CreateService("checkout")
+	cat.CreateService("payments")
+	if err := cat.Persist(); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+
+	other := NewPostgresCatalogStore(db, "tenant-other", 0)
+	other.Persist(nil, map[string]*ServiceInfo{
+		"foreign-svc": {OrgID: "tenant-other", FirstSeen: time.Now().UTC(), Manual: true},
+	})
+
+	pager := catalogStore().(CatalogPager)
+	page, total, err := pager.ListServicesPage(CatalogPageOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListServicesPage: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("total = %d, want 2 (default org only)", total)
+	}
+	for _, row := range page {
+		if row.Name == "foreign-svc" {
+			t.Fatal("foreign-org service leaked into default-org page")
+		}
+		if row.Info.OrgID != storage.DefaultOrgID {
+			t.Fatalf("service OrgID = %q, want %q", row.Info.OrgID, storage.DefaultOrgID)
+		}
+	}
+}
+
+func ids(ps []*Pattern) []string {
+	out := make([]string, len(ps))
+	for i, p := range ps {
+		out[i] = p.ID
+	}
+	return out
+}
+
+func svcNames(rows []ServiceRow) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.Name
+	}
+	return out
+}

--- a/pkg/agent/catalog_pg_store.go
+++ b/pkg/agent/catalog_pg_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -162,6 +163,81 @@ const (
 		    LIMIT 1
 		) lo ON TRUE
 		WHERE p.org_id = $1 AND p.kind = 'log' AND p.deleted = FALSE`
+
+	// Page: one bounded slice of the SAME fleet read view Snapshot returns —
+	// identical org scope (p.org_id = $1, kind='log', deleted=FALSE, and the
+	// logs-present filter the agg join enforces) so a page can never cross a
+	// tenant boundary or surface a pattern Snapshot would hide. The optional
+	// case-insensitive search ($2) matches template / id / service; an empty
+	// $2 expands to '%%' and matches every row. Ordered by fleet count
+	// descending with id as a stable tie-break — the SAME order Catalog.All /
+	// pagePatterns sort by — so pages never drift between requests.
+	sqlCatalogPageLogs = `
+		SELECT p.id, COALESCE(p.service, ''), COALESCE(p.verdict, ''), p.tags,
+		       agg.total_count, agg.first_seen, agg.last_seen, agg.total_baseline,
+		       lo.template, COALESCE(lo.source, ''), COALESCE(lo.rule_name, ''),
+		       lo.baseline_variance, lo.baseline_avg,
+		       COALESCE(lo.spike_baseline_mode, ''), lo.seasonal, lo.samples
+		FROM vs_patterns p
+		JOIN LATERAL (
+		    SELECT SUM(count) AS total_count, MIN(first_seen) AS first_seen,
+		           MAX(last_seen) AS last_seen, SUM(baseline_frequency) AS total_baseline
+		    FROM vs_logs
+		    WHERE org_id = p.org_id AND pattern_id = p.id
+		) agg ON agg.total_count IS NOT NULL
+		JOIN LATERAL (
+		    SELECT template, source, rule_name,
+		           baseline_variance, baseline_avg, spike_baseline_mode, seasonal, samples
+		    FROM vs_logs
+		    WHERE org_id = p.org_id AND pattern_id = p.id
+		    ORDER BY instance_index ASC
+		    LIMIT 1
+		) lo ON TRUE
+		WHERE p.org_id = $1 AND p.kind = 'log' AND p.deleted = FALSE
+		  AND (lo.template ILIKE '%' || $2 || '%'
+		       OR p.id ILIKE '%' || $2 || '%'
+		       OR COALESCE(p.service, '') ILIKE '%' || $2 || '%')
+		ORDER BY agg.total_count DESC, p.id ASC
+		LIMIT $3 OFFSET $4`
+
+	// Count: the whole-(filtered-)set pattern total the page reports, computed
+	// without materializing rows. It shares the page's FROM/WHERE verbatim (the
+	// same org scope and logs-present filter) so the total always matches the
+	// page's population.
+	sqlCatalogCountLogs = `
+		SELECT COUNT(*)
+		FROM vs_patterns p
+		JOIN LATERAL (
+		    SELECT SUM(count) AS total_count
+		    FROM vs_logs
+		    WHERE org_id = p.org_id AND pattern_id = p.id
+		) agg ON agg.total_count IS NOT NULL
+		JOIN LATERAL (
+		    SELECT template FROM vs_logs
+		    WHERE org_id = p.org_id AND pattern_id = p.id
+		    ORDER BY instance_index ASC
+		    LIMIT 1
+		) lo ON TRUE
+		WHERE p.org_id = $1 AND p.kind = 'log' AND p.deleted = FALSE
+		  AND (lo.template ILIKE '%' || $2 || '%'
+		       OR p.id ILIKE '%' || $2 || '%'
+		       OR COALESCE(p.service, '') ILIKE '%' || $2 || '%')`
+
+	// Page / Count services: the SAME org scope Snapshot's service read uses
+	// (org_id = $1, deleted = FALSE) plus an optional name search ($2) and a
+	// deterministic first_seen-then-name order so service pages never drift.
+	sqlCatalogPageServices = `
+		SELECT name, manual, first_seen
+		FROM vs_services
+		WHERE org_id = $1 AND deleted = FALSE
+		  AND name ILIKE '%' || $2 || '%'
+		ORDER BY first_seen ASC, name ASC
+		LIMIT $3 OFFSET $4`
+	sqlCatalogCountServices = `
+		SELECT COUNT(*)
+		FROM vs_services
+		WHERE org_id = $1 AND deleted = FALSE
+		  AND name ILIKE '%' || $2 || '%'`
 
 	// Curate — one statement per operator mutation (all values bound).
 	sqlCurateVerdict = `UPDATE vs_patterns SET verdict = $3, updated_at = NOW() WHERE org_id = $1 AND id = $2 AND kind = 'log'`
@@ -453,6 +529,121 @@ func (s *pgCatalogStore) Snapshot() ([]*Pattern, map[string]ServiceInfo, error) 
 		services[name] = *svc
 	}
 	return out, services, nil
+}
+
+// ListPatternsPage implements the optional CatalogPager capability: one bounded
+// page of the fleet read view plus the whole-(filtered-)set total, both pushed
+// into SQL so an unbounded catalog is never loaded whole to render one list
+// page. It applies the EXACT org scope Snapshot uses (org_id, kind='log',
+// deleted=FALSE, logs-present), ordered by fleet count descending with id as a
+// stable tie-break so pages never drift between requests.
+func (s *pgCatalogStore) ListPatternsPage(opts CatalogPageOptions) ([]*Pattern, int, error) {
+	search := strings.TrimSpace(opts.Search)
+	var total int
+	if err := s.db.QueryRow(sqlCatalogCountLogs, s.orgID, search).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("agent: pg catalog count logs: %w", err)
+	}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = DefaultCatalogPageSize
+	}
+	offset := opts.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	rows, err := s.db.Query(sqlCatalogPageLogs, s.orgID, search, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("agent: pg catalog page logs: %w", err)
+	}
+	defer rows.Close()
+	var out []*Pattern
+	for rows.Next() {
+		var (
+			id, service, verdict       string
+			tagsRaw, samplesRaw        []byte
+			seasonalRaw                []byte
+			totalCount                 int64
+			firstSeen, lastSeen        time.Time
+			totalBaseline              float64
+			baselineVar                float64
+			baselineAvg                float64
+			spikeBaselineMode          string
+			template, source, ruleName string
+		)
+		if err := rows.Scan(&id, &service, &verdict, &tagsRaw,
+			&totalCount, &firstSeen, &lastSeen, &totalBaseline,
+			&template, &source, &ruleName, &baselineVar, &baselineAvg,
+			&spikeBaselineMode, &seasonalRaw, &samplesRaw); err != nil {
+			return nil, 0, fmt.Errorf("agent: pg catalog page logs scan: %w", err)
+		}
+		out = append(out, &Pattern{
+			ID:                id,
+			OrgID:             s.orgID,
+			Template:          template,
+			FirstSeen:         firstSeen,
+			LastSeen:          lastSeen,
+			Count:             int(totalCount),
+			BaselineFrequency: totalBaseline,
+			BaselineVariance:  baselineVar,
+			BaselineAvg:       baselineAvg,
+			SpikeBaselineMode: spikeBaselineMode,
+			Seasonal:          decodeSeasonal(seasonalRaw),
+			Verdict:           verdict,
+			RuleName:          ruleName,
+			Source:            source,
+			Service:           service,
+			Tags:              decodeStringSlice(tagsRaw),
+			Samples:           decodeStringSlice(samplesRaw),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("agent: pg catalog page logs rows: %w", err)
+	}
+	return out, total, nil
+}
+
+// ListServicesPage implements the optional CatalogPager capability for
+// services: one bounded page plus the whole-(filtered-)set total, both in SQL.
+// It applies the EXACT org scope Snapshot's service read uses (org_id,
+// deleted=FALSE), ordered by first_seen then name so pages never drift.
+func (s *pgCatalogStore) ListServicesPage(opts CatalogPageOptions) ([]ServiceRow, int, error) {
+	search := strings.TrimSpace(opts.Search)
+	var total int
+	if err := s.db.QueryRow(sqlCatalogCountServices, s.orgID, search).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("agent: pg catalog count services: %w", err)
+	}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = DefaultCatalogPageSize
+	}
+	offset := opts.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	rows, err := s.db.Query(sqlCatalogPageServices, s.orgID, search, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("agent: pg catalog page services: %w", err)
+	}
+	defer rows.Close()
+	out := make([]ServiceRow, 0, limit)
+	for rows.Next() {
+		var (
+			name      string
+			manual    bool
+			firstSeen time.Time
+		)
+		if err := rows.Scan(&name, &manual, &firstSeen); err != nil {
+			return nil, 0, fmt.Errorf("agent: pg catalog page services scan: %w", err)
+		}
+		out = append(out, ServiceRow{
+			Name: name,
+			Info: ServiceInfo{OrgID: s.orgID, FirstSeen: firstSeen, Manual: manual},
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("agent: pg catalog page services rows: %w", err)
+	}
+	return out, total, nil
 }
 
 // Curate applies one operator mutation to the curated root columns or the

--- a/pkg/agent/catalog_pg_store_test.go
+++ b/pkg/agent/catalog_pg_store_test.go
@@ -27,6 +27,7 @@ import (
 var allCatalogQueries = []string{
 	sqlCatalogLoadLogs, sqlCatalogSelectServices, sqlCatalogUpsertRoot,
 	sqlCatalogUpsertLog, sqlCatalogInsertServiceIfAbsent, sqlCatalogSnapshotLogs,
+	sqlCatalogPageLogs, sqlCatalogCountLogs, sqlCatalogPageServices, sqlCatalogCountServices,
 	sqlCurateVerdict, sqlCurateTags, sqlCurateMarkKnown, sqlCurateRepointService,
 	sqlCurateDelete, sqlCurateResetPatterns, sqlCurateResetServices,
 	sqlCurateEndGrace, sqlCurateRestartGrace, sqlCurateCreateService,

--- a/pkg/agent/catalog_store.go
+++ b/pkg/agent/catalog_store.go
@@ -57,6 +57,57 @@ type CatalogStore interface {
 	Curate(edit CatalogEdit) error
 }
 
+// DefaultCatalogPageSize is the bounded page the pattern/service list reads
+// return when the caller does not request a specific size. It is the catalog
+// twin of storage.DefaultIncidentPageSize / DefaultAnalysisPageSize: on a
+// backend with an unbounded catalog (Postgres) the list serves one cheap
+// COUNT plus one bounded page rather than the whole table, so a large learned
+// catalog never ships whole to render one list load.
+const DefaultCatalogPageSize = 1000
+
+// CatalogPageOptions is one bounded read request against the catalog: skip
+// Offset rows and return at most Limit, optionally filtered to Search. A
+// non-positive Limit means DefaultCatalogPageSize; a negative Offset is
+// treated as 0. Search is a case-insensitive substring matched against the
+// pattern template/id/service (patterns) or the service name (services); an
+// empty Search returns the unfiltered ordering.
+type CatalogPageOptions struct {
+	Offset int
+	Limit  int
+	Search string
+}
+
+// ServiceRow is one ordered service list row: the service name plus its
+// ServiceInfo. The paged service read returns an ordered slice (services
+// sorted by FirstSeen then name) rather than the map AllServices returns,
+// because a page needs a stable order the map cannot carry.
+type ServiceRow struct {
+	Name string
+	Info ServiceInfo
+}
+
+// CatalogPager is the OPTIONAL paged-read capability a CatalogStore may
+// implement on top of the base seam, mirroring storage.IncidentPager /
+// AnalysisPager: it splits the two things the list endpoints need — a cheap
+// total COUNT and one bounded page — so an unbounded backend (Postgres) pushes
+// both into SQL (LIMIT/OFFSET + COUNT with an optional ILIKE search) instead
+// of loading the whole catalog per list load. A store that does not implement
+// it (a store with only the base Snapshot) is served by the Catalog folding
+// Snapshot into an in-memory page, so callers get one uniform seam; the OSS
+// Postgres store implements it directly. Consumers discover it via a type
+// assertion, exactly like the storage pagers.
+type CatalogPager interface {
+	// ListPatternsPage returns one bounded page of patterns ordered by Count
+	// descending (id ascending as a stable tie-break) — the same order
+	// Catalog.All sorts by — filtered to opts.Search when set, plus the
+	// whole-(filtered-)set total computed without materializing the page.
+	ListPatternsPage(opts CatalogPageOptions) (patterns []*Pattern, total int, err error)
+	// ListServicesPage returns one bounded page of services ordered by
+	// FirstSeen ascending (name ascending as a stable tie-break), filtered to
+	// opts.Search when set, plus the whole-(filtered-)set total.
+	ListServicesPage(opts CatalogPageOptions) (services []ServiceRow, total int, err error)
+}
+
 // CatalogEditKind discriminates which operator mutation a CatalogEdit carries.
 // The set mirrors the Catalog curation method set one-for-one.
 type CatalogEditKind string

--- a/pkg/controllers/agent.go
+++ b/pkg/controllers/agent.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -232,20 +233,122 @@ func (a *AgentController) getStatus(c *fiber.Ctx) error {
 }
 
 func (a *AgentController) listPatterns(c *fiber.Ctx) error {
-	all := a.catalog.All()
-	rows := make([]patternRow, 0, len(all))
-	for _, p := range all {
+	size := parsePatternPageSize(c.Query("page_size"))
+	offset, page := pageOffset(c.Query("page"), c.Query("offset"), size)
+	patterns, total, err := a.catalog.PatternsPage(agent.CatalogPageOptions{
+		Offset: offset,
+		Limit:  size,
+		Search: c.Query("q"),
+	})
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+	rows := make([]patternRow, 0, len(patterns))
+	for _, p := range patterns {
 		// Strip the redacted sample ring from list rows: the list is
 		// potentially thousands of patterns and the ring belongs only on the
-		// detail read (getPattern). a.catalog.All() already returns copies, so
-		// nil-ing this field never touches the stored pattern.
+		// detail read (getPattern). PatternsPage already returns copies, so
+		// nil-ing this field never touches the stored pattern. Readiness is
+		// computed ONLY for the returned page, never the whole catalog.
 		p.Samples = nil
 		rows = append(rows, patternRow{
 			Pattern:   p,
 			Readiness: agent.LogReadiness(p, a.catalogCfg.AutoPromoteAfter, a.pollInterval),
 		})
 	}
-	return c.JSON(fiber.Map{"patterns": rows})
+	return c.JSON(pagedPatternResponse(rows, total, offset, size, page))
+}
+
+// DefaultPatternPageSize / DefaultServicePageSize are the bounded default page
+// the pattern / service list reads return when the caller requests no size.
+// They mirror storage.DefaultAnalysisPageSize: one cheap count + one bounded
+// page instead of the whole catalog per list load.
+const (
+	DefaultPatternPageSize = agent.DefaultCatalogPageSize
+	DefaultServicePageSize = agent.DefaultCatalogPageSize
+)
+
+// parsePatternPageSize resolves the requested pattern page size: the catalog
+// default when unset, clamped to [1, maxIncidentPageSize] otherwise so a single
+// request stays bounded — the pattern twin of parseAnalysisPageSize.
+func parsePatternPageSize(v string) int {
+	if v == "" {
+		return DefaultPatternPageSize
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return DefaultPatternPageSize
+	}
+	if n > maxIncidentPageSize {
+		return maxIncidentPageSize
+	}
+	return n
+}
+
+// parseServicePageSize is the service twin of parsePatternPageSize.
+func parseServicePageSize(v string) int {
+	if v == "" {
+		return DefaultServicePageSize
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return DefaultServicePageSize
+	}
+	if n > maxIncidentPageSize {
+		return maxIncidentPageSize
+	}
+	return n
+}
+
+// pagedPatternResponse builds the patterns list response from the CHEAP total
+// count and ONE bounded page of rows. It preserves the existing `patterns`
+// array (so consumers reading only `patterns` keep working) and adds total +
+// offset-based continuation (offset / next_offset / page / page_size),
+// mirroring pagedAnalysisResponse. A full page (len == size) implies at least
+// one more page; an underfull page is the last one.
+func pagedPatternResponse(rows []patternRow, total, offset, size, page int) fiber.Map {
+	out := rows
+	if out == nil {
+		out = []patternRow{}
+	}
+	resp := fiber.Map{
+		"patterns":  out,
+		"total":     total,
+		"offset":    offset,
+		"page":      page,
+		"page_size": size,
+	}
+	if len(rows) == size {
+		resp["next_offset"] = offset + len(rows)
+	} else {
+		resp["next_offset"] = nil
+	}
+	return resp
+}
+
+// pagedServiceResponse builds the services list response. The back-compat
+// `services` key stays a name→facts MAP (existing consumers — the reassign
+// dropdown, the overview — read it unchanged); pagination is additive (total +
+// offset / next_offset / page / page_size). The deterministic page ORDER lives
+// server-side (first_seen then name); the map carries only this page's entries,
+// so a name appears in at most one page and the union across pages is exact.
+func pagedServiceResponse(services map[string]fiber.Map, total, offset, size, page int) fiber.Map {
+	if services == nil {
+		services = map[string]fiber.Map{}
+	}
+	resp := fiber.Map{
+		"services":  services,
+		"total":     total,
+		"offset":    offset,
+		"page":      page,
+		"page_size": size,
+	}
+	if len(services) == size {
+		resp["next_offset"] = offset + len(services)
+	} else {
+		resp["next_offset"] = nil
+	}
+	return resp
 }
 
 // patternRow is the GET /api/agent/patterns response DTO. It embeds the on-disk
@@ -451,24 +554,33 @@ func (a *AgentController) flushShadow(c *fiber.Ctx) error {
 // its detail page.)
 func (a *AgentController) listServices(c *fiber.Ctx) error {
 	grace := serviceGraceDuration()
-	all := a.catalog.AllServices()
-	out := make(map[string]fiber.Map, len(all))
-	for name, info := range all {
-		inGrace, remaining := graceStatus(info.FirstSeen, grace)
+	size := parseServicePageSize(c.Query("page_size"))
+	offset, page := pageOffset(c.Query("page"), c.Query("offset"), size)
+	svcs, total, err := a.catalog.ServicesPage(agent.CatalogPageOptions{
+		Offset: offset,
+		Limit:  size,
+		Search: c.Query("q"),
+	})
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+	out := make(map[string]fiber.Map, len(svcs))
+	for _, row := range svcs {
+		inGrace, remaining := graceStatus(row.Info.FirstSeen, grace)
 		m := fiber.Map{
-			"first_seen":              info.FirstSeen,
-			"manual":                  info.Manual,
+			"first_seen":              row.Info.FirstSeen,
+			"manual":                  row.Info.Manual,
 			"in_grace":                inGrace,
 			"grace_seconds_remaining": remaining,
 		}
 		// Preserve the org_id field exactly as ServiceInfo serialized it
 		// (omitempty) so no existing consumer of this shape regresses.
-		if info.OrgID != "" {
-			m["org_id"] = info.OrgID
+		if row.Info.OrgID != "" {
+			m["org_id"] = row.Info.OrgID
 		}
-		out[name] = m
+		out[row.Name] = m
 	}
-	return c.JSON(fiber.Map{"services": out})
+	return c.JSON(pagedServiceResponse(out, total, offset, size, page))
 }
 
 // serviceIncidentScanLimit bounds the incident-history scan for the

--- a/pkg/controllers/agent_paged_test.go
+++ b/pkg/controllers/agent_paged_test.go
@@ -1,0 +1,114 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/VersusControl/versus-incident/pkg/agent"
+	"github.com/VersusControl/versus-incident/pkg/storage"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// agent_paged_test.go — the pattern/service list reads now serve one bounded
+// page plus a cheap total instead of the whole catalog, mirroring the
+// incidents/analyses pager. These tests pin the additive paged envelope
+// (total / offset / page_size / next_offset) and prove a full page advertises a
+// continuation while an underfull page ends it.
+
+func pagedListApp(t *testing.T, cat *agent.Catalog) *fiber.App {
+	t.Helper()
+	ctrl := NewAgentController(cat, nil, nil, nil, nil, false)
+	app := fiber.New()
+	app.Get("/api/agent/patterns", ctrl.listPatterns)
+	app.Get("/api/agent/services", ctrl.listServices)
+	return app
+}
+
+// TestListPatterns_PagedEnvelope proves a bounded page_size returns only that
+// many rows, the true whole-set total, and a next_offset that walks the pages
+// without overlap — then nils out on the final underfull page.
+func TestListPatterns_PagedEnvelope(t *testing.T) {
+	cat, err := agent.LoadCatalog(storage.NewMemory())
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	cat.Upsert("p1", "alpha", "src", 5, 0.2, "default", "checkout")
+	cat.Upsert("p2", "bravo", "src", 4, 0.2, "default", "orders")
+	cat.Upsert("p3", "charlie", "src", 3, 0.2, "default", "cache")
+
+	app := pagedListApp(t, cat)
+
+	code, body := getJSON(t, app, "/api/agent/patterns?page_size=2")
+	if code != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%v", code, body)
+	}
+	patterns, _ := body["patterns"].([]any)
+	if len(patterns) != 2 {
+		t.Fatalf("patterns len = %d, want 2 (bounded page, not whole catalog)", len(patterns))
+	}
+	if body["total"] != float64(3) {
+		t.Fatalf("total = %v, want 3 (whole-set count)", body["total"])
+	}
+	if body["page_size"] != float64(2) {
+		t.Fatalf("page_size = %v, want 2", body["page_size"])
+	}
+	if body["next_offset"] != float64(2) {
+		t.Fatalf("next_offset = %v, want 2 (full page ⇒ continue)", body["next_offset"])
+	}
+
+	// The final window is underfull ⇒ next_offset nils out.
+	_, tail := getJSON(t, app, "/api/agent/patterns?offset=2&page_size=2")
+	tailRows, _ := tail["patterns"].([]any)
+	if len(tailRows) != 1 {
+		t.Fatalf("tail len = %d, want 1", len(tailRows))
+	}
+	if tail["total"] != float64(3) {
+		t.Fatalf("tail total = %v, want 3 (unchanged)", tail["total"])
+	}
+	if tail["next_offset"] != nil {
+		t.Fatalf("tail next_offset = %v, want nil (underfull ⇒ last page)", tail["next_offset"])
+	}
+}
+
+// TestListServices_PagedEnvelope proves the services list keeps its back-compat
+// name→facts MAP shape while gaining the same bounded paged envelope.
+func TestListServices_PagedEnvelope(t *testing.T) {
+	cat, err := agent.LoadCatalog(storage.NewMemory())
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	for _, name := range []string{"checkout", "orders", "cache"} {
+		cat.RegisterService(name)
+	}
+
+	app := pagedListApp(t, cat)
+
+	code, body := getJSON(t, app, "/api/agent/services?page_size=2")
+	if code != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%v", code, body)
+	}
+	// Back-compat: services stays a MAP, not an array.
+	svcs, ok := body["services"].(map[string]any)
+	if !ok {
+		t.Fatalf("services is not a map: %T", body["services"])
+	}
+	if len(svcs) != 2 {
+		t.Fatalf("services page len = %d, want 2 (bounded)", len(svcs))
+	}
+	if body["total"] != float64(3) {
+		t.Fatalf("total = %v, want 3", body["total"])
+	}
+	if body["next_offset"] != float64(2) {
+		t.Fatalf("next_offset = %v, want 2", body["next_offset"])
+	}
+	// Each page entry still carries the grace facts the UI reads.
+	for name, raw := range svcs {
+		m, _ := raw.(map[string]any)
+		if _, has := m["manual"]; !has {
+			t.Fatalf("service %q missing manual flag: %v", name, m)
+		}
+		if _, has := m["in_grace"]; !has {
+			t.Fatalf("service %q missing in_grace: %v", name, m)
+		}
+	}
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -575,6 +575,31 @@ export interface AnalysisIndex {
   page_size?: number;
 }
 
+// PatternIndex is the paged pattern-list envelope: one bounded page of learned
+// log patterns plus the whole-set total, so the Patterns page first render is
+// fast even on a large learned catalog. It mirrors AnalysisIndex; `next_offset`
+// is where to resume (null at the end).
+export interface PatternIndex {
+  patterns: Pattern[];
+  total: number;
+  offset?: number;
+  next_offset?: number | null;
+  page?: number;
+  page_size?: number;
+}
+
+// ServiceIndex is the paged service-list envelope. It keeps the back-compat
+// name→facts MAP shape the reassign dropdown and overview already read, and
+// adds the same bounded paging fields as PatternIndex.
+export interface ServiceIndex {
+  services: Record<string, ServiceInfo>;
+  total: number;
+  offset?: number;
+  next_offset?: number | null;
+  page?: number;
+  page_size?: number;
+}
+
 // ---------- Team / member management ----------
 
 // MemberMeta mirrors pkg/teams.MemberMeta — typed per-channel ids.
@@ -1281,6 +1306,28 @@ export const api = {
     request<{ patterns: Pattern[] }>("/api/agent/patterns").then(
       (r) => r.patterns ?? [],
     ),
+  // listPatternsIndex is the Patterns-page variant: it returns one bounded page
+  // of learned patterns (ordered by fleet count) PLUS the whole-set total in a
+  // single request, so the first render is fast on a large catalog. Pass
+  // `offset` to load the next chunk; the response's `next_offset` is where to
+  // resume (null at the end). `pageSize` overrides the server default; `q`
+  // filters by template/id/service.
+  listPatternsIndex: (opts?: {
+    offset?: number;
+    pageSize?: number;
+    page?: number;
+    q?: string;
+  }) => {
+    const p = new URLSearchParams();
+    if (opts?.offset) p.set("offset", String(opts.offset));
+    if (opts?.pageSize) p.set("page_size", String(opts.pageSize));
+    if (opts?.page) p.set("page", String(opts.page));
+    if (opts?.q) p.set("q", opts.q);
+    const qs = p.toString();
+    return request<PatternIndex>(
+      `/api/agent/patterns${qs ? `?${qs}` : ""}`,
+    );
+  },
   getPattern: (id: string) => request<Pattern>(`/api/agent/patterns/${id}`),
   updatePattern: (id: string, body: { verdict?: string; tags?: string[] }) =>
     request<Pattern>(`/api/agent/patterns/${id}`, {
@@ -1567,6 +1614,27 @@ export const api = {
     request<{ services: Record<string, ServiceInfo> }>(
       "/api/agent/services",
     ).then((r) => r.services ?? {}),
+  // listServicesIndex is the Services-page variant: it returns one bounded page
+  // of services (the back-compat name→facts MAP) PLUS the whole-set total in a
+  // single request. Pass `offset` to load the next chunk; `next_offset` is
+  // where to resume (null at the end). `pageSize` overrides the server default;
+  // `q` filters by service name.
+  listServicesIndex: (opts?: {
+    offset?: number;
+    pageSize?: number;
+    page?: number;
+    q?: string;
+  }) => {
+    const p = new URLSearchParams();
+    if (opts?.offset) p.set("offset", String(opts.offset));
+    if (opts?.pageSize) p.set("page_size", String(opts.pageSize));
+    if (opts?.page) p.set("page", String(opts.page));
+    if (opts?.q) p.set("q", opts.q);
+    const qs = p.toString();
+    return request<ServiceIndex>(
+      `/api/agent/services${qs ? `?${qs}` : ""}`,
+    );
+  },
   // getServiceDetail reads the OSS service-detail aggregate (meta + grace +
   // patterns + bounded incident summary). 404 means the service is unknown.
   getServiceDetail: (name: string) =>

--- a/ui/src/pages/PatternsPage.test.tsx
+++ b/ui/src/pages/PatternsPage.test.tsx
@@ -33,6 +33,7 @@ vi.mock("@/lib/api", async (importActual) => {
     api: {
       ...actual.api,
       listPatterns: vi.fn(),
+      listPatternsIndex: vi.fn(),
       getPattern: vi.fn(),
       listBaselines: vi
         .fn()
@@ -110,7 +111,11 @@ async function openPeek(): Promise<HTMLElement> {
 describe("PatternsPage peek — fetches the pattern DETAIL", () => {
   beforeEach(() => {
     vi.mocked(api.listServiceOverrides).mockResolvedValue([]);
-    vi.mocked(api.listPatterns).mockResolvedValue([listRow()]);
+    vi.mocked(api.listPatternsIndex).mockResolvedValue({
+      patterns: [listRow()],
+      total: 1,
+      next_offset: null,
+    });
     vi.mocked(api.getPattern).mockResolvedValue(detail());
   });
 
@@ -163,11 +168,15 @@ describe("PatternsPage — Verdict cell learning hint", () => {
   });
 
   it("shows the seen/needed progress meter when a count target exists", async () => {
-    vi.mocked(api.listPatterns).mockResolvedValue([
-      listRow({
-        readiness: { ready: false, seen: 40, needed: 100, rate_per_min: 2 },
-      }),
-    ]);
+    vi.mocked(api.listPatternsIndex).mockResolvedValue({
+      patterns: [
+        listRow({
+          readiness: { ready: false, seen: 40, needed: 100, rate_per_min: 2 },
+        }),
+      ],
+      total: 1,
+      next_offset: null,
+    });
     renderPage();
     const row = await screen.findByText("payment <*> failed");
     const cell = row.closest("tr")!;
@@ -175,6 +184,52 @@ describe("PatternsPage — Verdict cell learning hint", () => {
     expect(cell.textContent).toContain("40");
     expect(cell.textContent).toContain("100");
     expect(within(cell).queryByText(/auto-promotion off/)).toBeNull();
+  });
+});
+
+// The Patterns list is served as bounded pages (a cheap total + one page), not
+// the whole catalog. These pin the paged wiring: the whole-set total drives the
+// header, and a server-advertised next page surfaces a "Load more" control that
+// pulls the following page on demand.
+describe("PatternsPage — server-side paging", () => {
+  beforeEach(() => {
+    vi.mocked(api.listServiceOverrides).mockResolvedValue([]);
+    vi.mocked(api.getPattern).mockResolvedValue(detail());
+  });
+
+  it("renders the whole-set total in the header, not the loaded page size", async () => {
+    vi.mocked(api.listPatternsIndex).mockResolvedValue({
+      patterns: [listRow()],
+      total: 4200,
+      next_offset: null,
+    });
+    renderPage();
+    // The subtitle reflects the server total (4,200), not the one loaded row.
+    expect(await screen.findByText(/4,200 log templates learned/)).toBeTruthy();
+  });
+
+  it("loads the next page when Load more is clicked", async () => {
+    vi.mocked(api.listPatternsIndex)
+      .mockResolvedValueOnce({
+        patterns: [listRow({ id: "p-1", template: "first page <*>" })],
+        total: 2,
+        next_offset: 1,
+      })
+      .mockResolvedValueOnce({
+        patterns: [listRow({ id: "p-2", template: "second page <*>" })],
+        total: 2,
+        next_offset: null,
+      });
+    renderPage();
+
+    // First page rendered; the load-more control advertises more rows.
+    expect(await screen.findByText("first page <*>")).toBeTruthy();
+    const more = await screen.findByTestId("pattern-load-more");
+    fireEvent.click(within(more).getByRole("button"));
+
+    // The second page is fetched and appended.
+    expect(await screen.findByText("second page <*>")).toBeTruthy();
+    expect(api.listPatternsIndex).toHaveBeenCalledWith({ offset: 1 });
   });
 });
 

--- a/ui/src/pages/PatternsPage.tsx
+++ b/ui/src/pages/PatternsPage.tsx
@@ -1,8 +1,14 @@
 import { useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, Eye, Search, Trash2 } from "lucide-react";
-import { api, type Pattern } from "@/lib/api";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type InfiniteData,
+} from "@tanstack/react-query";
+import { Check, Eye, Loader2, Search, Trash2 } from "lucide-react";
+import { api, type Pattern, type PatternIndex } from "@/lib/api";
 import { displayService, fmtAbs, fmtRel } from "@/lib/format";
 import { useTableKeys } from "@/lib/hooks";
 import { TopBar } from "@/components/TopBar";
@@ -70,11 +76,39 @@ export function PatternsPage() {
   const scope = isExclusionScope(params.get(SCOPE_PARAM));
 
   const refresh = useAutoRefresh();
-  const { data, isLoading, isError, error, refetch, isRefetching } = useQuery({
-    queryKey: ["patterns"],
-    queryFn: api.listPatterns,
+  // The pattern list is served as bounded pages (a cheap total + one page of
+  // learned patterns) instead of the whole catalog, mirroring the analyses
+  // list. useInfiniteQuery accumulates loaded pages; the client-side
+  // filter/sort/search below operates over what is loaded, and "Load more"
+  // pulls the next page on demand.
+  const patternsQ = useInfiniteQuery({
+    queryKey: ["patterns-all"],
+    queryFn: ({ pageParam }) => api.listPatternsIndex({ offset: pageParam }),
+    initialPageParam: 0,
+    // next_offset is the resume cursor; null/undefined means no more rows.
+    getNextPageParam: (last) => last.next_offset ?? undefined,
     refetchInterval: refresh.refetchInterval,
   });
+  const {
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isRefetching,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = patternsQ;
+
+  // Accumulate the loaded pages into a single list; total comes from the first
+  // page (the true whole-set count, never data.length). The server ships only
+  // one bounded page up front, so a large learned catalog never loads whole.
+  const data = useMemo<Pattern[] | undefined>(() => {
+    const pages = patternsQ.data?.pages;
+    if (!pages || pages.length === 0) return undefined;
+    return pages.flatMap((p) => p.patterns);
+  }, [patternsQ.data]);
+  const total = patternsQ.data?.pages[0]?.total;
 
   const [q, setQ] = useState("");
   const [peekId, setPeekId] = useState<string | null>(null);
@@ -101,19 +135,31 @@ export function PatternsPage() {
     Pattern,
     Error,
     VerdictVars,
-    { prev?: Pattern[] }
+    { prev?: InfiniteData<PatternIndex> }
   >({
     mutationFn: ({ id, verdict }) => api.updatePattern(id, { verdict }),
     onMutate: async ({ id, verdict }) => {
-      await qc.cancelQueries({ queryKey: ["patterns"] });
-      const prev = qc.getQueryData<Pattern[]>(["patterns"]);
-      qc.setQueryData<Pattern[]>(["patterns"], (old) =>
-        (old ?? []).map((p) => (p.id === id ? { ...p, verdict } : p)),
+      await qc.cancelQueries({ queryKey: ["patterns-all"] });
+      const prev = qc.getQueryData<InfiniteData<PatternIndex>>([
+        "patterns-all",
+      ]);
+      qc.setQueryData<InfiniteData<PatternIndex>>(["patterns-all"], (old) =>
+        old
+          ? {
+              ...old,
+              pages: old.pages.map((page) => ({
+                ...page,
+                patterns: page.patterns.map((p) =>
+                  p.id === id ? { ...p, verdict } : p,
+                ),
+              })),
+            }
+          : old,
       );
       return { prev };
     },
     onError: (err, vars, ctx) => {
-      if (ctx?.prev) qc.setQueryData(["patterns"], ctx.prev);
+      if (ctx?.prev) qc.setQueryData(["patterns-all"], ctx.prev);
       toast.push({
         tone: "error",
         title: "Verdict update failed",
@@ -123,7 +169,9 @@ export function PatternsPage() {
     },
     onSuccess: (_data, vars, ctx) => {
       const prevVerdict =
-        ctx?.prev?.find((p) => p.id === vars.id)?.verdict ?? "";
+        ctx?.prev?.pages
+          .flatMap((p) => p.patterns)
+          .find((p) => p.id === vars.id)?.verdict ?? "";
       toast.push({
         tone: "ok",
         title:
@@ -139,13 +187,19 @@ export function PatternsPage() {
         },
       });
     },
-    onSettled: () => qc.invalidateQueries({ queryKey: ["patterns"] }),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ["patterns-all"] });
+      // Keep the overview/detail readers of the bounded ["patterns"] query in
+      // sync with the verdict change made here.
+      qc.invalidateQueries({ queryKey: ["patterns"] });
+    },
   });
 
   // ----- clear all logs: destructive reset of every learned log pattern -----
   const reset = useMutation({
     mutationFn: api.clearPatterns,
     onSuccess: (res) => {
+      qc.invalidateQueries({ queryKey: ["patterns-all"] });
       qc.invalidateQueries({ queryKey: ["patterns"] });
       setConfirmReset(false);
       toast.push({
@@ -311,7 +365,7 @@ export function PatternsPage() {
     <>
       <TopBar
         title="What the agent knows right now"
-        subtitle={data ? `${data.length} log templates learned` : "The agent learns recurring message templates from your logs so it can spot new or unusual ones."}
+        subtitle={total != null ? `${total.toLocaleString()} log templates learned` : "The agent learns recurring message templates from your logs so it can spot new or unusual ones."}
         actions={
           <button
             className="btn btn-danger"
@@ -569,6 +623,27 @@ export function PatternsPage() {
               </table>
             </div>
             <Pagination state={pg} />
+            {(isFetchingNextPage || hasNextPage) && (
+              <div
+                className="flex items-center justify-center gap-1.5 border-t border-ink-600 px-3 py-2 text-2xs text-ink-400"
+                data-testid="pattern-load-more"
+              >
+                {isFetchingNextPage ? (
+                  <>
+                    <Loader2 size={12} className="animate-spin" />
+                    Loading more…
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    className="text-brand-300 hover:underline"
+                    onClick={() => fetchNextPage()}
+                  >
+                    Load more ({total?.toLocaleString() ?? ""} total)
+                  </button>
+                )}
+              </div>
+            )}
           </div>
         )}
       </main>
@@ -714,7 +789,7 @@ export function PatternsPage() {
         <ReassignModal
           sourceType="log"
           matches={reassignMatches}
-          invalidateKeys={[["patterns"]]}
+          invalidateKeys={[["patterns-all"], ["patterns"]]}
           onClose={() => setReassignMatches(null)}
           onDone={() => bulk.clear()}
         />

--- a/ui/src/pages/ServicesPage.test.tsx
+++ b/ui/src/pages/ServicesPage.test.tsx
@@ -25,6 +25,7 @@ vi.mock("@/lib/api", async (importActual) => {
     api: {
       ...actual.api,
       listServices: vi.fn(),
+      listServicesIndex: vi.fn(),
       getServiceDetail: vi.fn(),
       listBaselines: vi
         .fn()
@@ -83,7 +84,11 @@ function renderPage() {
 
 describe("ServicesPage row actions", () => {
   beforeEach(() => {
-    vi.mocked(api.listServices).mockResolvedValue({ checkout: svc() });
+    vi.mocked(api.listServicesIndex).mockResolvedValue({
+      services: { checkout: svc() },
+      total: 1,
+      next_offset: null,
+    });
     vi.mocked(api.getServiceDetail).mockResolvedValue({
       service: "checkout",
       first_seen: new Date().toISOString(),
@@ -145,9 +150,13 @@ describe("ServicesPage Active/Ignored scope", () => {
   // succeeds), an admin session (deployment org + admin whoami), and a policy
   // that already ignores one of the two services.
   function renderScoped(initialEntry = "/agent/services") {
-    vi.mocked(api.listServices).mockResolvedValue({
-      checkout: svc(),
-      payments: svc(),
+    vi.mocked(api.listServicesIndex).mockResolvedValue({
+      services: {
+        checkout: svc(),
+        payments: svc(),
+      },
+      total: 2,
+      next_offset: null,
     });
     vi.mocked(api.getServiceDetail).mockResolvedValue({
       service: "checkout",
@@ -235,7 +244,11 @@ describe("ServicesPage Active/Ignored scope", () => {
 
   it("keeps the scope toggle absent on a community / unlicensed binary", async () => {
     // Community defaults from the module mock: baselines + deployment 403.
-    vi.mocked(api.listServices).mockResolvedValue({ checkout: svc() });
+    vi.mocked(api.listServicesIndex).mockResolvedValue({
+      services: { checkout: svc() },
+      total: 1,
+      next_offset: null,
+    });
     vi.mocked(api.listBaselines).mockRejectedValue(
       new (await import("@/lib/api")).ApiError(403, "community"),
     );
@@ -245,6 +258,58 @@ describe("ServicesPage Active/Ignored scope", () => {
     renderPage();
     await screen.findByLabelText("View service checkout");
     expect(screen.queryByRole("tablist", { name: "Learning scope" })).toBeNull();
+  });
+});
+
+// The Services list is served as bounded pages (a cheap total + one page),
+// keeping the back-compat name→facts map shape. These pin the paged wiring:
+// the whole-set total drives the header, and a server-advertised next page
+// surfaces a "Load more" control that merges the following page in.
+describe("ServicesPage — server-side paging", () => {
+  beforeEach(() => {
+    vi.mocked(api.getServiceDetail).mockResolvedValue({
+      service: "checkout",
+      first_seen: new Date().toISOString(),
+      in_grace: false,
+      grace_seconds_remaining: 0,
+      patterns: [],
+      incidents: { window_days: 30, count: 0, severities: {}, recent: [] },
+      counts: { patterns: 0, incidents: 0 },
+    });
+  });
+
+  it("renders the whole-set total in the header, not the loaded page size", async () => {
+    vi.mocked(api.listServicesIndex).mockResolvedValue({
+      services: { checkout: svc() },
+      total: 3100,
+      next_offset: null,
+    });
+    renderPage();
+    expect(await screen.findByText(/3,100 discovered/)).toBeTruthy();
+  });
+
+  it("loads and merges the next page when Load more is clicked", async () => {
+    vi.mocked(api.listServicesIndex)
+      .mockResolvedValueOnce({
+        services: { checkout: svc() },
+        total: 2,
+        next_offset: 1,
+      })
+      .mockResolvedValueOnce({
+        services: { payments: svc() },
+        total: 2,
+        next_offset: null,
+      });
+    renderPage();
+
+    expect(await screen.findByText("checkout")).toBeTruthy();
+    const more = await screen.findByTestId("service-load-more");
+    fireEvent.click(more.querySelector("button")!);
+
+    // The second page is fetched and merged into the same table.
+    expect(await screen.findByText("payments")).toBeTruthy();
+    expect(screen.getByText("checkout")).toBeTruthy();
+    expect(api.listServicesIndex).toHaveBeenCalledWith({ offset: 1 });
   });
 });
 

--- a/ui/src/pages/ServicesPage.tsx
+++ b/ui/src/pages/ServicesPage.tsx
@@ -1,8 +1,13 @@
 import { useMemo, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { Link, useSearchParams } from "react-router-dom";
-import { Plus, Search, Trash2, Eye } from "lucide-react";
-import { api } from "@/lib/api";
+import { Loader2, Plus, Search, Trash2, Eye } from "lucide-react";
+import { api, type ServiceInfo } from "@/lib/api";
 import { fmtAbs, fmtRel } from "@/lib/format";
 import { TopBar } from "@/components/TopBar";
 import { Pill } from "@/components/Pill";
@@ -49,11 +54,45 @@ export function ServicesPage() {
   const qc = useQueryClient();
   const toast = useToast();
   const refresh = useAutoRefresh();
-  const { data, isLoading, isError, error, refetch, isRefetching } = useQuery({
-    queryKey: ["services"],
-    queryFn: api.listServices,
+  // The service list is served as bounded pages (a cheap total + one page of
+  // services) instead of the whole estate, mirroring the analyses/patterns
+  // lists. useInfiniteQuery accumulates loaded pages into one name→facts map;
+  // the client-side sort/search/scope below operate over what is loaded and
+  // "Load more" pulls the next page on demand.
+  const servicesQ = useInfiniteQuery({
+    queryKey: ["services-all"],
+    queryFn: ({ pageParam }) => api.listServicesIndex({ offset: pageParam }),
+    initialPageParam: 0,
+    // next_offset is the resume cursor; null/undefined means no more rows.
+    getNextPageParam: (last) => last.next_offset ?? undefined,
     refetchInterval: refresh.refetchInterval,
   });
+  const {
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isRefetching,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = servicesQ;
+
+  // Merge the loaded pages into one name→facts map; total comes from the first
+  // page (the true whole-set count, never the loaded size). The server ships
+  // only one bounded page up front, so a large estate never loads whole. Every
+  // downstream reader (peek lookup, Object.entries, grace flags) keeps working
+  // on this merged Record unchanged.
+  const data = useMemo<Record<string, ServiceInfo> | undefined>(() => {
+    const pages = servicesQ.data?.pages;
+    if (!pages || pages.length === 0) return undefined;
+    const merged: Record<string, ServiceInfo> = {};
+    for (const page of pages) {
+      Object.assign(merged, page.services);
+    }
+    return merged;
+  }, [servicesQ.data]);
+  const total = servicesQ.data?.pages[0]?.total;
 
   const [q, setQ] = useState("");
   const [params] = useSearchParams();
@@ -82,6 +121,7 @@ export function ServicesPage() {
     mutationFn: ({ name, action }: { name: string; action: GraceAction }) =>
       api.controlGrace(name, action),
     onSuccess: (_data, { name, action }) => {
+      qc.invalidateQueries({ queryKey: ["services-all"] });
       qc.invalidateQueries({ queryKey: ["services"] });
       toast.push({
         tone: "ok",
@@ -116,6 +156,7 @@ export function ServicesPage() {
     mutationFn: (name: string) => api.createService(name),
     onSuccess: (_d, name) => {
       setShowAdd(false);
+      qc.invalidateQueries({ queryKey: ["services-all"] });
       qc.invalidateQueries({ queryKey: ["services"] });
       toast.push({ tone: "ok", title: `Service "${name}" created` });
     },
@@ -132,6 +173,7 @@ export function ServicesPage() {
       api.renameService(v.from, v.to),
     onSuccess: (res, v) => {
       setRenameTarget(null);
+      qc.invalidateQueries({ queryKey: ["services-all"] });
       qc.invalidateQueries({ queryKey: ["services"] });
       qc.invalidateQueries({ queryKey: ["service-overrides"] });
       toast.push({
@@ -154,6 +196,7 @@ export function ServicesPage() {
   const deleteService = useMutation({
     mutationFn: (name: string) => api.deleteService(name),
     onSuccess: (_d, name) => {
+      qc.invalidateQueries({ queryKey: ["services-all"] });
       qc.invalidateQueries({ queryKey: ["services"] });
       toast.push({ tone: "ok", title: `Service "${name}" deleted` });
     },
@@ -173,6 +216,7 @@ export function ServicesPage() {
   const clearServices = useMutation({
     mutationFn: api.clearServices,
     onSuccess: (res) => {
+      qc.invalidateQueries({ queryKey: ["services-all"] });
       qc.invalidateQueries({ queryKey: ["services"] });
       setConfirmClear(false);
       toast.push({
@@ -332,7 +376,7 @@ export function ServicesPage() {
     <>
       <TopBar
         title="Services"
-        subtitle={data ? `${entries.length} discovered` : undefined}
+        subtitle={total != null ? `${total.toLocaleString()} discovered` : undefined}
         actions={
           <div className="flex items-center gap-2">
             <button
@@ -550,6 +594,27 @@ export function ServicesPage() {
               </table>
             </div>
             <Pagination state={pg} />
+            {(isFetchingNextPage || hasNextPage) && (
+              <div
+                className="flex items-center justify-center gap-1.5 border-t border-ink-600 px-3 py-2 text-2xs text-ink-400"
+                data-testid="service-load-more"
+              >
+                {isFetchingNextPage ? (
+                  <>
+                    <Loader2 size={12} className="animate-spin" />
+                    Loading more…
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    className="text-brand-300 hover:underline"
+                    onClick={() => fetchNextPage()}
+                  >
+                    Load more ({total?.toLocaleString() ?? ""} total)
+                  </button>
+                )}
+              </div>
+            )}
           </div>
         )}
       </main>


### PR DESCRIPTION
## What does this PR do?

Adds server-side pagination to the agent catalog list endpoints (`GET /api/agent/patterns`, `GET /api/agent/services`) so they serve a bounded page plus a cheap total count instead of materializing the whole catalog on every request. Brings these two lists onto the same pattern the incidents/analyses lists already use.

## Why?

On the Postgres backend, `listPatterns`/`listServices` went through `catalog.Snapshot()` — an unbounded `SELECT` over `vs_patterns`/`vs_services` plus a full JSON serialize and per-row readiness compute on every list load. This is the catalog twin of the incidents/analyses pagination already shipped. No linked issue — internal perf follow-up.

## How to test

1. Run OSS with `STORAGE_TYPE=postgres` and generate enough varied logs across many services to learn more patterns/services than one page (or pass a small `page_size`).
2. `GET /api/agent/patterns?page_size=5` → 5 rows, `total` = whole-catalog count, `next_offset` set on a full page; walk `offset`/`page` → non-overlapping, stable, gap-free windows; `next_offset` null on the last underfull page.
3. `?q=<substring>` filters server-side (smaller `total`); re-fetching a page is deterministic (patterns fleet-count desc→id; services first_seen→name).
4. `GET /api/agent/services?page_size=5` → paged envelope; `services` stays a name→facts map with grace fields; `total` = whole set.
5. `page_size` clamps to `[1,5000]` (default 1000); negative `offset` → 0.
6. UI Patterns/Services pages: header shows the whole-set total, **Load more** appends the next page, table sort works on loaded rows.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (config / API / default behavior)
- [ ] Documentation only
- [ ] Refactor (no functional change)
- [ ] CI / build / chore

## Checklist

- [x] `go test versus` passes locally
- [x] `go vet versus` is clean
- [x] Code is `gofmt`
- [x] Added or updated tests for the change
- [ ] Updated user-facing docs under `src/` if behavior changes *(internal admin API; no `src/` doc change)*
- [ ] Updated `ROADMAP.md` if this closes a roadmap item
- [x] No secrets, tokens, or webhook URLs introduced in source / YAML
- [x] No new third-party dependencies (or justified in the description)