### PR TITLE
feat: incident report + service-attribution fixes

### DIFF
--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -21,6 +21,32 @@ var ansiEscapeRe = regexp.MustCompile("\x1b\\[[0-9;?]*[ -/]*[@-~]")
 // service name and falls through to the next pattern.
 var logLevelRe = regexp.MustCompile(`^(?i:TRACE|DEBUG|INFO|WARN|WARNING|ERROR|FATAL)$`)
 
+// httpMethodRe matches a capture that is exactly an HTTP method. Request-log
+// layouts ("POST /api/orders 200") put the method right where a positional
+// pattern looks for a service, and because it is all letters the numeric guard
+// does not reject it. Extract skips such a capture so a signal is never filed
+// under "POST" or "GET". TRACE is intentionally omitted here — it is already
+// covered by logLevelRe.
+var httpMethodRe = regexp.MustCompile(`^(?i:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|CONNECT)$`)
+
+// abbrevLoggerRe matches an SLF4J / Logback abbreviated logger class name —
+// two or more leading single-letter dotted segments followed by a final token,
+// e.g. "o.s.boot.SpringApplication", "c.e.demo.Foo". Console layouts print the
+// abbreviated logger where a dotted-name pattern looks for a service, so
+// Extract skips this shape. It requires AT LEAST TWO single-letter segments so
+// a legitimate dotted service or host with multi-letter labels ("api.prod",
+// "auth.internal") is never rejected.
+var abbrevLoggerRe = regexp.MustCompile(`^(?:[A-Za-z]\.){2,}`)
+
+// reservedContextRe matches a small, conservative set of framework / thread
+// context words that leak through positional patterns as a bogus "service" —
+// the NestJS logger context ("Nest") and the bare JVM main thread ("main").
+// Extract skips these so a signal is never filed under a framework banner. The
+// set is deliberately tiny; broader denylisting risks rejecting a real service
+// that happens to share the name and is left to per-pattern tuning or the
+// operator's Service-cell reassign / ServiceOverride.
+var reservedContextRe = regexp.MustCompile(`^(?i:Nest|main)$`)
+
 // hasLetterRe matches a capture that contains at least one ASCII letter. The
 // bracket/syslog patterns capture with the class [A-Za-z0-9._-]+, which also
 // matches a purely-numeric token — a thread id / PID / port / address (e.g.
@@ -43,14 +69,14 @@ var hasLetterRe = regexp.MustCompile(`[A-Za-z]`)
 // It is anchored (^…$, case-insensitive) and deliberately tight so it rejects
 // ONLY clear thread-name shapes and never a legitimate service that merely
 // contains digits/dashes ("api2", "auth-service", "order-service-2",
-// "nio-gateway" — the "nio-<port>-exec-<n>" shape is specific enough not to
-// catch that). Each alternative below targets one common thread family.
+// "nio-gateway" — the connector-exec shape below is specific enough not to
+// catch those). Each alternative below targets one common thread family.
 var threadNameRe = regexp.MustCompile(`(?i)^(?:` +
-	// Tomcat / servlet-container connector exec threads:
-	//   nio-8080-exec-8, http-nio-8080-exec-3, https-jsse-nio-8443-exec-1
-	`(?:https?-)?(?:jsse-)?nio-\d+-exec-\d+` + `|` +
-	//   ajp-nio-8009-exec-2 (AJP connector)
-	`ajp-nio-\d+-exec-\d+` + `|` +
+	// Servlet-container connector exec threads, with or without the leading
+	// protocol label(s): nio-8080-exec-8, http-nio-8080-exec-3,
+	// https-jsse-nio-8443-exec-1, ajp-nio-8009-exec-2, the prefix-less
+	// io-8080-exec-10, and the bare <port>-exec-<n> form 8080-exec-10.
+	`(?:[a-z]+-)*\d+-exec-\d+` + `|` +
 	//   bare exec worker: exec-4
 	`exec-\d+` + `|` +
 	// Standard java.util.concurrent / JVM threads:
@@ -121,7 +147,7 @@ func NewServiceMatcher(patterns []string) (*ServiceMatcher, []error) {
 // Extract returns the first capture group of the first matching pattern, or
 // "" when nothing matches.
 //
-// Four generic correctness guards run here so they benefit every configured
+// Several generic correctness guards run here so they benefit every configured
 // pattern at once:
 //   - ANSI escape sequences are stripped from the message before matching, so
 //     a colour-wrapped token (e.g. Spring Boot's "\x1b[34mlead-service\x1b[m")
@@ -130,6 +156,10 @@ func NewServiceMatcher(patterns []string) (*ServiceMatcher, []error) {
 //     never returned as a service. If a pattern's first group captures exactly
 //     a level token, we skip it and continue to the next pattern, so a greedy
 //     positional pattern cannot misattribute a signal to "DEBUG".
+//   - A bare HTTP method (GET/POST/PUT/DELETE/PATCH/HEAD/OPTIONS/CONNECT) is
+//     never returned as a service, so a request-log layout ("POST /api 200")
+//     cannot file a signal under "POST". TRACE is already covered by the
+//     log-level guard.
 //   - A purely-numeric/separator token (no ASCII letter — e.g. "1210", "8080",
 //     "10.0.0.1") is never returned as a service. The bracket/syslog patterns
 //     capture with [A-Za-z0-9._-]+, so a bracketed thread id / PID / port like
@@ -137,11 +167,17 @@ func NewServiceMatcher(patterns []string) (*ServiceMatcher, []error) {
 //     it and continues to the next pattern. A name that merely CONTAINS digits
 //     (has a letter) — "s3", "api-v2" — is kept.
 //   - A JVM / servlet-container / reactor THREAD name (e.g. "nio-8080-exec-8",
-//     "pool-2-thread-1", "reactor-http-nio-4") is never returned as a service.
-//     Those names contain letters, so the number guard does not catch them; a
-//     bracket rule would otherwise file a signal under the Tomcat worker thread
-//     instead of the service. The thread-name guard skips such a capture and
-//     continues to the next pattern (the logger / real service).
+//     "io-8080-exec-10", "pool-2-thread-1", "reactor-http-nio-4") is never
+//     returned as a service. Those names contain letters, so the number guard
+//     does not catch them; a bracket rule would otherwise file a signal under
+//     the Tomcat worker thread instead of the service. The thread-name guard
+//     skips such a capture and continues to the next pattern.
+//   - An SLF4J / Logback abbreviated logger class name (single-letter dotted
+//     segments, e.g. "o.s.boot.SpringApplication", "c.e.demo.Foo") is never
+//     returned as a service, while a legitimate dotted service/host with
+//     multi-letter labels ("api.prod", "auth.internal") is kept.
+//   - A small reserved framework/thread context word ("Nest", "main") is
+//     skipped so a signal is never filed under a framework banner.
 func (m *ServiceMatcher) Extract(message string) string {
 	if m == nil || message == "" {
 		return ""
@@ -153,10 +189,19 @@ func (m *ServiceMatcher) Extract(message string) string {
 			if logLevelRe.MatchString(sub[1]) {
 				continue
 			}
+			if httpMethodRe.MatchString(sub[1]) {
+				continue
+			}
 			if !hasLetterRe.MatchString(sub[1]) {
 				continue
 			}
 			if threadNameRe.MatchString(sub[1]) {
+				continue
+			}
+			if abbrevLoggerRe.MatchString(sub[1]) {
+				continue
+			}
+			if reservedContextRe.MatchString(sub[1]) {
 				continue
 			}
 			return sub[1]

--- a/pkg/agent/service_test.go
+++ b/pkg/agent/service_test.go
@@ -365,3 +365,138 @@ func TestThreadNameGuard(t *testing.T) {
 		}
 	}
 }
+
+// TestServiceMatcher_ReportedGarbageRejected drives the exact garbage service
+// names customers saw leaking through operator-configured patterns and proves
+// the tightened guards reject every one while the legitimate names still pass.
+// Each bad line pairs the garbage token with a real service later on the line
+// so the guard's fall-through is observable end to end.
+func TestServiceMatcher_ReportedGarbageRejected(t *testing.T) {
+	// A permissive operator pattern: "first token, then anything". It happily
+	// captures a logger, an HTTP method, a thread name, or the bare "main" —
+	// exactly the misconfiguration the generic guards exist to backstop. A
+	// second key=value rule carries the REAL service later on the line.
+	m, errs := NewServiceMatcher([]string{
+		`(?m)^([A-Za-z][A-Za-z0-9._-]*)\b`,
+		`(?i)\b(?:service|svc|app|component)\s*=\s*"?([A-Za-z0-9._-]+)`,
+	})
+	if len(errs) != 0 {
+		t.Fatalf("patterns must compile cleanly, got %v", errs)
+	}
+
+	rejected := []struct{ name, line string }{
+		{"abbreviated logger", "o.s.boot.SpringApplication started service=order-service"},
+		{"abbreviated logger short", "c.e.demo.Foo booting service=order-service"},
+		{"http method POST", "POST /api/orders 200 service=order-service"},
+		{"http method GET", "GET /health 200 service=order-service"},
+		{"connector exec no nio prefix", "io-8080-exec-10 handling service=order-service"},
+		{"bare port exec", "8080-exec-10 handling service=order-service"},
+		{"nestjs context", "Nest starting up service=order-service"},
+		{"jvm main thread", "main bootstrapping service=order-service"},
+	}
+	for _, tc := range rejected {
+		got := m.Extract(tc.line)
+		if got != "order-service" {
+			t.Errorf("%s: Extract(%q) = %q — garbage token must be rejected and fall through to %q",
+				tc.name, tc.line, got, "order-service")
+		}
+	}
+
+	// The same permissive first-token pattern must STILL return a legitimate
+	// leading service name (no over-rejection).
+	kept := []struct{ line, want string }{
+		{"order-service-2 is up", "order-service-2"},
+		{"api.prod healthy", "api.prod"},
+		{"auth.internal ready", "auth.internal"},
+		{"nio-gateway routing traffic", "nio-gateway"},
+		{"s3 uploader connected", "s3"},
+	}
+	for _, tc := range kept {
+		if got := m.Extract(tc.line); got != tc.want {
+			t.Errorf("legit leading service: Extract(%q) = %q, want %q", tc.line, got, tc.want)
+		}
+	}
+}
+
+// TestHTTPMethodGuard exercises the HTTP-method guard directly: an exact method
+// token is rejected; TRACE is intentionally left to the log-level guard; a real
+// service that merely starts with a method word is kept.
+func TestHTTPMethodGuard(t *testing.T) {
+	methods := []string{"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "get", "Post"}
+	for _, s := range methods {
+		if !httpMethodRe.MatchString(s) {
+			t.Errorf("httpMethodRe should match method %q", s)
+		}
+	}
+	// TRACE is a log level, covered elsewhere — not by the method guard.
+	if httpMethodRe.MatchString("TRACE") {
+		t.Errorf("httpMethodRe must NOT match TRACE (owned by logLevelRe)")
+	}
+	// A real service that only CONTAINS a method word is not a bare method.
+	for _, s := range []string{"get-service", "post-office", "options-api", "postgres"} {
+		if httpMethodRe.MatchString(s) {
+			t.Errorf("httpMethodRe must only match a BARE method, not %q", s)
+		}
+	}
+}
+
+// TestAbbrevLoggerGuard exercises the abbreviated-logger guard directly: an
+// SLF4J/Logback abbreviated class name (two+ single-letter dotted segments) is
+// rejected, while a legitimate dotted service/host with multi-letter labels —
+// and a logger whose FIRST segment alone is single-letter ("c.example.Foo") —
+// is kept.
+func TestAbbrevLoggerGuard(t *testing.T) {
+	abbrev := []string{
+		"o.s.boot.SpringApplication", "c.e.demo.Foo", "o.a.c.h.Http11Processor",
+		"a.b.C", "x.y.z.Service",
+	}
+	for _, s := range abbrev {
+		if !abbrevLoggerRe.MatchString(s) {
+			t.Errorf("abbrevLoggerRe should match abbreviated logger %q", s)
+		}
+	}
+	kept := []string{
+		"api.prod", "auth.internal", "order-service", "s3",
+		"c.example.OrderController", // only ONE single-letter segment → kept
+		"payments.gateway.internal",
+	}
+	for _, s := range kept {
+		if abbrevLoggerRe.MatchString(s) {
+			t.Errorf("abbrevLoggerRe must NOT match legitimate name %q", s)
+		}
+	}
+}
+
+// TestReservedContextGuard exercises the reserved framework/thread context
+// guard: "Nest" (NestJS logger context) and "main" (bare JVM thread) are
+// rejected; everything that merely contains them is kept. See the report note
+// on the "Nest" trade-off.
+func TestReservedContextGuard(t *testing.T) {
+	for _, s := range []string{"Nest", "nest", "main", "MAIN"} {
+		if !reservedContextRe.MatchString(s) {
+			t.Errorf("reservedContextRe should match reserved word %q", s)
+		}
+	}
+	for _, s := range []string{"nest-service", "mainframe", "main-api", "nestjs-app", "domain"} {
+		if reservedContextRe.MatchString(s) {
+			t.Errorf("reservedContextRe must only match a BARE reserved word, not %q", s)
+		}
+	}
+}
+
+// TestThreadNameGuard_ConnectorExec covers the broadened connector-exec shapes:
+// the prefix-less "io-8080-exec-10" and the bare "<port>-exec-<n>" form are now
+// recognised as threads, while real services with digits/dashes are not.
+func TestThreadNameGuard_ConnectorExec(t *testing.T) {
+	threads := []string{"io-8080-exec-10", "8080-exec-10", "ajp-8009-exec-2", "http-nio-8080-exec-1"}
+	for _, s := range threads {
+		if !threadNameRe.MatchString(s) {
+			t.Errorf("threadNameRe should match connector-exec thread %q", s)
+		}
+	}
+	for _, s := range []string{"order-service-2", "nio-gateway", "exec-worker", "api2-service"} {
+		if threadNameRe.MatchString(s) {
+			t.Errorf("threadNameRe must NOT match service name %q", s)
+		}
+	}
+}

--- a/pkg/controllers/incidents_admin.go
+++ b/pkg/controllers/incidents_admin.go
@@ -138,10 +138,46 @@ func (i *IncidentAdminController) capabilities(c *fiber.Ctx) error {
 			"default_channel": settings.DefaultChannel,
 			"default_window":  settings.DefaultWindow,
 			"include_chart":   settings.IncludeChart,
-			"channels":        enabledAlertChannels(cfg),
-			"public_host_set": strings.TrimSpace(cfg.PublicHost) != "",
+			"channels":        i.reportChannels(c),
+			// configured_disabled lists channels that are set up (a runtime
+			// override exists) but currently turned OFF, so absent from
+			// channels — lets the report UI hint "configured but disabled"
+			// instead of silently dropping them. Always a non-null [].
+			"configured_disabled": i.reportConfiguredDisabledChannels(c),
+			"public_host_set":     strings.TrimSpace(cfg.PublicHost) != "",
 		},
 	})
+}
+
+// reportChannels returns the notification channels to offer in the report
+// channel picker. When a ReportChannelLister is registered (enterprise) it lists
+// the effective (hot-configured) enabled channels for the REQUEST org from the
+// masked runtime-channel view — the SAME source the alert-fatigue picker uses —
+// so the two pickers stay consistent. OSS registers none, so it falls back to
+// the static enabled channels from the global config (single-tenant behaviour
+// byte-for-byte unchanged).
+func (i *IncidentAdminController) reportChannels(c *fiber.Ctx) []string {
+	if l := reportChannelLister(); l != nil {
+		if channels := l.EnabledAlertChannels(c.UserContext(), middleware.OrgFromContext(c)); channels != nil {
+			return channels
+		}
+	}
+	return enabledAlertChannels(config.GetConfig())
+}
+
+// reportConfiguredDisabledChannels returns the channels that are configured (a
+// runtime override exists) but currently disabled for the REQUEST org, so they
+// are absent from reportChannels. When a ReportChannelLister is registered
+// (enterprise) it sources them from the masked runtime-channel view. OSS
+// registers none — community mode has no runtime-override concept — so this is
+// always an empty (non-nil) slice, serialized as [] not null.
+func (i *IncidentAdminController) reportConfiguredDisabledChannels(c *fiber.Ctx) []string {
+	if l := reportChannelLister(); l != nil {
+		if names := l.ConfiguredDisabledChannels(c.UserContext(), middleware.OrgFromContext(c)); names != nil {
+			return names
+		}
+	}
+	return []string{}
 }
 
 // enabledAlertChannels lists the notification channels currently enabled in

--- a/pkg/controllers/incidents_admin.go
+++ b/pkg/controllers/incidents_admin.go
@@ -263,7 +263,7 @@ func summarize(r *storage.IncidentRecord) fiber.Map {
 		"title":               r.Title,
 		"source":              r.Source,
 		"origin":              r.EffectiveOrigin(),
-		"service":             r.Service,
+		"service":             services.ServiceLabel(r),
 		"resolved":            r.Resolved,
 		"channels_notified":   r.ChannelsNotified,
 		"oncall_triggered":    r.OnCallTriggered,

--- a/pkg/controllers/incidents_admin_test.go
+++ b/pkg/controllers/incidents_admin_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
+	"github.com/VersusControl/versus-incident/pkg/config"
 	"github.com/VersusControl/versus-incident/pkg/services"
 	"github.com/VersusControl/versus-incident/pkg/storage"
 
@@ -77,9 +80,9 @@ func (s searcherStorage) SearchAnalyses(string, int) ([]*storage.AnalysisRecord,
 // memory backend (the same path file storage takes).
 func TestCapabilitiesReflectsSearcher(t *testing.T) {
 	t.Cleanup(func() { services.SetStorage(nil) })
-	// capabilities now reads config.GetConfig() for the report block, so the
-	// global config must exist (sync.Once-guarded; safe if a sibling test
-	// already loaded it).
+	// capabilities reads the global config for the report block, so the global
+	// config must exist (sync.Once-guarded; safe if a sibling test already
+	// loaded it).
 	loadGatewayConfig(t, "test-gateway-secret")
 
 	ctrl := NewIncidentAdminController()
@@ -111,6 +114,182 @@ func TestCapabilitiesReflectsSearcher(t *testing.T) {
 			}
 			if got.Search != tc.want {
 				t.Fatalf("search = %v, want %v", got.Search, tc.want)
+			}
+		})
+	}
+}
+
+// fakeReportChannelLister is a controllers.ReportChannelLister that returns a
+// fixed per-org channel list, standing in for the enterprise lister backed by
+// the runtime channel resolver's masked EffectiveEnabled view.
+type fakeReportChannelLister struct {
+	byOrg         map[string][]string
+	disabledByOrg map[string][]string
+}
+
+func (f fakeReportChannelLister) EnabledAlertChannels(_ context.Context, org string) []string {
+	return f.byOrg[org]
+}
+
+func (f fakeReportChannelLister) ConfiguredDisabledChannels(_ context.Context, org string) []string {
+	return f.disabledByOrg[org]
+}
+
+// TestCapabilitiesReportChannelsFallsBackToStatic proves that with NO lister
+// registered (community/OSS), report.channels is the static enabled-channel
+// list from the global config — single-tenant behaviour unchanged.
+func TestCapabilitiesReportChannelsFallsBackToStatic(t *testing.T) {
+	t.Cleanup(func() { services.SetStorage(nil) })
+	loadGatewayConfig(t, "test-gateway-secret")
+
+	// No lister registered: the handler must use enabledAlertChannels(GetConfig()).
+	SetReportChannelLister(nil)
+	services.SetStorage(storage.NewMemory())
+
+	ctrl := NewIncidentAdminController()
+	app := fiber.New()
+	app.Get("/cap", ctrl.capabilities)
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/cap", nil))
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var got struct {
+		Report struct {
+			Channels           []string `json:"channels"`
+			ConfiguredDisabled []string `json:"configured_disabled"`
+		} `json:"report"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", body, err)
+	}
+	want := enabledAlertChannels(config.GetConfig())
+	if len(got.Report.Channels) != len(want) {
+		t.Fatalf("report.channels = %v, want static %v", got.Report.Channels, want)
+	}
+	for idx := range want {
+		if got.Report.Channels[idx] != want[idx] {
+			t.Fatalf("report.channels = %v, want static %v", got.Report.Channels, want)
+		}
+	}
+	// No lister → community has no runtime-override concept, so
+	// configured_disabled is an empty, non-null slice.
+	if got.Report.ConfiguredDisabled == nil {
+		t.Fatalf("report.configured_disabled = null, want [] (non-nil)")
+	}
+	if len(got.Report.ConfiguredDisabled) != 0 {
+		t.Fatalf("report.configured_disabled = %v, want []", got.Report.ConfiguredDisabled)
+	}
+}
+
+// TestCapabilitiesReflectsRuntimeChannels proves the report channel picker is
+// built from the registered ReportChannelLister — the masked runtime-channel
+// view (the SAME source the alert-fatigue picker uses) — not the static YAML
+// config. With Slack disabled in the static floor but the lister reporting a
+// hot-configured Slack for the request org, report.channels must include
+// "slack", exactly as the alert-fatigue picker shows it.
+func TestCapabilitiesReflectsRuntimeChannels(t *testing.T) {
+	t.Cleanup(func() { services.SetStorage(nil) })
+	loadGatewayConfig(t, "test-gateway-secret")
+
+	// Static YAML floor: Slack disabled. Confirm the pre-condition so the test
+	// proves the lister — not a stale global — is what surfaces.
+	if config.GetConfig().Alert.Slack.Enable {
+		t.Skip("static config unexpectedly has Slack enabled; cannot prove override")
+	}
+
+	// The request org is the default org (no OrgInjector mounted on this app).
+	SetReportChannelLister(fakeReportChannelLister{
+		byOrg:         map[string][]string{storage.DefaultOrgID: {"slack", "email"}},
+		disabledByOrg: map[string][]string{storage.DefaultOrgID: {"telegram"}},
+	})
+	t.Cleanup(func() { SetReportChannelLister(nil) })
+
+	services.SetStorage(storage.NewMemory())
+
+	ctrl := NewIncidentAdminController()
+	app := fiber.New()
+	app.Get("/cap", ctrl.capabilities)
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/cap", nil))
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var got struct {
+		Report struct {
+			Channels           []string `json:"channels"`
+			ConfiguredDisabled []string `json:"configured_disabled"`
+		} `json:"report"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", body, err)
+	}
+	found := false
+	for _, ch := range got.Report.Channels {
+		if ch == "slack" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("report.channels = %v, want it to include the hot-configured \"slack\"", got.Report.Channels)
+	}
+	// The lister's configured-but-disabled list is echoed verbatim into
+	// report.configured_disabled.
+	if len(got.Report.ConfiguredDisabled) != 1 || got.Report.ConfiguredDisabled[0] != "telegram" {
+		t.Fatalf("report.configured_disabled = %v, want [telegram]", got.Report.ConfiguredDisabled)
+	}
+}
+
+// TestEnabledAlertChannelsFromResolvedConfig is a table test proving
+// enabledAlertChannels reflects whatever effective config it is handed —
+// including a runtime-resolved one — in a stable order.
+func TestEnabledAlertChannelsFromResolvedConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *config.Config
+		want []string
+	}{
+		{
+			name: "none enabled",
+			cfg:  &config.Config{},
+			want: []string{},
+		},
+		{
+			name: "runtime-enabled slack surfaces",
+			cfg: func() *config.Config {
+				c := &config.Config{}
+				c.Alert.Slack.Enable = true
+				return c
+			}(),
+			want: []string{"slack"},
+		},
+		{
+			name: "multiple channels in stable order",
+			cfg: func() *config.Config {
+				c := &config.Config{}
+				c.Alert.Slack.Enable = true
+				c.Alert.Email.Enable = true
+				c.Alert.Lark.Enable = true
+				return c
+			}(),
+			want: []string{"slack", "email", "lark"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := enabledAlertChannels(tc.cfg)
+			if len(got) != len(tc.want) {
+				t.Fatalf("channels = %v, want %v", got, tc.want)
+			}
+			for idx := range tc.want {
+				if got[idx] != tc.want[idx] {
+					t.Fatalf("channels = %v, want %v", got, tc.want)
+				}
 			}
 		})
 	}

--- a/pkg/controllers/report_channels.go
+++ b/pkg/controllers/report_channels.go
@@ -1,0 +1,73 @@
+package controllers
+
+import (
+	"context"
+	"sync"
+)
+
+// report_channels.go — the single-slot, process-wide report channel-lister seam.
+//
+// The incident-report channel picker (capabilities.report.channels) must offer
+// exactly the notification channels an operator can actually target, INCLUDING
+// channels configured at runtime (the admin-page "Alert channels" hot-config),
+// not just the ones enabled in the static YAML `alert.*` floor.
+//
+// LISTING a runtime channel is a different job from RESOLVING it for a send:
+// listing must never open a channel's sealed secret and must key off the
+// REQUEST org. A consumer registers a lister that reports the effective enabled
+// channels from the masked runtime view (the same source the alert-fatigue
+// picker uses), so the two pickers stay consistent. OSS registers none, so the
+// capabilities handler falls back to the static enabled-channel list and
+// single-tenant behaviour is byte-for-byte unchanged.
+//
+// It is the direct sibling of config.AlertConfigResolver / SetAlertConfigResolver:
+// one process-wide slot, registered once at boot, mutex-guarded.
+
+// ReportChannelLister lists the notification channels to offer in the incident
+// report channel picker for the request's org.
+//
+// Contract:
+//   - EnabledAlertChannels returns the channel names (e.g. "slack", "telegram")
+//     to offer for org, in a stable order. It MUST reflect the effective enable
+//     (runtime override overlaid on the YAML floor) without opening any channel
+//     secret — listing never decrypts.
+//   - ConfiguredDisabledChannels returns the channel names that are configured
+//     (a runtime override exists) but currently disabled, so NOT in
+//     EnabledAlertChannels, in a stable order. It lets the report UI tell the
+//     operator a channel is set up but turned OFF, instead of silently omitting
+//     it. Same no-decrypt, REQUEST-org rule as EnabledAlertChannels.
+//   - org is the REQUEST org (middleware.OrgFromContext), never a boot-pinned or
+//     caller-supplied value; ctx carries the request context.
+//   - Both methods return a non-nil (possibly empty) slice.
+type ReportChannelLister interface {
+	EnabledAlertChannels(ctx context.Context, org string) []string
+	ConfiguredDisabledChannels(ctx context.Context, org string) []string
+}
+
+// Process-wide single slot. A consumer registers a lister at boot; the
+// capabilities handler reads it once per request. Mutex-guarded so a boot-time
+// registration is safely visible to the HTTP handler goroutines.
+var (
+	reportChannelListerMu   sync.Mutex
+	reportChannelListerSlot ReportChannelLister
+)
+
+// SetReportChannelLister registers the lister the report channel picker consults
+// for its offered-channel list. Last-wins: a second call replaces the first.
+// Passing nil clears the slot (back to the static enabled-channel fallback). OSS
+// ships none, so the picker uses the static `alert.*` enabled list unchanged.
+// This is the entry point the enterprise wiring attaches to (mirror of
+// config.SetAlertConfigResolver). Call at boot.
+func SetReportChannelLister(l ReportChannelLister) {
+	reportChannelListerMu.Lock()
+	defer reportChannelListerMu.Unlock()
+	reportChannelListerSlot = l
+}
+
+// reportChannelLister returns the registered lister, or nil when none is set
+// (community mode).
+func reportChannelLister() ReportChannelLister {
+	reportChannelListerMu.Lock()
+	defer reportChannelListerMu.Unlock()
+	return reportChannelListerSlot
+}

--- a/pkg/core/report.go
+++ b/pkg/core/report.go
@@ -59,6 +59,11 @@ type ReportModel struct {
 	// the wall-clock zone. Empty is treated as "UTC".
 	TZLabel string
 
+	// Title is the header/caption heading. It is operator-configurable via
+	// the report settings; an empty value is treated as "Incident report" so a
+	// directly-constructed model still renders a title.
+	Title string
+
 	// Headline stats.
 	Total        int            // incidents in the window
 	ByOrigin     map[string]int // ai_detect / webhook counts (primary category axis)

--- a/pkg/report/renderer.go
+++ b/pkg/report/renderer.go
@@ -64,7 +64,11 @@ var (
 	colText      = color.RGBA{0xe2, 0xe8, 0xf0, 0xff} // slate-200
 	colTextMuted = color.RGBA{0x94, 0xa3, 0xb8, 0xff} // slate-400
 	colTextFaint = color.RGBA{0x64, 0x74, 0x8b, 0xff} // slate-500
-	colAccent    = color.RGBA{0x38, 0xbd, 0xf8, 0xff} // sky-400 (ai-detect series)
+
+	// Trend-series colors — two distinct, vibrant hues so the stacked
+	// AI-detect / Webhook bars are easy to tell apart on the slate-800 panel.
+	colSeriesAI      = color.RGBA{0x81, 0x8c, 0xf8, 0xff} // violet-400 (AI-detect series)
+	colSeriesWebhook = color.RGBA{0x34, 0xd3, 0x99, 0xff} // emerald-400 (Webhook series)
 )
 
 // severityColor maps a severity label (any case) to its accent color. The
@@ -178,7 +182,11 @@ func (r *Renderer) Render(ctx context.Context, m core.ReportModel) (*core.Report
 
 	// ---- Header ------------------------------------------------------
 	y := padding + 30
-	drawString(img, fc.title, colText, padding, y, "Incident report")
+	title := strings.TrimSpace(m.Title)
+	if title == "" {
+		title = "Incident report"
+	}
+	drawString(img, fc.title, colText, padding, y, title)
 	y += 30
 	sub := fmt.Sprintf("%s → %s %s", fmtTime(m.WindowStart), fmtTime(m.WindowEnd), tzLabelOf(m))
 	drawString(img, fc.body, colTextMuted, padding, y, sub)
@@ -194,15 +202,18 @@ func (r *Renderer) Render(ctx context.Context, m core.ReportModel) (*core.Report
 	tileW := (usable - 3*gap) / 4
 	ai := m.ByOrigin[reportOriginAIDetect]
 	wh := m.ByOrigin[reportOriginWebhook]
-	tiles := []struct{ label, value string }{
-		{"TOTAL", strconv.Itoa(m.Total)},
-		{"AI-DETECT / WEBHOOK", fmt.Sprintf("%d / %d", ai, wh)},
-		{"OPEN / RESOLVED", fmt.Sprintf("%d / %d", m.Open, m.Resolved)},
-		{"CRITICAL / HIGH", strconv.Itoa(m.CriticalHigh)},
+	tiles := []struct {
+		label, value string
+		valueCol     color.RGBA
+	}{
+		{"TOTAL", strconv.Itoa(m.Total), colText},
+		{"AI-DETECT / WEBHOOK", fmt.Sprintf("%d / %d", ai, wh), colText},
+		{"OPEN / RESOLVED", fmt.Sprintf("%d / %d", m.Open, m.Resolved), colText},
+		{"CRITICAL / HIGH", strconv.Itoa(m.CriticalHigh), accent},
 	}
 	for i, t := range tiles {
 		tx := padding + i*(tileW+gap)
-		drawStatTile(img, fc, tx, tileTop, tileW, tileH, t.label, t.value)
+		drawStatTile(img, fc, tx, tileTop, tileW, tileH, t.label, t.value, t.valueCol)
 	}
 	y = tileTop + tileH + 28
 
@@ -262,10 +273,11 @@ func (r *Renderer) Render(ctx context.Context, m core.ReportModel) (*core.Report
 }
 
 // drawStatTile draws one headline stat: a panel with a big value and a small
-// muted label beneath it.
-func drawStatTile(img *image.RGBA, fc *faces, x, y, w, h int, label, value string) {
+// muted label beneath it. valueCol colors the headline number so a key tile
+// (e.g. CRITICAL / HIGH) can pop in its severity accent.
+func drawStatTile(img *image.RGBA, fc *faces, x, y, w, h int, label, value string, valueCol color.RGBA) {
 	fillRect(img, x, y, x+w, y+h, colPanel)
-	drawString(img, fc.stat, colText, x+16, y+50, truncateToWidth(fc.stat, value, w-32))
+	drawString(img, fc.stat, valueCol, x+16, y+50, truncateToWidth(fc.stat, value, w-32))
 	drawString(img, fc.small, colTextMuted, x+16, y+h-16, truncateToWidth(fc.small, label, w-32))
 }
 
@@ -279,6 +291,7 @@ func drawTrendPanel(img *image.RGBA, fc *faces, x, y, w, h int, m core.ReportMod
 		unit = "per day"
 	}
 	drawString(img, fc.h2, colTextMuted, x, y+4, "TREND ("+unit+")")
+	drawTrendLegend(img, fc, x, y+4, x+w)
 	fillRect(img, x, y+16, x+w, y+h, colPanel)
 
 	plotTop := y + 30
@@ -325,21 +338,47 @@ func drawTrendPanel(img *image.RGBA, fc *faces, x, y, w, h int, m core.ReportMod
 		if total > 0 && bh < 2 {
 			bh = 2
 		}
-		// Stacked: webhook (neutral) at the base, ai-detect (accent) on top.
+		// Stacked: webhook (emerald) at the base, ai-detect (violet) on top.
 		whH := 0
 		if total > 0 {
 			whH = b.Webhook * bh / total
 		}
 		aiH := bh - whH
 		if whH > 0 {
-			fillRect(img, bx, plotBottom-whH, bx+barW, plotBottom, colTextFaint)
+			fillRect(img, bx, plotBottom-whH, bx+barW, plotBottom, colSeriesWebhook)
 		}
 		if aiH > 0 {
-			fillRect(img, bx, plotBottom-whH-aiH, bx+barW, plotBottom-whH, colAccent)
+			fillRect(img, bx, plotBottom-whH-aiH, bx+barW, plotBottom-whH, colSeriesAI)
 		}
 		if i%labelEvery == 0 {
 			drawString(img, fc.tiny, colTextFaint, bx, plotBottom+16, b.Label)
 		}
+	}
+}
+
+// drawTrendLegend draws a compact two-entry legend (AI-detect / Webhook)
+// right-aligned to the panel's right edge on the header row, each a small
+// filled square in the series color followed by the label in that same color.
+// Kept in fc.tiny and inside [x, right] so it never overlaps the title or bars.
+func drawTrendLegend(img *image.RGBA, fc *faces, _, baseline, right int) {
+	entries := []struct {
+		label string
+		col   color.RGBA
+	}{
+		{"AI-detect", colSeriesAI},
+		{"Webhook", colSeriesWebhook},
+	}
+	lx := right
+	// Lay out right-to-left so the pair hugs the panel's right edge.
+	for i := len(entries) - 1; i >= 0; i-- {
+		e := entries[i]
+		lw := textWidth(fc.tiny, e.label)
+		lx -= lw
+		drawString(img, fc.tiny, e.col, lx, baseline, e.label)
+		lx -= 6 // gap between swatch and label
+		lx -= 8 // swatch width
+		fillRect(img, lx, baseline-8, lx+8, baseline, e.col)
+		lx -= 14 // gap before the previous entry
 	}
 }
 
@@ -376,7 +415,7 @@ func drawSeverityPanel(img *image.RGBA, fc *faces, x, y, w, h int, m core.Report
 	}
 	for i, b := range rows {
 		ry := rowTop + i*rowGap
-		drawString(img, fc.small, colTextMuted, x+14, ry+4, b.Label)
+		drawString(img, fc.small, severityColor(b.Label), x+14, ry+4, b.Label)
 		bw := b.Count * barMax / maxCount
 		if b.Count > 0 && bw < 2 {
 			bw = 2

--- a/pkg/report/renderer_test.go
+++ b/pkg/report/renderer_test.go
@@ -3,6 +3,8 @@ package report
 import (
 	"bytes"
 	"context"
+	"image"
+	"image/color"
 	"image/png"
 	"testing"
 	"time"
@@ -184,6 +186,87 @@ func TestRenderer_ChartsToggle(t *testing.T) {
 	}
 }
 
+// TestRenderer_Title asserts the configured title flows into the drawn header:
+// a custom title changes the pixels versus the default, an empty title falls
+// back to the default (byte-identical to explicitly setting "Incident report"),
+// and every variant still renders a valid PNG of the right dimensions.
+func TestRenderer_Title(t *testing.T) {
+	r, err := NewRenderer()
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	def := fixedModel()
+	def.Title = "Incident report"
+	custom := fixedModel()
+	custom.Title = "Weekly Ops Digest"
+	blank := fixedModel()
+	blank.Title = ""
+
+	dImg, err := r.Render(context.Background(), def)
+	if err != nil {
+		t.Fatalf("render default title: %v", err)
+	}
+	cImg, err := r.Render(context.Background(), custom)
+	if err != nil {
+		t.Fatalf("render custom title: %v", err)
+	}
+	bImg, err := r.Render(context.Background(), blank)
+	if err != nil {
+		t.Fatalf("render blank title: %v", err)
+	}
+	// A custom title changes the header pixels.
+	if bytes.Equal(dImg.Data, cImg.Data) {
+		t.Fatal("custom title produced an identical image to the default")
+	}
+	// A blank title falls back to "Incident report" (identical to default).
+	if !bytes.Equal(dImg.Data, bImg.Data) {
+		t.Fatal("blank title did not fall back to the default header")
+	}
+	if _, err := png.Decode(bytes.NewReader(cImg.Data)); err != nil {
+		t.Fatalf("custom-title png.Decode: %v", err)
+	}
+}
+
+// TestWorstSeverityColor_PicksHighestNonEmptyBand proves the report accent
+// (and BY-SEVERITY bar tint) reflects the worst band that actually has
+// incidents, and only falls back to neutral slate for a genuinely empty
+// window. This is what turns the broadened severity extraction into a visibly
+// colored report.
+func TestWorstSeverityColor_PicksHighestNonEmptyBand(t *testing.T) {
+	slate := color.RGBA{0x64, 0x74, 0x8b, 0xff}
+
+	rows := []core.Bucket{
+		{Label: "critical", Count: 2},
+		{Label: "high", Count: 1},
+		{Label: "medium", Count: 0},
+		{Label: "low", Count: 0},
+		{Label: "unknown", Count: 0},
+	}
+	if got := worstSeverityColor(rows); got == slate {
+		t.Fatal("accent is slate for a window with critical incidents")
+	}
+	if got := worstSeverityColor(rows); got != severityColor("critical") {
+		t.Fatalf("accent = %v, want critical red", got)
+	}
+
+	// When only lower bands have incidents, the accent follows the worst one.
+	high := []core.Bucket{
+		{Label: "critical", Count: 0},
+		{Label: "high", Count: 3},
+		{Label: "medium", Count: 1},
+		{Label: "unknown", Count: 0},
+	}
+	if got := worstSeverityColor(high); got != severityColor("high") {
+		t.Fatalf("accent = %v, want high orange", got)
+	}
+
+	// A truly empty window stays slate.
+	empty := []core.Bucket{{Label: "critical", Count: 0}, {Label: "unknown", Count: 0}}
+	if got := worstSeverityColor(empty); got != slate {
+		t.Fatalf("empty-window accent = %v, want slate", got)
+	}
+}
+
 // TestRenderer_EmptyWindowNoPanic asserts an all-quiet window renders a valid
 // PNG rather than panicking on a divide-by-zero in the chart scaling.
 func TestRenderer_EmptyWindowNoPanic(t *testing.T) {
@@ -232,5 +315,104 @@ func TestRenderer_ContextCancelled(t *testing.T) {
 	cancel()
 	if _, err := r.Render(ctx, fixedModel()); err == nil {
 		t.Fatal("expected error on cancelled context")
+	}
+}
+
+// renderDecoded renders the model and returns the decoded image so a test can
+// inspect individual pixels.
+func renderDecoded(t *testing.T, m core.ReportModel) image.Image {
+	t.Helper()
+	r, err := NewRenderer()
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	img, err := r.Render(context.Background(), m)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	decoded, err := png.Decode(bytes.NewReader(img.Data))
+	if err != nil {
+		t.Fatalf("png.Decode: %v", err)
+	}
+	return decoded
+}
+
+// countColor tallies how many pixels in the image exactly match c.
+func countColor(img image.Image, c color.RGBA) int {
+	b := img.Bounds()
+	n := 0
+	for y := b.Min.Y; y < b.Max.Y; y++ {
+		for x := b.Min.X; x < b.Max.X; x++ {
+			r, g, bl, a := img.At(x, y).RGBA()
+			if uint8(r>>8) == c.R && uint8(g>>8) == c.G && uint8(bl>>8) == c.B && uint8(a>>8) == c.A {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// TestRenderer_TrendSeriesDistinctColors asserts the stacked trend bars render
+// the two origins in DIFFERENT, vibrant series colors (violet AI-detect on top
+// of emerald Webhook) rather than the old gray/sky pair — the customer's "all
+// charts look the same color" complaint.
+func TestRenderer_TrendSeriesDistinctColors(t *testing.T) {
+	if colSeriesAI == colSeriesWebhook {
+		t.Fatal("the two trend series must be distinct colors")
+	}
+	img := renderDecoded(t, fixedModel())
+
+	aiPixels := countColor(img, colSeriesAI)
+	whPixels := countColor(img, colSeriesWebhook)
+	if aiPixels == 0 {
+		t.Fatal("no AI-detect (violet) series pixels drawn")
+	}
+	if whPixels == 0 {
+		t.Fatal("no Webhook (emerald) series pixels drawn")
+	}
+
+	// The old palette used slate-500 (colTextFaint) for the webhook series and
+	// sky-400 (colAccent) for AI-detect inside the bars. Neither should now be
+	// the dominant series fill.
+	if countColor(img, colSeriesWebhook) < 4 {
+		t.Fatal("emerald webhook series is not rendered as bars")
+	}
+	if countColor(img, colSeriesAI) < 4 {
+		t.Fatal("violet AI-detect series is not rendered as bars")
+	}
+}
+
+// TestRenderer_CriticalHighTileUsesWorstSeverityColor asserts the CRITICAL /
+// HIGH headline tile renders its value in the worst-severity accent (matching
+// the top accent bar) so the key number pops, while a window whose worst band
+// changes moves that tile's color with it.
+func TestRenderer_CriticalHighTileUsesWorstSeverityColor(t *testing.T) {
+	// fixedModel has critical incidents → worst severity is red.
+	m := fixedModel()
+	worst := worstSeverityColor(m.BySeverity)
+	if worst != severityColor("critical") {
+		t.Fatalf("precondition: worst = %v, want critical red", worst)
+	}
+	img := renderDecoded(t, m)
+
+	// The stat value is drawn in fc.stat (34px bold) in the worst-severity
+	// color, so a healthy count of exactly-red pixels must exist.
+	if got := countColor(img, worst); got < 20 {
+		t.Fatalf("critical/high tile value not rendered in worst-severity color (matched %d px)", got)
+	}
+}
+
+// TestRenderer_SeverityLabelsTinted asserts each BY-SEVERITY row label is drawn
+// in its own severity color rather than a single muted slate, so the panel is
+// not monochrome.
+func TestRenderer_SeverityLabelsTinted(t *testing.T) {
+	img := renderDecoded(t, fixedModel())
+	// The critical label text is drawn in red; the high label in orange. At
+	// least one glyph pixel of each must be present.
+	if countColor(img, severityColor("critical")) < 20 {
+		t.Fatal("critical severity label not tinted red")
+	}
+	if countColor(img, severityColor("high")) < 4 {
+		t.Fatal("high severity label not tinted orange")
 	}
 }

--- a/pkg/services/emit_interceptor.go
+++ b/pkg/services/emit_interceptor.go
@@ -124,7 +124,7 @@ func filterProvidersByChannel(providers []core.AlertProvider, names []string) []
 // enterprise wrapper can reuse the exact same key as its own store key.
 func EmitFingerprint(content map[string]interface{}) string {
 	source := firstString(content, "source")
-	service := firstString(content, "servicename", "service", "service_name", "app", "component")
+	service := extractService(content)
 	pattern := firstString(content, "patternid", "pattern_id", "key")
 	severity := firstString(content, "severity")
 

--- a/pkg/services/incident.go
+++ b/pkg/services/incident.go
@@ -232,7 +232,7 @@ func buildIncidentRecord(incident *m.Incident, cfg *config.Config, content map[s
 		OrgID:           storage.DefaultOrgID,
 		TeamID:          incident.TeamID,
 		Title:           firstString(content, "title", "alertname", "summary", "subject", "name"),
-		Service:         firstString(content, "service", "service_name", "app", "component"),
+		Service:         extractService(content),
 		Source:          resolveSource(content, hint),
 		Origin:          origin,
 		Resolved:        resolved,
@@ -341,6 +341,16 @@ func firstString(content map[string]interface{}, keys ...string) string {
 		}
 	}
 	return ""
+}
+
+// extractService resolves the service label from a free-form content map.
+// It is the single shared key set for service attribution: the persisted
+// IncidentRecord.Service column, the report, and the emit fingerprint all
+// derive the service through here so they agree with what the incident detail
+// shows. firstString matches keys case-insensitively, so the one-word
+// ServiceName/servicename and the underscored service_name are all honoured.
+func extractService(content map[string]interface{}) string {
+	return firstString(content, "ServiceName", "Service", "service", "service_name", "servicename", "app", "component")
 }
 
 // isResolved checks if the alert is resolved by checking common status fields

--- a/pkg/services/incident_test.go
+++ b/pkg/services/incident_test.go
@@ -184,3 +184,81 @@ func TestBuildIncidentRecord_Origin(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildIncidentRecord_Service asserts the persisted Service column is
+// derived through the shared key set that the incident detail and report read,
+// so the incidents LIST (which renders the column) agrees with the DETAIL. The
+// regression was the one-word "ServiceName" key being omitted, leaving the
+// column blank while the detail showed a service.
+func TestBuildIncidentRecord_Service(t *testing.T) {
+	cfg := &config.Config{}
+
+	tests := []struct {
+		name    string
+		content map[string]interface{}
+		want    string
+	}{
+		{"one-word ServiceName only (the reported bug)", map[string]interface{}{"ServiceName": "checkout"}, "checkout"},
+		{"lowercased servicename", map[string]interface{}{"servicename": "billing"}, "billing"},
+		{"agent sets ServiceName and Service", map[string]interface{}{"ServiceName": "payments", "Service": "payments"}, "payments"},
+		{"underscored service_name", map[string]interface{}{"service_name": "orders"}, "orders"},
+		{"exact Service", map[string]interface{}{"Service": "web"}, "web"},
+		{"lower service", map[string]interface{}{"service": "api"}, "api"},
+		{"app fallback", map[string]interface{}{"app": "worker"}, "worker"},
+		{"component fallback", map[string]interface{}{"component": "scheduler"}, "scheduler"},
+		{"no service keys stays blank", map[string]interface{}{"title": "disk full"}, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inc := m.NewIncident("", &tc.content, false)
+			rec := buildIncidentRecord(inc, cfg, tc.content, false, "")
+			if rec.Service != tc.want {
+				t.Fatalf("Service = %q, want %q", rec.Service, tc.want)
+			}
+		})
+	}
+}
+
+// TestServiceLabel_ListEqualsDetail proves the list value (ServiceLabel) and
+// the detail value agree. The detail derives its service from content via
+// pickString(ServiceName, Service, service); ServiceLabel returns the durable
+// column when present and otherwise falls back to the same content, so a fresh
+// record and a LEGACY row (blank column, service only in content) both display
+// what the detail shows.
+func TestServiceLabel_ListEqualsDetail(t *testing.T) {
+	// detailService mirrors ui IncidentDetailPage's
+	// pickString(content, "ServiceName", "Service", "service").
+	detailService := func(content map[string]interface{}) string {
+		return firstString(content, "ServiceName", "Service", "service")
+	}
+
+	cfg := &config.Config{}
+	contents := []map[string]interface{}{
+		{"ServiceName": "checkout"}, // agent / detail key
+		{"ServiceName": "payments", "Service": "payments"},
+		{"Service": "web"},
+		{"service": "api"},
+	}
+	for _, content := range contents {
+		inc := m.NewIncident("", &content, false)
+		rec := buildIncidentRecord(inc, cfg, content, false, "")
+		if ServiceLabel(rec) != detailService(content) {
+			t.Fatalf("fresh record: list %q != detail %q (content %v)", ServiceLabel(rec), detailService(content), content)
+		}
+
+		// Legacy row: same content, but the column was persisted blank before
+		// the fix. ServiceLabel must fall back to content and match the detail.
+		legacy := &storage.IncidentRecord{Content: content}
+		if ServiceLabel(legacy) != detailService(content) {
+			t.Fatalf("legacy row: list %q != detail %q (content %v)", ServiceLabel(legacy), detailService(content), content)
+		}
+	}
+
+	// A durable column always wins over content for the list, so sorting /
+	// filtering that keys on the stored column is never regressed.
+	pinned := &storage.IncidentRecord{Service: "stored-svc", Content: map[string]interface{}{"ServiceName": "content-svc"}}
+	if got := ServiceLabel(pinned); got != "stored-svc" {
+		t.Fatalf("stored column must win: ServiceLabel = %q, want %q", got, "stored-svc")
+	}
+}

--- a/pkg/services/report.go
+++ b/pkg/services/report.go
@@ -271,7 +271,7 @@ func BuildAggregateReportModel(recs []*storage.IncidentRecord, window string, st
 		}
 
 		// Service tally (redacted label).
-		svcLabel := scrub(reportServiceName(rec))
+		svcLabel := scrub(ServiceLabel(rec))
 		if svcLabel == "" {
 			svcLabel = "unknown"
 		}
@@ -414,13 +414,19 @@ func reportSeverity(rec *storage.IncidentRecord) string {
 	return s
 }
 
-// reportServiceName resolves the service label for one record: the durable
-// Service field, else a best-effort pull from content.
-func reportServiceName(rec *storage.IncidentRecord) string {
+// ServiceLabel resolves a record's display service: the durable Service
+// column, else a best-effort pull from content using the shared key set. The
+// incidents list and the report both route through here so a legacy row whose
+// stored column predates the aligned key set still shows the same service the
+// detail derives from content.
+func ServiceLabel(rec *storage.IncidentRecord) string {
+	if rec == nil {
+		return ""
+	}
 	if rec.Service != "" {
 		return rec.Service
 	}
-	return contentString(rec.Content, "ServiceName", "Service", "service")
+	return extractService(rec.Content)
 }
 
 // reportTitle resolves a display title for one record when the durable Title

--- a/pkg/services/report.go
+++ b/pkg/services/report.go
@@ -156,17 +156,19 @@ func reportAllow(key string, perMinute int) bool {
 var severityBands = []string{"critical", "high", "medium", "low", "unknown"}
 
 // severityBand maps a free-form severity/verdict label to one of the fixed
-// bands. The unknown band catches webhook incidents with no severity so a
-// row is never dropped.
+// bands. The synonym set mirrors the UI's normalizeSeverity (severity.ts) so a
+// severity the UI shows colored never lands in the gray unknown band here. The
+// unknown band still catches webhook incidents with no severity so a row is
+// never dropped.
 func severityBand(s string) string {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "critical", "fatal", "emergency":
+	case "critical", "fatal", "emergency", "crit", "p1", "sev1":
 		return "critical"
-	case "high", "error", "err":
+	case "high", "error", "err", "major", "p2", "sev2":
 		return "high"
-	case "medium", "warning", "warn":
+	case "medium", "warning", "warn", "med", "p3", "sev3":
 		return "medium"
-	case "low", "info", "notice":
+	case "low", "info", "notice", "informational", "minor", "p4", "p5":
 		return "low"
 	default:
 		return "unknown"
@@ -405,13 +407,19 @@ func buildTrend(recs []*storage.IncidentRecord, start, end time.Time, unit strin
 }
 
 // reportSeverity extracts a best-effort severity for one record from its
-// content (Severity, then Verdict). Raw — the caller bands it.
+// content. It reads the SAME key set as the UI's severityFromContent
+// (severity.ts): the top-level Severity/severity/level/priority keys, then the
+// nested Alertmanager/Prometheus shape (content.labels.severity /
+// content.commonLabels.severity), before falling back to Verdict. Raw — the
+// caller bands it.
 func reportSeverity(rec *storage.IncidentRecord) string {
-	s := contentString(rec.Content, "Severity", "severity")
-	if s == "" {
-		s = contentString(rec.Content, "Verdict", "verdict")
+	if s := contentString(rec.Content, "Severity", "severity", "level", "priority"); s != "" {
+		return s
 	}
-	return s
+	if s := nestedContentString(rec.Content, "severity", "labels", "commonLabels"); s != "" {
+		return s
+	}
+	return contentString(rec.Content, "Verdict", "verdict")
 }
 
 // ServiceLabel resolves a record's display service: the durable Service
@@ -492,7 +500,9 @@ func buildWindowModel(st storage.Provider, scrubber core.Scrubber, settings Repo
 	if err != nil {
 		return core.ReportModel{}, err
 	}
-	return BuildAggregateReportModel(recs, window, start, end, unit, scrubber, settings.IncludeChart, loc), nil
+	model := BuildAggregateReportModel(recs, window, start, end, unit, scrubber, settings.IncludeChart, loc)
+	model.Title = settings.Title
+	return model, nil
 }
 
 func renderReport(ctx context.Context, cfg *config.Config, st storage.Provider, renderer core.ReportRenderer, scrubber core.Scrubber, window string) (*core.ReportImage, error) {
@@ -543,7 +553,14 @@ func sendReport(ctx context.Context, cfg *config.Config, st storage.Provider, re
 	// senders (Teams/Viber/Lark) cannot leak unredacted fields; the
 	// already-redacted caption is the only text that travels.
 	carrier := &m.Incident{ID: "report-" + window}
-	att := core.Attachment{Filename: img.Filename, MIME: img.MIME, Data: img.Data, Caption: caption}
+	// When charts are included the report is a visual dashboard: image-capable
+	// channels get the image with NO caption. With charts off, keep the image +
+	// redacted caption. The caption stays redacted either way (DLP unchanged).
+	attCaption := caption
+	if model.IncludeCharts {
+		attCaption = ""
+	}
+	att := core.Attachment{Filename: img.Filename, MIME: img.MIME, Data: img.Data, Caption: attCaption}
 
 	out := &ReportOutcome{Window: window, Failed: map[string]string{}, Bytes: len(img.Data)}
 	for _, p := range targets {
@@ -556,6 +573,9 @@ func sendReport(ctx context.Context, cfg *config.Config, st storage.Provider, re
 			continue
 		}
 		if ts, ok := p.(core.TextSender); ok {
+			// Text-only channels (Teams/Viber/Lark) cannot render an image, so
+			// they still get the redacted fallback text even when charts are on
+			// — otherwise they'd receive nothing.
 			if err := ts.SendText(carrier, fallbackText); err != nil {
 				out.Failed[p.Name()] = err.Error()
 			} else {
@@ -623,7 +643,12 @@ func resolveReportChannels(explicit, defaultChannel string) []string {
 // redacted aggregate ReportModel — never from raw content.
 func reportCaption(model core.ReportModel) string {
 	var b strings.Builder
-	b.WriteString("Incident report — ")
+	title := strings.TrimSpace(model.Title)
+	if title == "" {
+		title = defaultReportTitle
+	}
+	b.WriteString(title)
+	b.WriteString(" — ")
 	b.WriteString(windowLabel(model.Window))
 	b.WriteString(": ")
 	b.WriteString(fmt.Sprintf("%d incident", model.Total))
@@ -725,6 +750,37 @@ func contentString(content map[string]interface{}, keys ...string) string {
 	for _, k := range keys {
 		if v, ok := lower[strings.ToLower(k)]; ok {
 			if s, ok := v.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// nestedContentString digs one level into a nested map under any of the given
+// parent keys (case-insensitive) and returns the first non-empty string at
+// key. It matches the UI's severityFromContent handling of the
+// Alertmanager/Prometheus shape, where severity lives at
+// content.labels.severity / content.commonLabels.severity.
+func nestedContentString(content map[string]interface{}, key string, parents ...string) string {
+	if content == nil {
+		return ""
+	}
+	for _, p := range parents {
+		v, ok := content[p]
+		if !ok {
+			for ck, cv := range content {
+				if strings.EqualFold(ck, p) {
+					v, ok = cv, true
+					break
+				}
+			}
+		}
+		if !ok {
+			continue
+		}
+		if nested, ok := v.(map[string]interface{}); ok {
+			if s := contentString(nested, key); s != "" {
 				return s
 			}
 		}

--- a/pkg/services/report_test.go
+++ b/pkg/services/report_test.go
@@ -87,6 +87,80 @@ func rec(id, service, severity, origin, source string, resolved bool, created ti
 	}
 }
 
+// --- severity extraction + banding -----------------------------------------
+
+// TestReportSeverity_MatchesUIKeys proves the report reads the SAME rich key
+// set the UI's severityFromContent/normalizeSeverity (ui/src/lib/severity.ts)
+// reads, so a severity the UI shows colored never bands to gray "unknown" in
+// the report. A couple of the UI's own cases are mirrored here to keep the two
+// in sync.
+func TestReportSeverity_MatchesUIKeys(t *testing.T) {
+	cases := []struct {
+		name    string
+		content map[string]interface{}
+		want    string // banded
+	}{
+		// Alertmanager/Prometheus shape: severity only in nested labels.
+		{"nested labels.severity critical", map[string]interface{}{"labels": map[string]interface{}{"severity": "critical"}}, "critical"},
+		{"nested commonLabels.severity warning", map[string]interface{}{"commonLabels": map[string]interface{}{"severity": "warning"}}, "medium"},
+		// Extra top-level keys the UI reads.
+		{"priority P1", map[string]interface{}{"priority": "P1"}, "critical"},
+		{"level error", map[string]interface{}{"level": "error"}, "high"},
+		// Synonyms mirrored from normalizeSeverity.
+		{"sev2 -> high", map[string]interface{}{"Severity": "sev2"}, "high"},
+		{"crit -> critical", map[string]interface{}{"severity": "crit"}, "critical"},
+		{"minor -> low", map[string]interface{}{"severity": "minor"}, "low"},
+		{"p3 -> medium", map[string]interface{}{"priority": "p3"}, "medium"},
+		// Precedence: an explicit top-level key wins over nested labels.
+		{"top-level wins over nested", map[string]interface{}{"Severity": "info", "labels": map[string]interface{}{"severity": "critical"}}, "low"},
+		// Verdict remains the last-resort fallback.
+		{"verdict fallback", map[string]interface{}{"Verdict": "critical"}, "critical"},
+		// Truly-absent severity still bands to unknown (row is never dropped).
+		{"absent -> unknown", map[string]interface{}{"foo": "bar"}, "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &storage.IncidentRecord{Content: tc.content}
+			if got := severityBand(reportSeverity(r)); got != tc.want {
+				t.Fatalf("band = %q, want %q (raw severity %q)", got, tc.want, reportSeverity(r))
+			}
+		})
+	}
+}
+
+// TestBuildAggregateReportModel_NestedAndSynonymSeverities proves the assembled
+// model colors correctly: incidents whose severity lives ONLY in nested
+// labels, or under priority/level with a synonym value, land in their real
+// band instead of "unknown" — so BySeverity and the derived worst-severity
+// accent go red/orange, not slate.
+func TestBuildAggregateReportModel_NestedAndSynonymSeverities(t *testing.T) {
+	start := time.Date(2026, 8, 9, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	withContent := func(id string, content map[string]interface{}, created time.Time) *storage.IncidentRecord {
+		return &storage.IncidentRecord{
+			ID: id, Title: id + " title", Service: "payments",
+			Origin: storage.OriginWebhook, Source: "webhook", CreatedAt: created, Content: content,
+		}
+	}
+	recs := []*storage.IncidentRecord{
+		withContent("n1", map[string]interface{}{"labels": map[string]interface{}{"severity": "critical"}}, end.Add(-1*time.Hour)),
+		withContent("p1", map[string]interface{}{"priority": "P1"}, end.Add(-2*time.Hour)),
+		withContent("l1", map[string]interface{}{"level": "error"}, end.Add(-3*time.Hour)),
+	}
+
+	m := BuildAggregateReportModel(recs, "today", start, end, "hour", testScrubber(t), true, time.UTC)
+
+	want := map[string]int{"critical": 2, "high": 1, "medium": 0, "low": 0, "unknown": 0}
+	for _, b := range m.BySeverity {
+		if b.Count != want[b.Label] {
+			t.Fatalf("severity %q = %d, want %d (nested/synonym severities must not band to unknown)", b.Label, b.Count, want[b.Label])
+		}
+	}
+	if m.CriticalHigh != 3 {
+		t.Fatalf("criticalHigh = %d, want 3", m.CriticalHigh)
+	}
+}
+
 // --- window resolution -----------------------------------------------------
 
 func TestWindowBounds(t *testing.T) {
@@ -148,6 +222,47 @@ func TestWindowBoundsIn_TimezoneShiftsTodayStart(t *testing.T) {
 	}
 }
 
+// TestWindowBoundsIn_24hVsToday reproduces the customer's report at
+// 2026-08-10 15:00 in Asia/Ho_Chi_Minh: "24h" must be the rolling
+// now-24h → now range (2026-08-09 15:00 → 2026-08-10 15:00), while "today" is
+// local-midnight → now (2026-08-10 00:00 → 2026-08-10 15:00). Proving both in
+// a non-UTC location confirms the 24h computation is correct end-to-end, so a
+// "today"-looking render can only come from a "today" window being passed.
+func TestWindowBoundsIn_24hVsToday(t *testing.T) {
+	ict, err := time.LoadLocation("Asia/Ho_Chi_Minh")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	// 15:00 local on 2026-08-10 == 08:00 UTC (ICT is UTC+7).
+	now := time.Date(2026, 8, 10, 8, 0, 0, 0, time.UTC)
+
+	// 24h: rolling window, exactly 24h back from now.
+	start, end, unit := WindowBoundsIn("24h", now, ict)
+	wantStart := time.Date(2026, 8, 9, 15, 0, 0, 0, ict)
+	wantEnd := time.Date(2026, 8, 10, 15, 0, 0, 0, ict)
+	if !start.In(ict).Equal(wantStart) {
+		t.Fatalf("24h start = %v, want %v (now-24h)", start.In(ict), wantStart)
+	}
+	if !end.In(ict).Equal(wantEnd) || unit != "hour" {
+		t.Fatalf("24h end=%v unit=%q, want %v hour", end.In(ict), unit, wantEnd)
+	}
+
+	// today: local midnight → now, which is where the customer's observed
+	// range comes from.
+	tStart, tEnd, _ := WindowBoundsIn("today", now, ict)
+	if !tStart.In(ict).Equal(time.Date(2026, 8, 10, 0, 0, 0, 0, ict)) {
+		t.Fatalf("today start = %v, want local midnight 2026-08-10 00:00", tStart.In(ict))
+	}
+	if !tEnd.In(ict).Equal(wantEnd) {
+		t.Fatalf("today end = %v, want %v (now)", tEnd.In(ict), wantEnd)
+	}
+	// The two windows must be genuinely different: only "today" starts at
+	// midnight, so a midnight-start render means window=today was used.
+	if start.Equal(tStart) {
+		t.Fatal("24h and today must have different starts; 24h must not start at local midnight")
+	}
+}
+
 // TestBuildAggregateReportModel_TimezoneRendering asserts the SAME window
 // renders its timestamps + caption in the configured timezone: UTC keeps the
 // "… UTC" label byte-for-byte, while a non-UTC location shifts the printed
@@ -186,6 +301,35 @@ func TestBuildAggregateReportModel_TimezoneRendering(t *testing.T) {
 	// Both models describe the same instant — only the printed zone differs.
 	if !utcModel.WindowEnd.Equal(ictModel.WindowEnd) {
 		t.Fatal("UTC and ICT models must describe the same window-end instant")
+	}
+}
+
+// TestReportCaption_UsesConfiguredTitle: the caption leads with the model's
+// configured title, and falls back to "Incident report" when it is blank so a
+// directly-constructed model still reads sensibly.
+func TestReportCaption_UsesConfiguredTitle(t *testing.T) {
+	m := core.ReportModel{Window: "today", Title: "Weekly Ops Digest",
+		ByOrigin: map[string]int{"ai_detect": 0, "webhook": 0}}
+	if cap := reportCaption(m); !strings.HasPrefix(cap, "Weekly Ops Digest — ") {
+		t.Fatalf("caption did not lead with configured title: %q", cap)
+	}
+	m.Title = ""
+	if cap := reportCaption(m); !strings.HasPrefix(cap, "Incident report — ") {
+		t.Fatalf("blank title did not fall back to default: %q", cap)
+	}
+}
+
+// TestBuildWindowModel_CarriesConfiguredTitle: the settings Title flows onto
+// the built model so the renderer and caption draw it.
+func TestBuildWindowModel_CarriesConfiguredTitle(t *testing.T) {
+	st := windowStore(t)
+	model, err := buildWindowModel(st, testScrubber(t),
+		ReportSettings{Enable: true, IncludeChart: true, Title: "Weekly Ops Digest"}, "24h")
+	if err != nil {
+		t.Fatalf("buildWindowModel: %v", err)
+	}
+	if model.Title != "Weekly Ops Digest" {
+		t.Fatalf("model.Title = %q, want \"Weekly Ops Digest\"", model.Title)
 	}
 }
 
@@ -413,7 +557,8 @@ func windowStore(t *testing.T) storage.Provider {
 
 func TestSendReport_ImageChannelUploadsPNGWithCaption(t *testing.T) {
 	st := windowStore(t)
-	enableReport(t, st, ReportSettings{Enable: true, IncludeChart: true, DefaultWindow: "24h"})
+	// Charts OFF → the image travels WITH the redacted caption.
+	enableReport(t, st, ReportSettings{Enable: true, IncludeChart: false, DefaultWindow: "24h"})
 	slack := &fakeImageProvider{name: "slack"}
 
 	out, err := sendReport(context.Background(), &config.Config{}, st, fakeRenderer{}, testScrubber(t),
@@ -435,6 +580,42 @@ func TestSendReport_ImageChannelUploadsPNGWithCaption(t *testing.T) {
 	}
 	if !strings.Contains(slack.gotAtt.Caption, "2 incidents") {
 		t.Fatalf("caption missing count: %q", slack.gotAtt.Caption)
+	}
+}
+
+// TestSendReport_ChartsOn_ImageOnlyNoCaption: when charts are included the
+// report is a visual dashboard, so image-capable channels get the PNG with an
+// EMPTY caption. Text-only channels cannot render an image, so they still get
+// the redacted fallback text.
+func TestSendReport_ChartsOn_ImageOnlyNoCaption(t *testing.T) {
+	st := windowStore(t)
+	enableReport(t, st, ReportSettings{Enable: true, IncludeChart: true, DefaultWindow: "24h"})
+
+	// Image-capable channel: PNG with an EMPTY caption.
+	slack := &fakeImageProvider{name: "slack"}
+	if _, err := sendReport(context.Background(), &config.Config{}, st, fakeRenderer{}, testScrubber(t),
+		[]core.AlertProvider{slack}, ReportSendOptions{Window: "24h", Channel: "slack"}); err != nil {
+		t.Fatalf("sendReport (image): %v", err)
+	}
+	if !slack.called || string(slack.gotAtt.Data) != "PNGDATA" {
+		t.Fatalf("slack did not receive the PNG: %+v", slack)
+	}
+	if slack.gotAtt.Caption != "" {
+		t.Fatalf("charts-on caption must be empty (image only), got %q", slack.gotAtt.Caption)
+	}
+
+	// Text-only channel still gets the fallback (never silently dropped).
+	teams := &fakeTextProvider{name: "msteams"}
+	out, err := sendReport(context.Background(), &config.Config{}, st, fakeRenderer{}, testScrubber(t),
+		[]core.AlertProvider{teams}, ReportSendOptions{Window: "24h", Channel: "msteams"})
+	if err != nil {
+		t.Fatalf("sendReport (text): %v", err)
+	}
+	if !teams.called || teams.gotText == "" {
+		t.Fatalf("text-only channel must still receive the fallback: %+v", teams)
+	}
+	if len(out.Fallback) != 1 || out.Fallback[0] != "msteams" {
+		t.Fatalf("fallback = %v, want [msteams]", out.Fallback)
 	}
 }
 

--- a/pkg/services/reportsettings.go
+++ b/pkg/services/reportsettings.go
@@ -45,6 +45,14 @@ const (
 	defaultTimezone = "UTC"
 )
 
+// defaultReportTitle is the header/caption title applied when the store holds
+// no value. maxReportTitleRunes bounds an operator-supplied title so a runaway
+// value can't break the rendered header.
+const (
+	defaultReportTitle  = "Incident report"
+	maxReportTitleRunes = 80
+)
+
 // sendTimeRe matches a 24-hour "HH:MM" wall-clock time (00:00–23:59). It is
 // the single source of truth for the scheduler send-time format, shared by the
 // admin PUT validator (ValidSendTime) and the due-check parser (parseSendTime).
@@ -59,6 +67,10 @@ type ReportSettings struct {
 	IncludeChart   bool   `json:"include_chart"`
 	RatePerMinute  int    `json:"rate_per_minute"`
 	DefaultWindow  string `json:"default_window"`
+	// Title is the operator-configurable heading drawn in the report image
+	// header and used in the channel caption. Default "Incident report";
+	// trimmed, defaulted when blank, and length-bounded server-side.
+	Title string `json:"title"`
 	// ScheduleEnabled turns on the recurring daily digest: when Enable AND
 	// ScheduleEnabled are both true, the report is sent once per local day at
 	// SendTime in Timezone, over DefaultWindow to DefaultChannel. Default
@@ -87,6 +99,7 @@ func DefaultReportSettings() ReportSettings {
 		IncludeChart:    true,
 		RatePerMinute:   6,
 		DefaultWindow:   reportWindowToday,
+		Title:           defaultReportTitle,
 		ScheduleEnabled: false,
 		SendTime:        defaultSendTime,
 		Timezone:        defaultTimezone,
@@ -116,6 +129,13 @@ func (s ReportSettings) sanitize() ReportSettings {
 	s.DefaultWindow = normalizeReportWindow(s.DefaultWindow)
 	if s.RatePerMinute < 0 {
 		s.RatePerMinute = 0
+	}
+	s.Title = strings.TrimSpace(s.Title)
+	if s.Title == "" {
+		s.Title = defaultReportTitle
+	}
+	if r := []rune(s.Title); len(r) > maxReportTitleRunes {
+		s.Title = string(r[:maxReportTitleRunes])
 	}
 	s.SendTime = strings.TrimSpace(s.SendTime)
 	if s.SendTime == "" {

--- a/pkg/services/reportsettings_test.go
+++ b/pkg/services/reportsettings_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -20,6 +21,9 @@ func TestReportSettings_DefaultsWhenAbsent(t *testing.T) {
 	for _, got := range []ReportSettings{LoadReportSettings(nil), LoadReportSettings(storage.NewMemory())} {
 		if got.ScheduleEnabled || got.SendTime != "09:00" || got.Timezone != "UTC" {
 			t.Fatalf("scheduler defaults = %+v, want off/09:00/UTC", got)
+		}
+		if got.Title != "Incident report" {
+			t.Fatalf("default title = %q, want \"Incident report\"", got.Title)
 		}
 	}
 }
@@ -41,6 +45,12 @@ func TestReportSettings_SaveLoadRoundTrip(t *testing.T) {
 	}
 }
 
+func TestDefaultReportSettings_Title(t *testing.T) {
+	if got := DefaultReportSettings().Title; got != "Incident report" {
+		t.Fatalf("DefaultReportSettings().Title = %q, want \"Incident report\"", got)
+	}
+}
+
 func TestReportSettings_Sanitize(t *testing.T) {
 	st := storage.NewMemory()
 	// A bogus window is normalized to today; a negative rate is clamped to 0.
@@ -57,6 +67,29 @@ func TestReportSettings_Sanitize(t *testing.T) {
 	// Empty send-time/timezone fall back to the built-in defaults.
 	if got.SendTime != "09:00" || got.Timezone != "UTC" {
 		t.Fatalf("empty send_time/timezone not defaulted: %+v", got)
+	}
+	// A blank title defaults to "Incident report".
+	if got.Title != "Incident report" {
+		t.Fatalf("blank title not defaulted: %q", got.Title)
+	}
+}
+
+func TestReportSettings_Sanitize_TitleTrimAndClamp(t *testing.T) {
+	st := storage.NewMemory()
+	// A padded title is trimmed.
+	if err := SaveReportSettings(st, ReportSettings{Enable: true, Title: "  Weekly Ops Digest  "}); err != nil {
+		t.Fatalf("SaveReportSettings: %v", err)
+	}
+	if got := LoadReportSettings(st); got.Title != "Weekly Ops Digest" {
+		t.Fatalf("title not trimmed: %q", got.Title)
+	}
+	// An over-long title is clamped to 80 runes.
+	long := strings.Repeat("x", 200)
+	if err := SaveReportSettings(st, ReportSettings{Enable: true, Title: long}); err != nil {
+		t.Fatalf("SaveReportSettings: %v", err)
+	}
+	if got := LoadReportSettings(st); len([]rune(got.Title)) != 80 {
+		t.Fatalf("over-long title not clamped: %d runes", len([]rune(got.Title)))
 	}
 }
 

--- a/ui/src/components/AgentChannelsSettingsControl.test.tsx
+++ b/ui/src/components/AgentChannelsSettingsControl.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ToastProvider } from "@/components/Toast";
+import { AgentChannelsSettingsControl } from "@/components/AgentChannelsSettingsControl";
+import type { ChannelSettingsMap, ChannelSettingsView } from "@/lib/api";
+import { CHANNELS } from "@/lib/agentChannels";
+
+// Gate the control straight to the admin controls so the channel cards render.
+vi.mock("@/lib/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({
+    org: "acme",
+    enterprise: true,
+    role: "admin",
+    isAdmin: true,
+    hasSession: true,
+    loading: false,
+    session: {},
+  }),
+}));
+
+vi.mock("@/lib/api", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getChannelSettings: vi.fn(),
+      setChannelSettings: vi.fn(),
+    },
+  };
+});
+
+import { api } from "@/lib/api";
+
+const view = (enabled: boolean): ChannelSettingsView => ({
+  enabled,
+  configured: false,
+  source: "yaml",
+  yaml_enabled: enabled,
+  fields: {},
+});
+
+const channelMap = (slackEnabled: boolean): ChannelSettingsMap =>
+  Object.fromEntries(
+    CHANNELS.map((c) => [c, view(c === "slack" ? slackEnabled : false)]),
+  );
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderControl() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={qc}>
+      <ToastProvider>
+        <AgentChannelsSettingsControl />
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AgentChannelsSettingsControl — prominent enable toggle", () => {
+  it("renders the enable switch and reflects the loaded OFF state", async () => {
+    vi.mocked(api.getChannelSettings).mockResolvedValue(channelMap(false));
+    renderControl();
+
+    const toggle = await screen.findByTestId("channel-enable-toggle-slack");
+    expect(toggle.getAttribute("role")).toBe("switch");
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect(
+      screen.getByTestId("channel-enable-state-slack").textContent,
+    ).toBe("Disabled");
+  });
+
+  it("reflects the loaded ON state", async () => {
+    vi.mocked(api.getChannelSettings).mockResolvedValue(channelMap(true));
+    renderControl();
+
+    const toggle = await screen.findByTestId("channel-enable-toggle-slack");
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+    expect(
+      screen.getByTestId("channel-enable-state-slack").textContent,
+    ).toBe("Enabled");
+  });
+
+  it("toggles state on click and saves the new enable value", async () => {
+    vi.mocked(api.getChannelSettings).mockResolvedValue(channelMap(false));
+    vi.mocked(api.setChannelSettings).mockResolvedValue(channelMap(true));
+    renderControl();
+
+    const toggle = await screen.findByTestId("channel-enable-toggle-slack");
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+    expect(
+      screen.getByTestId("channel-enable-state-slack").textContent,
+    ).toBe("Enabled");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(api.setChannelSettings).toHaveBeenCalledWith(
+        "slack",
+        expect.objectContaining({ enable: true }),
+      ),
+    );
+  });
+});

--- a/ui/src/components/AgentChannelsSettingsControl.tsx
+++ b/ui/src/components/AgentChannelsSettingsControl.tsx
@@ -143,6 +143,10 @@ export function AgentChannelsSettingsControl() {
 
   const invalidate = () => {
     qc.invalidateQueries({ queryKey: ["agent-channel-settings"] });
+    // Enabling/disabling a channel changes capabilities.report.channels, which
+    // drives the incident-report channel picker (and report-action gating).
+    // Invalidate it so the picker refreshes without a hard reload.
+    qc.invalidateQueries({ queryKey: ["capabilities"] });
   };
 
   return (
@@ -296,7 +300,52 @@ function ChannelCard({
 
   return (
     <div className="rounded-control border border-ink-600/60 bg-ink-700/30 p-3">
-      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+      <div
+        className="mb-3 flex flex-wrap items-start gap-3 rounded-control border border-ink-600/60 bg-ink-700/50 p-2.5"
+        data-testid={`channel-enable-control-${channel}`}
+      >
+        <button
+          type="button"
+          role="switch"
+          aria-checked={enabled}
+          aria-label={`Enable ${channelLabel(channel)} channel`}
+          disabled={busy}
+          data-testid={`channel-enable-toggle-${channel}`}
+          onClick={() => setEnabled((v) => !v)}
+          className={clsx(
+            "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition",
+            enabled ? "bg-link" : "bg-ink-600",
+            busy && "opacity-70",
+          )}
+        >
+          <span
+            className={clsx(
+              "inline-block h-4 w-4 transform rounded-full bg-white transition",
+              enabled ? "translate-x-4" : "translate-x-0.5",
+            )}
+          />
+        </button>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-xs font-semibold text-ink-100">
+            Enable this channel
+            <span
+              data-testid={`channel-enable-state-${channel}`}
+              className={clsx(
+                "rounded-full px-1.5 py-0.5 text-2xs font-medium",
+                enabled ? "bg-link/20 text-link" : "bg-ink-600 text-ink-300",
+              )}
+            >
+              {enabled ? "Enabled" : "Disabled"}
+            </span>
+          </div>
+          <div className="text-2xs text-ink-400">
+            Off = configured but not used; the channel won't receive alerts or
+            reports.
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-2 flex flex-wrap items-center gap-2">
         <div className="flex items-center gap-2">
           <ChannelIcon id={channel} size={14} />
           <span className="text-sm font-medium text-ink-100">
@@ -304,16 +353,6 @@ function ChannelCard({
           </span>
           <ProvenanceChip source={view?.source ?? "yaml"} />
         </div>
-        <label className="flex cursor-pointer items-center gap-2 text-xs text-ink-200">
-          <input
-            type="checkbox"
-            checked={enabled}
-            disabled={busy}
-            onChange={(e) => setEnabled(e.target.checked)}
-            className="h-4 w-4 accent-link"
-          />
-          Enable
-        </label>
       </div>
 
       <div className="grid gap-2 sm:grid-cols-2">

--- a/ui/src/components/Dropdown.tsx
+++ b/ui/src/components/Dropdown.tsx
@@ -125,7 +125,7 @@ export function Dropdown({
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-label={ariaLabel}
-        className="input flex w-full items-center justify-between gap-2 text-left disabled:cursor-not-allowed disabled:opacity-60"
+        className="input flex w-full items-center justify-between gap-2 pr-2.5 text-left disabled:cursor-not-allowed disabled:opacity-60"
         onClick={() => !disabled && setOpen((o) => !o)}
         onKeyDown={onButtonKeyDown}
       >

--- a/ui/src/components/ReportSettingsControl.test.tsx
+++ b/ui/src/components/ReportSettingsControl.test.tsx
@@ -36,6 +36,7 @@ afterEach(() => {
 function settings(over: Partial<ReportSettings> = {}): ReportSettings {
   return {
     enable: true,
+    title: "Incident report",
     default_channel: "",
     include_chart: true,
     rate_per_minute: 0,
@@ -149,5 +150,42 @@ describe("ReportSettingsControl — scheduled delivery", () => {
     expect(
       await screen.findByText(/inactive until the incidents report is enabled/),
     ).toBeTruthy();
+  });
+});
+
+describe("ReportSettingsControl — report title", () => {
+  beforeEach(() => {
+    vi.mocked(api.capabilities).mockResolvedValue(caps);
+    vi.mocked(api.updateReportSettings).mockImplementation((s) =>
+      Promise.resolve(s),
+    );
+  });
+
+  it("renders the title input with the loaded value", async () => {
+    vi.mocked(api.getReportSettings).mockResolvedValue(
+      settings({ title: "Weekly ops report" }),
+    );
+    renderControl();
+
+    const title = (await screen.findByTestId(
+      "report-title",
+    )) as HTMLInputElement;
+    expect(title.value).toBe("Weekly ops report");
+  });
+
+  it("saves an edited title, trimmed", async () => {
+    vi.mocked(api.getReportSettings).mockResolvedValue(settings());
+    renderControl();
+
+    const title = (await screen.findByTestId(
+      "report-title",
+    )) as HTMLInputElement;
+    fireEvent.change(title, { target: { value: "  Prod incidents  " } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(api.updateReportSettings).toHaveBeenCalled());
+    expect(vi.mocked(api.updateReportSettings).mock.calls[0][0]).toMatchObject({
+      title: "Prod incidents",
+    });
   });
 });

--- a/ui/src/components/ReportSettingsControl.tsx
+++ b/ui/src/components/ReportSettingsControl.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Loader2 } from "lucide-react";
+import { Info, Loader2 } from "lucide-react";
 import { api, type ReportSettings } from "@/lib/api";
-import { REPORT_WINDOWS } from "@/lib/reportAnalytics";
+import { configuredDisabledHint, REPORT_WINDOWS } from "@/lib/reportAnalytics";
 import {
   detectLocalZone,
   resolveTimezone,
@@ -83,6 +83,7 @@ export function ReportSettingsControl() {
   }
 
   const channels = cap.data?.report?.channels ?? [];
+  const disabledHint = configuredDisabledHint(cap.data);
   const set = <K extends keyof ReportSettings>(key: K, value: ReportSettings[K]) =>
     setForm((f) => (f ? { ...f, [key]: value } : f));
 
@@ -118,6 +119,25 @@ export function ReportSettingsControl() {
       </label>
 
       <div>
+        <label className="field-label" htmlFor="rs-title">
+          Report title
+        </label>
+        <input
+          id="rs-title"
+          type="text"
+          data-testid="report-title"
+          className="input"
+          maxLength={80}
+          placeholder="Incident report"
+          value={form.title}
+          onChange={(e) => set("title", e.target.value)}
+        />
+        <p className="mt-1 text-2xs text-ink-400">
+          The title shown on the report image, e.g. "Incident report".
+        </p>
+      </div>
+
+      <div>
         <label className="field-label" htmlFor="rs-default-channel">
           Default channel
         </label>
@@ -142,6 +162,15 @@ export function ReportSettingsControl() {
               </option>
             )}
         </select>
+        {disabledHint && (
+          <p
+            data-testid="report-configured-disabled-hint"
+            className="mt-1 flex items-start gap-1.5 text-2xs text-ink-400"
+          >
+            <Info size={12} className="mt-0.5 shrink-0" aria-hidden />
+            {disabledHint}
+          </p>
+        )}
       </div>
 
       <div>
@@ -274,7 +303,7 @@ export function ReportSettingsControl() {
         <button
           className="btn btn-primary"
           data-testid="report-settings-save"
-          onClick={() => form && save.mutate(form)}
+          onClick={() => form && save.mutate({ ...form, title: form.title.trim() })}
           disabled={save.isPending}
         >
           {save.isPending ? (

--- a/ui/src/components/ReportsDialog.tsx
+++ b/ui/src/components/ReportsDialog.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { BarChart3 } from "lucide-react";
+import { BarChart3, Info } from "lucide-react";
 import clsx from "clsx";
 import { api, type Capabilities } from "@/lib/api";
 import {
   canReport,
+  configuredDisabledHint,
   defaultReportChannel,
   defaultReportWindow,
   hasReportChannel,
@@ -58,6 +59,7 @@ function ReportsDialog({
   const toast = useToast();
   const channels = reportChannels(cap);
   const hasChannel = hasReportChannel(cap);
+  const disabledHint = configuredDisabledHint(cap);
   const [channel, setChannel] = useState(() => defaultReportChannel(cap));
   const [window, setWindow] = useState<ReportWindow>(() =>
     defaultReportWindow(cap),
@@ -198,6 +200,16 @@ function ReportsDialog({
             No notification channel is enabled. Configure a channel (Slack,
             Telegram, Email, …) to send this report. The preview above is still
             downloadable.
+          </p>
+        )}
+
+        {disabledHint && (
+          <p
+            data-testid="report-configured-disabled-hint"
+            className="flex items-start gap-1.5 text-2xs text-ink-400"
+          >
+            <Info size={12} className="mt-0.5 shrink-0" aria-hidden />
+            {disabledHint}
           </p>
         )}
       </div>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -319,6 +319,17 @@ body {
   textarea.input {
     @apply h-auto py-2;
   }
+  select.input {
+    /* Native selects: drop the browser arrow (which pins to the right edge and
+       ignores padding) and paint our own slate-400 chevron with real right
+       spacing. pr-8 reserves room so the longest option never runs under it.
+       Text <input>s keep the tighter px-2. */
+    @apply appearance-none pr-8;
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='none' stroke='%2394a3b8' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 8l4 4 4-4'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.55rem center;
+    background-size: 1rem;
+  }
   .field-label {
     @apply mb-1 block text-2xs uppercase tracking-wider text-ink-300;
   }

--- a/ui/src/lib/agentChannels.test.ts
+++ b/ui/src/lib/agentChannels.test.ts
@@ -200,4 +200,14 @@ describe("AgentChannelsSettingsControl: gating + write-only secrets", () => {
     expect(cmp.includes("buildChannelPut")).toBe(true);
     expect(cmp.includes("localStorage")).toBe(false);
   });
+
+  it("save and clear invalidate BOTH agent-channel-settings AND capabilities (so the report channel picker refreshes)", () => {
+    // A single invalidate helper backs both mutations; enabling/disabling a
+    // channel must refresh capabilities.report.channels which drives the
+    // incident-report channel picker — otherwise it keeps serving "(none)".
+    expect(/queryKey:\s*\["agent-channel-settings"\]/.test(cmp)).toBe(true);
+    expect(/queryKey:\s*\["capabilities"\]/.test(cmp)).toBe(true);
+    // Both the save and clear onSuccess run the same invalidate().
+    expect((cmp.match(/invalidate\(\);/g) || []).length).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1246,6 +1246,11 @@ export interface ReportCapabilities {
   default_window: string;
   include_chart: boolean;
   channels: string[];
+  // configured_disabled are channels that ARE configured but currently
+  // disabled, so they are NOT in `channels` (the picker's enabled options).
+  // The picker names them so the operator knows to enable them in Alert
+  // channels. Always an array (never null); empty on older servers.
+  configured_disabled: string[];
   public_host_set: boolean;
 }
 
@@ -1266,6 +1271,7 @@ export interface Capabilities {
 // a 400.
 export interface ReportSettings {
   enable: boolean;
+  title: string;
   default_channel: string;
   include_chart: boolean;
   rate_per_minute: number;

--- a/ui/src/lib/reportAnalytics.test.ts
+++ b/ui/src/lib/reportAnalytics.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import type { Capabilities, ReportSendResult } from "@/lib/api";
 import {
   canReport,
+  configuredDisabledChannels,
+  configuredDisabledHint,
   defaultReportChannel,
   defaultReportWindow,
   hasReportChannel,
@@ -16,6 +18,7 @@ const report = (over?: Partial<NonNullable<Capabilities["report"]>>) => ({
   default_window: "today",
   include_chart: true,
   channels: [] as string[],
+  configured_disabled: [] as string[],
   public_host_set: false,
   ...over,
 });
@@ -78,6 +81,43 @@ describe("no-channel degrade", () => {
     );
     expect(hasReportChannel(c)).toBe(true);
     expect(reportChannels(c)).toEqual(["slack", "telegram"]);
+  });
+});
+
+describe("configuredDisabledChannels", () => {
+  it("is empty when the field is absent (older server)", () => {
+    expect(configuredDisabledChannels(undefined)).toEqual([]);
+    expect(configuredDisabledChannels(cap(report()))).toEqual([]);
+  });
+  it("returns the configured-but-disabled channels", () => {
+    expect(
+      configuredDisabledChannels(
+        cap(report({ configured_disabled: ["slack", "email"] })),
+      ),
+    ).toEqual(["slack", "email"]);
+  });
+});
+
+describe("configuredDisabledHint", () => {
+  it("is empty when nothing is configured-but-disabled", () => {
+    expect(configuredDisabledHint(undefined)).toBe("");
+    expect(configuredDisabledHint(cap(report()))).toBe("");
+  });
+  it("names a single channel with singular grammar", () => {
+    expect(
+      configuredDisabledHint(cap(report({ configured_disabled: ["slack"] }))),
+    ).toBe(
+      "slack is configured but disabled — enable it in Alert channels to use it here.",
+    );
+  });
+  it("joins multiple channels with plural grammar", () => {
+    expect(
+      configuredDisabledHint(
+        cap(report({ configured_disabled: ["slack", "email"] })),
+      ),
+    ).toBe(
+      "slack, email are configured but disabled — enable them in Alert channels to use them here.",
+    );
   });
 });
 

--- a/ui/src/lib/reportAnalytics.ts
+++ b/ui/src/lib/reportAnalytics.ts
@@ -40,6 +40,28 @@ export function hasReportChannel(cap: Capabilities | undefined): boolean {
   return reportChannels(cap).length > 0;
 }
 
+// configuredDisabledChannels returns the channels that are configured but
+// currently disabled — present in the runtime channel store yet not enabled,
+// so they are NOT offered in the picker. Empty when the server omits the field
+// (older server). The operator must enable them in Alert channels first.
+export function configuredDisabledChannels(
+  cap: Capabilities | undefined,
+): string[] {
+  return cap?.report?.configured_disabled ?? [];
+}
+
+// configuredDisabledHint builds the operator-facing note naming the
+// configured-but-disabled channels, or "" when there are none. Grammatical
+// number matches the count so it reads naturally for one or many channels.
+export function configuredDisabledHint(cap: Capabilities | undefined): string {
+  const names = configuredDisabledChannels(cap);
+  if (names.length === 0) return "";
+  const isOne = names.length === 1;
+  return `${names.join(", ")} ${isOne ? "is" : "are"} configured but disabled — enable ${
+    isOne ? "it" : "them"
+  } in Alert channels to use ${isOne ? "it" : "them"} here.`;
+}
+
 // defaultReportChannel picks the initial picker selection: the configured
 // default_channel when it is actually enabled, else the first enabled channel,
 // else "".

--- a/ui/src/pages/AlertFatiguePage.test.tsx
+++ b/ui/src/pages/AlertFatiguePage.test.tsx
@@ -488,7 +488,7 @@ describe("AlertFatiguePage — floored (high/critical) rows can't be suppressed"
     vi.mocked(api.getAlertFatigueConfig).mockResolvedValue(cfg({ enabled: true }));
   });
 
-  it("disables Mark as spam and explains why on a floored tracking row", async () => {
+  it("replaces Mark as spam with a non-interactive hint on a floored tracking row", async () => {
     vi.mocked(api.listAlertFatigueFingerprints).mockResolvedValue(
       page([
         finding({
@@ -505,21 +505,21 @@ describe("AlertFatiguePage — floored (high/critical) rows can't be suppressed"
     );
     renderPage();
 
-    const btn = await screen.findByTestId("alert-fatigue-mark-spam-floored");
-    // The button reads as unavailable to assistive tech without leaving the
-    // page (aria-disabled keeps it focusable so the reason is reachable).
-    expect(btn.getAttribute("aria-disabled")).toBe("true");
+    const hint = await screen.findByTestId("alert-fatigue-mark-spam-floored");
+    // The affordance is a compact, non-interactive hint (a span), not an
+    // enabled button — there's nothing to click and nothing to suppress.
+    expect(hint.tagName).toBe("SPAN");
+    expect(screen.queryByRole("button", { name: "Mark as spam" })).toBeNull();
 
-    // Clicking it must NOT fire the suppression mutation — it would never take.
-    fireEvent.click(btn);
+    // Interacting with it must NOT fire the suppression mutation.
+    fireEvent.click(hint);
     expect(api.confirmAlertFatigueFingerprint).not.toHaveBeenCalled();
 
-    // The explanation is programmatically associated for assistive tech.
-    const describedBy = btn.getAttribute("aria-describedby");
-    expect(describedBy).toBeTruthy();
-    expect(document.getElementById(describedBy!)?.textContent).toMatch(
-      /always page/i,
-    );
+    // It conveys the "always pages / can't be suppressed" reason via its
+    // visible text plus the full explanation in title/aria-label.
+    expect(hint.textContent).toMatch(/always pages/i);
+    expect(hint.getAttribute("title")).toMatch(/always page.*can't be suppressed/i);
+    expect(hint.getAttribute("aria-label")).toMatch(/cannot be suppressed/i);
   });
 
   it("annotates a floored fatigued row so it doesn't read as silenced", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a batch of customer-reported issues and polishes the incident **report** and
**service attribution**:

- **Service name shows on the incident list** (was blank for webhook incidents that
  carry the service under `ServiceName`) and the log-based service matcher stops
  emitting garbage names (`o.s.boot.SpringApplication`, `POST`/`GET`,
  `io-8080-exec-10`, `main`, `Nest`).
- **The report renders in color** (severity was banding to gray) with a redesigned
  chart palette, a **configurable title**, an **image-only** delivery mode when
  charts are included, and a verified rolling **24h window**.
- **Runtime (hot-configured) channels now appear in the report channel picker**, a
  **configured-but-disabled** channel is called out with a hint, the channel
  **Enable toggle** is made prominent, and native `<select>` dropdown arrows get
  proper spacing.

## Why?

Several customer bug reports: blank service in the incidents webhook list, wrong
service names on the Service page, a colorless report image, and an inability to
select a hot-configured Slack channel for the report. Plus UX polish so a
configured-but-disabled channel and the enable toggle aren't confusing.

## How to test

1. Bring up the enterprise stack (`run/enterprise.sh`; enterprise Postgres pw
   `versus`), licensed.
2. **Service attribution:** POST a webhook whose payload carries the service only
   under `ServiceName` → the incidents list service column is populated and equals
   the detail. Feed log lines that previously mis-extracted (`o.s.boot.SpringApplication`,
   `POST`, `io-8080-exec-10`, `main`, `Nest`) → the Service page does not show them;
   legit names (`order-service-2`, `api.prod`, `nio-gateway`, `s3`) still resolve.
3. **Report:** POST an Alertmanager-shaped alert with nested `labels.severity:
   critical` → render the report and confirm it's in color (red/orange/amber bars,
   violet/emerald trend series with a legend, tinted severity labels, colored
   Critical/High tile). Select **Last 24h** → window is `now-24h → now`. Set a custom
   **Report title** → it appears in the image header. Enable **Include charts** →
   image-capable channels get the PNG with no caption; text-only channels get the
   redacted text summary.
4. **Channels:** enable Slack in Admin → Alert channels → it appears live in the
   incident-report channel picker. Configure a channel but leave it disabled → the
   report picker shows "configured but disabled — enable it in Alert channels" and
   it's not selectable. Confirm the Enable toggle is a prominent top-of-card switch
   and the `<select>` arrows have clear right spacing.

## Type of change

- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking) — configurable report title, image-only delivery, configured-disabled hint

## Checklist

- [x] `go test ./...` passes locally (OSS `pkg/{services,agent,controllers,report}`; enterprise `cmd/versus-enterprise`, `pkg/runtimechannels`)
- [x] `go vet ./...` is clean (both trees)
- [x] Code is `gofmt`'d
- [x] Added or updated tests (Go unit/race + UI vitest 540 tests; new Playwright `report-channels-flow.spec.ts`)
- [ ] Updated user-facing docs under `src/` if behavior changes
- [ ] Updated `ROADMAP.md` if this closes a roadmap item
- [x] No secrets, tokens, or webhook URLs introduced in source / YAML (channel names only leave the box; runtime channel secrets stay sealed/masked)
- [x] No new third-party dependencies

---

### Detailed changes

**Service attribution (OSS)**
- `pkg/services/incident.go`: shared `extractService(content)` (key set
  `ServiceName, Service, service, service_name, servicename, app, component`) used by
  `buildIncidentRecord`, the emit path, and the report; the list falls back to
  content-derived service for legacy blank-column rows so old rows also display.
- `pkg/agent/service.go`: `ServiceMatcher` gains guards that reject HTTP methods,
  connector/`main` thread names, and abbreviated dotted loggers (`o.s.boot.…`), plus
  a small reserved-context denylist (`Nest`, `main`) — while keeping legit names.

**Incident report (OSS)**
- `pkg/services/report.go`: `reportSeverity` now reads nested
  `labels.severity`/`commonLabels.severity` + `level`/`priority`, and `severityBand`
  maps the broader synonym set (`p1/sev1/error/major/…`) so real severities render in
  color. `ReportSettings.title` (default "Incident report", trimmed + 80-rune clamped)
  flows to the image header + caption. When `IncludeCharts` is on, image channels are
  sent the PNG with no caption; text-only channels keep the redacted fallback. 24h
  window verified as rolling `now-24h → now`.
- `pkg/report/renderer.go`: new chart palette — trend series **violet (AI-detect)** +
  **emerald (Webhook)** with a legend, severity row labels tinted their severity
  color, the Critical/High stat value tinted the worst-severity accent.

**Report channel picker (OSS + enterprise + UI)**
- OSS `pkg/controllers/incidents_admin.go` + a new `ReportChannelLister` seam: the
  capabilities `report.channels` and new `report.configured_disabled` are sourced
  from the runtime channel view, keyed by the request org; enterprise backs it with
  `runtimechannels.Resolver.EffectiveEnabled`/`Get` (masked, never decrypts). OSS with
  no lister falls back to the static enabled channels (community identical).
- UI: `AgentChannelsSettingsControl` invalidates `["capabilities"]` on channel
  save/clear so the report picker refreshes live; a prominent top-of-card Enable
  switch; the report pickers show the "configured but disabled" hint; native
  `<select className="input">` render a custom chevron with proper right padding.

### Verification
- **QA (functional + live e2e):** PASS 9/9, 0 defects — real-browser Playwright +
  live CLI stack (report color from nested labels, `ServiceName` list==detail,
  garbage-service rejection, 24h bounds, custom title, image-only, live channel
  picker, configured-disabled hint, select chevron).
- **Security & Compliance:** PASS — redaction/DLP intact on service + severity +
  title; capabilities lister org-scoped and secret-free; no new dependency findings;
  no OSS→enterprise import. One cosmetic nit (report title permits embedded newlines;
  admin-authored, own-org only).

### Open founder decisions (not in this PR)
- Flip the shipped default report window `today` → `24h`, or tighten picker/scheduler
  copy so "Today" (since local midnight) vs "Last 24h" (rolling) is unambiguous.
- When charts are on, keep sending text-only channels the text fallback (current) vs
  skip them entirely.
