### PR TITLE
feat: add LiteLLM as an AI gateway provider

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -239,7 +239,10 @@ agent:
   ai:
     enable: false                   # master switch (env: AGENT_AI_ENABLE)
     # provider selects the model backend (openai | deepseek | qwen | ollama |
-    # claude | gemini). Default openai. The api_key below must match the chosen provider.
+    # claude | gemini | litellm). Default openai. The api_key below must match the
+    # chosen provider. For "litellm" the backend targets a LiteLLM proxy
+    # (default http://localhost:4000/v1), api_key is the proxy virtual key, and
+    # model is the LiteLLM model alias (e.g. "gpt-5" or "claude-sonnet").
     provider: openai                # model backend (env: AGENT_AI_PROVIDER)
     api_key: ${AGENT_AI_API_KEY}
     model: "gpt-5.4-mini"

--- a/pkg/agent/ai/eino/holder.go
+++ b/pkg/agent/ai/eino/holder.go
@@ -13,8 +13,8 @@ import (
 
 // holder.go — the runtime model-construction lifecycle.
 //
-// The model PROVIDER (openai | deepseek | qwen | ollama | claude | gemini) is
-// chosen at CONSTRUCTION time: each provider picks a different SDK/builder
+// The model PROVIDER (openai | deepseek | qwen | ollama | claude | gemini |
+// litellm) is chosen at CONSTRUCTION time: each provider picks a different SDK/builder
 // (provider.go), so a provider change cannot hot-reload through a request
 // header the way the per-request key override (AuthKeyFunc) does — the model
 // object must be REBUILT. A Holder is the rebuild lifecycle: it caches a built

--- a/pkg/agent/ai/eino/provider.go
+++ b/pkg/agent/ai/eino/provider.go
@@ -60,6 +60,7 @@ var chatModelBuilders = map[string]chatModelBuilder{
 	"ollama":   buildOllamaChatModel,
 	"claude":   buildClaudeChatModel,
 	"gemini":   buildGeminiChatModel,
+	"litellm":  buildLiteLLMChatModel,
 }
 
 // resolveProvider normalises the configured provider: empty/whitespace becomes
@@ -175,6 +176,54 @@ func buildOpenAIChatModel(ctx context.Context, req chatModelRequest) (model.Tool
 		Timeout:             req.timeout,
 		HTTPClient:          req.httpClient,
 		BaseURL:             req.baseURL,
+		Model:               req.model,
+		MaxCompletionTokens: &maxCompletionTokens,
+		Temperature:         temperature,
+	}
+	if req.jsonMode {
+		conf.ResponseFormat = &einoopenai.ChatCompletionResponseFormat{
+			Type: einoopenai.ChatCompletionResponseFormatTypeJSONObject,
+		}
+	}
+	return einoopenai.NewChatModel(ctx, conf)
+}
+
+// buildLiteLLMChatModel wires a LiteLLM proxy (https://docs.litellm.ai/docs/simple_proxy):
+// an OpenAI-compatible gateway that fans a single endpoint out to 100+ upstream
+// providers (OpenAI, Anthropic, Bedrock, Vertex, Azure, Gemini, Ollama, ...). Because
+// the proxy speaks the OpenAI chat-completions wire format we reuse the OpenAI SDK, so
+// JSON-mode and tool-calling ride the same paths as buildOpenAIChatModel and the Bearer
+// virtual key rides the AuthKeyFunc transport on req.httpClient for free.
+//
+// One deliberate difference from buildOpenAIChatModel: BaseURL defaults to the
+// local proxy (http://localhost:4000/v1) when unset, the same way
+// buildQwenChatModel/buildOllamaChatModel default their endpoints — a LiteLLM
+// proxy is typically a sidecar. The test-only Options.BaseURL still wins.
+//
+// req.model is a LiteLLM *model alias* (a key from the proxy config, e.g. "gpt-5"
+// or "claude-sonnet"). Because this path shares the OpenAI SDK, the SDK applies
+// the SAME client-side beta-limitation guard as buildOpenAIChatModel: an explicit
+// temperature is rejected up front for reasoning families (gpt-5.*, o-series). So
+// we reuse isFixedSamplingModel to omit temperature when the alias names such a
+// family — otherwise an operator aliasing e.g. "gpt-5" through the proxy would have
+// to set temperature: -1 by hand. Non-matching aliases (claude-sonnet, ...) forward
+// the configured temperature unchanged; the proxy drops any remaining
+// per-provider-unsupported sampling params server-side (drop_params).
+func buildLiteLLMChatModel(ctx context.Context, req chatModelRequest) (model.ToolCallingChatModel, error) {
+	baseURL := req.baseURL
+	if baseURL == "" {
+		baseURL = "http://localhost:4000/v1"
+	}
+	maxCompletionTokens := req.maxTokens
+	temperature := req.temperature
+	if isFixedSamplingModel(req.model) {
+		temperature = nil
+	}
+	conf := &einoopenai.ChatModelConfig{
+		APIKey:              req.apiKey,
+		Timeout:             req.timeout,
+		HTTPClient:          req.httpClient,
+		BaseURL:             baseURL,
 		Model:               req.model,
 		MaxCompletionTokens: &maxCompletionTokens,
 		Temperature:         temperature,

--- a/pkg/agent/ai/eino/provider_test.go
+++ b/pkg/agent/ai/eino/provider_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/VersusControl/versus-incident/pkg/core"
 )
 
-// This file is the per-provider proving suite for the four chat backends that
-// ship in the registry alongside openai/gemini — deepseek, qwen, ollama and
-// claude. It mirrors the egress-capture pattern of
+// This file is the per-provider proving suite for the five chat backends that
+// ship in the registry alongside openai/gemini — deepseek, qwen, ollama,
+// claude and litellm. It mirrors the egress-capture pattern of
 // chatmodel_test.go / gemini_test.go: each provider either round-trips a
 // finding through an httptest server (asserting the outbound auth header and
 // JSON-mode knob) or, where the SDK cannot be hit via httptest, asserts the
@@ -46,6 +46,9 @@ func TestChatModel_RegistryBuildsAllProviders(t *testing.T) {
 		{"Ollama", "llama3"},
 		{"claude", "claude-3-5-sonnet-20241022"},
 		{"CLAUDE", "claude-3-5-sonnet-20241022"},
+		{"litellm", "gpt-5"},
+		{"LiteLLM", "gpt-5"},
+		{" litellm ", "gpt-5"},
 	}
 	for _, tc := range cases {
 		t.Run(strings.TrimSpace(tc.provider), func(t *testing.T) {
@@ -75,7 +78,7 @@ func TestChatModel_RegistryBuildsAllProviders(t *testing.T) {
 // (case-insensitive, empty ⇒ the openai default; unknown ⇒ false).
 func TestSupportedProvidersExported(t *testing.T) {
 	got := einowrap.SupportedProviders()
-	want := map[string]bool{"openai": true, "deepseek": true, "qwen": true, "ollama": true, "claude": true, "gemini": true}
+	want := map[string]bool{"openai": true, "deepseek": true, "qwen": true, "ollama": true, "claude": true, "gemini": true, "litellm": true}
 	if len(got) != len(want) {
 		t.Fatalf("SupportedProviders() = %v, want the %d registered providers", got, len(want))
 	}
@@ -264,6 +267,67 @@ func TestChatModel_Qwen_EgressBearerAndJSONMode(t *testing.T) {
 	}
 	if got.Title != expected.Title {
 		t.Errorf("Title = %q, want %q", got.Title, expected.Title)
+	}
+}
+
+// TestChatModel_LiteLLM_EgressBearerAndJSONMode proves the LiteLLM path end to
+// end: a LiteLLM proxy is OpenAI-compatible, so the runtime virtual key rides the
+// Bearer Authorization header, the JSON-mode request carries
+// response_format:{type:json_object}, and the reply round-trips through
+// detect.ParseFinding. It also proves opts.BaseURL overrides the built-in local
+// proxy default (http://localhost:4000/v1) so the test can point at httptest.
+func TestChatModel_LiteLLM_EgressBearerAndJSONMode(t *testing.T) {
+	expected := core.AIFinding{
+		Title:    "Connection pool exhausted",
+		Summary:  "the api service ran out of upstream DB connections.",
+		Severity: "high",
+		Category: "database",
+	}
+	var (
+		mu       sync.Mutex
+		seenAuth string
+		seenBody map[string]any
+	)
+	srv := newOpenAICompatServer(t, expected, &seenAuth, &seenBody, &mu)
+	defer srv.Close()
+
+	cfg := config.AgentAIConfig{
+		Provider:    "litellm",
+		APIKey:      "sk-litellm-virtual-key",
+		Model:       "gpt-5",
+		Temperature: 0.2,
+		MaxTokens:   256,
+	}
+	ctx := context.Background()
+	cm, err := einowrap.NewChatModel(ctx, cfg, einowrap.Options{BaseURL: srv.URL})
+	if err != nil {
+		t.Fatalf("NewChatModel(litellm): %v", err)
+	}
+	msg, err := cm.Generate(ctx, []*schema.Message{schema.SystemMessage("system"), schema.UserMessage("user")})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if seenAuth != "Bearer sk-litellm-virtual-key" {
+		t.Errorf("Authorization = %q, want Bearer sk-litellm-virtual-key", seenAuth)
+	}
+	if got := responseFormatType(seenBody); got != "json_object" {
+		t.Errorf("response_format.type = %q, want json_object (litellm OpenAI-compatible JSON-mode)", got)
+	}
+	// The "gpt-5" alias is a beta-limited family: the shared OpenAI SDK rejects an
+	// explicit temperature client-side, so the litellm builder must omit it (same
+	// as buildOpenAIChatModel). Prove it never reached the wire.
+	if _, hasTemp := seenBody["temperature"]; hasTemp {
+		t.Errorf("temperature was sent for a gpt-5 alias: %v; want it omitted (beta-limitation)", seenBody["temperature"])
+	}
+	got, err := detect.ParseFinding(msg.Content)
+	if err != nil {
+		t.Fatalf("ParseFinding: %v\nraw: %s", err, msg.Content)
+	}
+	if got.Title != expected.Title || got.Severity != expected.Severity {
+		t.Errorf("finding = %+v, want title=%q severity=%q", got, expected.Title, expected.Severity)
 	}
 }
 

--- a/pkg/agent/aisettings.go
+++ b/pkg/agent/aisettings.go
@@ -31,7 +31,7 @@ type AISettingsResolver interface {
 
 // AIProviderResolver is an OPTIONAL extension of AISettingsResolver: a
 // registered resolver that ALSO implements it can override the model PROVIDER
-// (openai | deepseek | qwen | ollama | claude | gemini) at runtime, so an
+// (openai | deepseek | qwen | ollama | claude | gemini | litellm) at runtime, so an
 // operator's provider change rebuilds the agent's model on its next run
 // without a process restart. ok=false ⇒ no opinion (use the configured
 // provider). A resolver that does not implement this interface simply has no

--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -358,10 +358,11 @@ type AgentAIConfig struct {
 	// to run detect mode in a "dry-run" fashion without an API key.
 	Enable bool `mapstructure:"enable"`
 	// Provider selects the model backend the eino layer constructs
-	// (e.g. "openai", "deepseek", "qwen", "ollama", "claude"). Empty
-	// defaults to "openai". The single APIKey below is the credential for
-	// the SELECTED provider — operators change the key to match when they
-	// switch provider. An unsupported value fails fast at model construction.
+	// (e.g. "openai", "deepseek", "qwen", "ollama", "claude", "gemini",
+	// "litellm"). Empty defaults to "openai". The single APIKey below is the
+	// credential for the SELECTED provider — operators change the key to match
+	// when they switch provider (for "litellm" it is the proxy virtual key).
+	// An unsupported value fails fast at model construction.
 	Provider string `mapstructure:"provider"`
 	// APIKey is the bearer token sent in the Authorization header.
 	APIKey string `mapstructure:"api_key"`

--- a/pkg/config/default_config.yaml
+++ b/pkg/config/default_config.yaml
@@ -193,7 +193,10 @@ agent:
   ai:
     enable: false
     # provider selects the model backend (openai | deepseek | qwen | ollama |
-    # claude | gemini). Default openai. The api_key below must match the chosen provider.
+    # claude | gemini | litellm). Default openai. The api_key below must match the
+    # chosen provider. For "litellm" the backend targets a LiteLLM proxy
+    # (default http://localhost:4000/v1), api_key is the proxy virtual key, and
+    # model is the LiteLLM model alias (e.g. "gpt-5" or "claude-sonnet").
     provider: openai
     api_key: ${AGENT_AI_API_KEY}
     model: "gpt-5.4-mini"

--- a/src/agent/configuration.md
+++ b/src/agent/configuration.md
@@ -268,7 +268,7 @@ on-demand **analyze** investigation. Shared keys apply to both; the
 agent:
   ai:
     enable: true
-    provider: openai            # openai | deepseek | qwen | ollama | claude | gemini
+    provider: openai            # openai | deepseek | qwen | ollama | claude | gemini | litellm
     api_key: ${AGENT_AI_API_KEY}
     model: gpt-4o-mini          # shared default for detect + analyze
     temperature: 0.2
@@ -290,11 +290,39 @@ temperature at `1` and reject any explicit value.
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `enable` | bool | `false` | Turns on the AI SRE (detect triage + analyze). Env: `AGENT_AI_ENABLE`. |
-| `provider` | string | `openai` | Model backend: `openai`, `deepseek`, `qwen`, `ollama`, `claude`, or `gemini`. An unknown value fails fast (no silent fallback). Env: `AGENT_AI_PROVIDER`. |
+| `provider` | string | `openai` | Model backend: `openai`, `deepseek`, `qwen`, `ollama`, `claude`, `gemini`, or `litellm`. An unknown value fails fast (no silent fallback). Env: `AGENT_AI_PROVIDER`. |
 | `api_key` | string | — | API key for the model provider. Env: `AGENT_AI_API_KEY`. |
 | `model` | string | — | Shared default model for both tasks. Env: `AGENT_AI_MODEL`. |
 | `temperature` | float | `0.2` | Randomness control. Set `-1` to omit the field for beta-limited / reasoning models that reject explicit temperature values. |
 | `analyze.model` | string | inherits `model` | Optional stronger model just for analyze. |
+
+### LiteLLM gateway
+
+Set `provider: litellm` to route the AI SRE through a
+[LiteLLM proxy](https://docs.litellm.ai/docs/simple_proxy) — one
+OpenAI-compatible endpoint that fans out to 100+ upstream providers
+(OpenAI, Anthropic, Bedrock, Vertex, Azure, Gemini, self-hosted, ...).
+This lets you centralise API keys, spend limits, caching, and fallbacks
+in the proxy while Versus keeps a single, stable configuration.
+
+```yaml
+agent:
+  ai:
+    enable: true
+    provider: litellm
+    api_key: ${LITELLM_VIRTUAL_KEY}   # the proxy virtual key (Bearer)
+    model: gpt-5                       # a LiteLLM model alias from your proxy config
+    temperature: 0.2
+    max_tokens: 1024
+```
+
+The backend speaks the OpenAI chat-completions wire format, so JSON-mode
+(detect) and tool-calling (analyze) work unchanged. `model` is the
+**model alias** defined in your LiteLLM proxy config, not a raw provider
+id; the proxy maps it to the upstream deployment and drops any
+per-provider-unsupported sampling params server-side. The endpoint
+defaults to a local proxy at `http://localhost:4000/v1` (the common
+sidecar deployment).
 
 > The tool-loop knobs `tool_timeout` and `parallel_tools` moved to the
 > root of `tools.yaml` (see below) — they apply to every analyze tool


### PR DESCRIPTION
<!--
Thanks for the contribution! Please make sure you have read CONTRIBUTING.md
and that your branch passes `go test ./...`, `go vet ./...`, and `gofmt -w .`.
-->

## What does this PR do?

Adds **LiteLLM** as a first class chat provider for the AI SRE agent, registered in the `eino` model builder registry alongside `openai`, `deepseek`, `qwen`, `ollama`, `claude`, and `gemini`. Set `agent.ai.provider: litellm` to route detect and analyze through a [LiteLLM proxy](https://docs.litellm.ai/docs/simple_proxy), one OpenAI compatible endpoint that fans out to 100+ upstream providers, reusing the already vendored `eino-ext/components/model/openai` with no new dependency.

Changes:
- `pkg/agent/ai/eino/provider.go`: `buildLiteLLMChatModel` plus the `"litellm"` registry entry.
- `pkg/agent/ai/eino/provider_test.go`: registry, exported validator, and egress tests for litellm.
- `pkg/config/agent.go`, `pkg/agent/aisettings.go`, `pkg/agent/ai/eino/holder.go`: provider list doc comments.
- `config/config.yaml`, `pkg/config/default_config.yaml`: provider comment plus a litellm usage note.
- `src/agent/configuration.md`: provider table row plus a LiteLLM gateway section.

## Why?

This adds gateway support so operators can centralise keys, spend caps, caching, and fallbacks in one proxy while Versus keeps a single stable config. The proxy speaks the OpenAI chat completions wire format, so it slots into the registry as a real discrete builder rather than a generic base url toggle, which means `SupportedProviders()` (the enterprise write boundary validator) and the runtime fail fast path both cover it for free. Prior art: #160 proposed an OpenAI compatible `base_url` field naming Gemini, LiteLLM, and OpenRouter; the AI layer then moved to the Eino framework with discrete first class builders, and this PR follows that direction with a real `buildLiteLLMChatModel`.

## How to test

<!-- Reproduction steps, sample config, sample request. -->
Sample config:

```yaml
agent:
  ai:
    enable: true
    provider: litellm
    api_key: ${LITELLM_VIRTUAL_KEY}   # proxy virtual key (Bearer)
    model: gpt-5                       # a LiteLLM model alias from your proxy config
    temperature: 0.2
    max_tokens: 1024
```

`model` is the alias defined in your proxy config (not a raw provider id); the endpoint defaults to a local sidecar at `http://localhost:4000/v1`.

Unit tests, `go test -race ./pkg/agent/ai/eino/...`:
```
--- PASS: TestChatModel_RegistryBuildsAllProviders/litellm
--- PASS: TestSupportedProvidersExported
--- PASS: TestChatModel_LiteLLM_EgressBearerAndJSONMode
ok  github.com/VersusControl/versus-incident/pkg/agent/ai/eino
```
The egress test spins up an httptest OpenAI compatible server and asserts that the virtual key rides the `Bearer` Authorization header, that JSON mode sends `response_format:{type:json_object}`, and that the reply round trips through `detect.ParseFinding`.

Live end to end through a real LiteLLM proxy. `NewToolCallingChatModel(provider=litellm)` builds `buildLiteLLMChatModel`, which calls the OpenAI SDK, which calls the LiteLLM proxy, which calls the upstream:
```
LIVE litellm response via http://localhost:4000/v1 (model=azure/gpt-4o-mini): "LITELLM_OK"
--- PASS: TestLive_LiteLLM (1.05s)
```
Proxy side confirmation of the same call (Azure OpenAI upstream through the proxy):
```
content: LITELLM_OK
model: azure/gpt-4o-mini
usage: {'completion_tokens': 6, 'prompt_tokens': 16, 'total_tokens': 22, ...}
```

Bug caught and fixed during the deep dive: the proxy path shares the OpenAI SDK, which validates the beta limitation client side, so for reasoning families (`gpt-5.*`, o series) an explicit `temperature` is rejected before the request leaves. Naively forwarding the configured temperature broke a `gpt-5` alias. The builder now reuses the same `isFixedSamplingModel` omission as `buildOpenAIChatModel`, so an operator aliasing `gpt-5` through the proxy does not have to set `temperature: -1` by hand. The egress test asserts that `temperature` is absent from the wire for a `gpt-5` alias.

Build, vet, and format are clean: `go build ./...`, `go vet ./pkg/agent/ai/eino/... ./pkg/config/...`, and `gofmt -l`. `go test -race ./pkg/...` is green for every package that builds locally, including `pkg/agent/ai/eino`, `pkg/agent/ai/detect`, `pkg/agent/ai/analyze`, `pkg/config`, and `pkg/core`. `pkg/controllers` and `pkg/routes` only fail to build locally because they `//go:embed ui/dist`, which needs the frontend build and is untouched by this PR.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (config / API / default behavior)
- [ ] Documentation only
- [ ] Refactor (no functional change)
- [ ] CI / build / chore

## Checklist

- [x] `go test ./...` passes locally
- [x] `go vet ./...` is clean
- [x] Code is `gofmt`'d
- [x] Added or updated tests for the change
- [x] Updated user-facing docs under `src/` if behavior changes
- [ ] Updated `ROADMAP.md` if this closes a roadmap item
- [x] No secrets, tokens, or webhook URLs introduced in source / YAML
- [x] No new third-party dependencies (or justified in the description)
