### PR TITLE
fix(service): bulk action service page

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/VersusControl/versus-incident
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.79.0

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -17,6 +17,16 @@ interface LearnExclusionsWire {
   log_patterns?: string[];
 }
 
+// fromLearnExclusionsWire is the ONE place the `log_patterns` ⇄ `patterns` seam
+// is crossed, so every read/write of the policy returns the same UI shape.
+function fromLearnExclusionsWire(r: LearnExclusionsWire): LearnExclusions {
+  return {
+    services: r.services ?? [],
+    metrics: r.metrics ?? [],
+    patterns: r.log_patterns ?? [],
+  };
+}
+
 const SECRET_KEY = "versus.gatewaySecret";
 const API_BASE = import.meta.env.VITE_API_BASE_URL || ""; // empty → uses Vite proxy
 
@@ -1865,7 +1875,9 @@ export const api = {
   // cookie, never a static token; the org and role are derived server-side. The
   // GET is the single state source the toggle + per-metric checkboxes read;
   // setServiceLearnExclusion toggles ONE service (POST add / DELETE remove);
-  // setLearnExclusions PUTs the whole list (read-modify-write off the GET),
+  // setServiceLearnExclusions posts an intent for MANY services at once, merged
+  // server-side under a per-org lock; setLearnExclusions PUTs the whole list
+  // (read-modify-write off the GET),
   // which is ALSO how a per-log-pattern exclusion is toggled (the server has no
   // per-pattern POST/DELETE convenience route — the whole-list PUT is the sole
   // write path for the `patterns` grain, same as metric/trace signals). All
@@ -1882,11 +1894,7 @@ export const api = {
   getLearnExclusions: () =>
     sessionRequest<LearnExclusionsWire>(
       "/enterprise/api/agent/learn-exclusions",
-    ).then((r) => ({
-      services: r.services ?? [],
-      metrics: r.metrics ?? [],
-      patterns: r.log_patterns ?? [],
-    })),
+    ).then(fromLearnExclusionsWire),
   setLearnExclusions: (input: LearnExclusions) =>
     sessionRequest<LearnExclusionsWire>("/enterprise/api/agent/learn-exclusions", {
       method: "PUT",
@@ -1895,20 +1903,22 @@ export const api = {
         metrics: input.metrics,
         log_patterns: input.patterns,
       }),
-    }).then((r) => ({
-      services: r.services ?? [],
-      metrics: r.metrics ?? [],
-      patterns: r.log_patterns ?? [],
-    })),
+    }).then(fromLearnExclusionsWire),
   setServiceLearnExclusion: (name: string, excluded: boolean) =>
     sessionRequest<LearnExclusionsWire>(
       `/enterprise/api/agent/learn-exclusions/services/${encodeURIComponent(name)}`,
       { method: excluded ? "POST" : "DELETE" },
-    ).then((r) => ({
-      services: r.services ?? [],
-      metrics: r.metrics ?? [],
-      patterns: r.log_patterns ?? [],
-    })),
+    ).then(fromLearnExclusionsWire),
+  // setServiceLearnExclusions is the BULK service write. It sends INTENT — the
+  // selected names + the direction — and NOT a resulting list, so a stale page
+  // can never revert a concurrent change or clobber another grain: the server
+  // merges against the current stored policy under a per-org lock and keeps
+  // metrics / includes / log patterns, which are never taken from the client.
+  setServiceLearnExclusions: (services: string[], exclude: boolean) =>
+    sessionRequest<LearnExclusionsWire>(
+      "/enterprise/api/agent/learn-exclusions/services/batch",
+      { method: "POST", body: JSON.stringify({ services, exclude }) },
+    ).then(fromLearnExclusionsWire),
 
   // getSSODeployment reads the license-issued single-tenant deployment org so
   // the admin controls drive SSO/connections/policy under it (not "default").

--- a/ui/src/lib/learnExclusionsApi.test.ts
+++ b/ui/src/lib/learnExclusionsApi.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { api } from "@/lib/api";
+
+// Wire-level contract for the BULK service exclusion write. The bulk bar must
+// send INTENT (the selected names + the direction) and nothing else: a body
+// carrying the resulting policy let a stale page revert a concurrent change,
+// and because that body also carried the metric + log-pattern grains, a
+// services bulk action could wipe a colleague's metric/log-pattern exclusions.
+// The server merges against the stored policy under a per-org lock instead.
+
+function stubFetch(payload: unknown) {
+  const spy = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+function sentBody(spy: ReturnType<typeof stubFetch>): unknown {
+  const init = spy.mock.calls[0][1] as RequestInit;
+  return JSON.parse(String(init.body));
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("api.setServiceLearnExclusions (bulk service intent)", () => {
+  it("POSTs only the service names and the exclude flag to the batch route", async () => {
+    const spy = stubFetch({
+      services: ["checkout", "payments"],
+      metrics: ["go_*"],
+      includes: [],
+      log_patterns: ["log:checkout:abc123"],
+    });
+
+    await api.setServiceLearnExclusions(["checkout", "payments"], true);
+
+    expect(spy.mock.calls[0][0]).toBe(
+      "/enterprise/api/agent/learn-exclusions/services/batch",
+    );
+    expect((spy.mock.calls[0][1] as RequestInit).method).toBe("POST");
+    // Exactly two keys — no `metrics`, no `log_patterns`, no `services`
+    // snapshot beyond the selection itself.
+    expect(sentBody(spy)).toEqual({
+      services: ["checkout", "payments"],
+      exclude: true,
+    });
+  });
+
+  it("carries exclude:false for a bulk resume", async () => {
+    const spy = stubFetch({ services: [], metrics: [], log_patterns: [] });
+    await api.setServiceLearnExclusions(["checkout"], false);
+    expect(sentBody(spy)).toEqual({ services: ["checkout"], exclude: false });
+  });
+
+  it("maps the response across the log_patterns ⇄ patterns seam", async () => {
+    stubFetch({
+      services: ["checkout"],
+      metrics: ["up"],
+      includes: [],
+      log_patterns: ["log:checkout:abc123"],
+    });
+    await expect(
+      api.setServiceLearnExclusions(["checkout"], true),
+    ).resolves.toEqual({
+      services: ["checkout"],
+      metrics: ["up"],
+      patterns: ["log:checkout:abc123"],
+    });
+  });
+
+  it("defaults every grain to an empty list on a sparse response", async () => {
+    stubFetch({});
+    await expect(
+      api.setServiceLearnExclusions(["checkout"], false),
+    ).resolves.toEqual({ services: [], metrics: [], patterns: [] });
+  });
+});

--- a/ui/src/lib/useLearnExclusions.ts
+++ b/ui/src/lib/useLearnExclusions.ts
@@ -37,7 +37,7 @@ import { useToast } from "@/components/toastContext";
 // feature never leaks a header or an inert widget to a non-admin.
 //
 // Disable-Learn semantics are preserved end to end: toggling calls the SAME enterprise
-// endpoints (POST/DELETE .../services/:name for a service; the whole-list PUT
+// endpoints (POST .../services/batch for a service selection; the whole-list PUT
 // for a metric/trace signal AND for a log pattern — the log-pattern grain has
 // no per-pattern POST/DELETE route, so it rides the same read-modify-write PUT
 // the metric grain does), and an excluded (service, signal) or (service,
@@ -97,15 +97,18 @@ export interface LearnExclusionControls {
   isServiceExcluded: (service: string) => boolean;
   isSignalExcluded: (signal: string) => boolean;
   isPatternExcluded: (patternKey: string) => boolean;
-  toggleService: (service: string, exclude: boolean) => void;
   toggleSignal: (signal: string, exclude: boolean) => void;
   togglePattern: (patternKey: string, exclude: boolean) => void;
-  // Batch variants for the bulk-action bar. Both fold MANY entries into ONE
-  // whole-list PUT (per-entry PUTs would race on the same stale list, the last
-  // write dropping the rest): toggleSignals over the metric grain,
-  // togglePatterns over the log-pattern grain.
+  // Batch variants for the bulk-action bar. toggleSignals (metric grain) and
+  // togglePatterns (log-pattern grain) fold MANY entries into ONE whole-list
+  // PUT — per-entry writes would race on the same stale list, the last write
+  // dropping the rest. toggleServices instead posts INTENT (the names + the
+  // direction) to the batch service route, which merges server-side under a
+  // per-org lock: nothing about the resulting policy comes from this client, so
+  // a stale page cannot revert a concurrent change or clobber another grain.
   toggleSignals: (signals: string[], exclude: boolean) => void;
   togglePatterns: (patternKeys: string[], exclude: boolean) => void;
+  toggleServices: (services: string[], exclude: boolean) => void;
 }
 
 // useLearnExclusions wires the shared control state for one list page. It reads
@@ -146,9 +149,9 @@ export function useLearnExclusions(licensed: boolean): LearnExclusionControls {
       description: err instanceof Error ? err.message : String(err),
     });
 
-  const serviceMut = useMutation({
-    mutationFn: (v: { service: string; exclude: boolean }) =>
-      api.setServiceLearnExclusion(v.service, v.exclude),
+  const servicesMut = useMutation({
+    mutationFn: (v: { services: string[]; exclude: boolean }) =>
+      api.setServiceLearnExclusions(v.services, v.exclude),
     onSuccess: onWritten,
     onError: onWriteError,
   });
@@ -161,7 +164,7 @@ export function useLearnExclusions(licensed: boolean): LearnExclusionControls {
 
   const busy =
     ex.isFetching ||
-    serviceMut.isPending ||
+    servicesMut.isPending ||
     signalMut.isPending ||
     !ex.data;
 
@@ -174,7 +177,6 @@ export function useLearnExclusions(licensed: boolean): LearnExclusionControls {
     isSignalExcluded: (signal) => metricExcluded(signal, ex.data?.metrics),
     isPatternExcluded: (patternKey) =>
       patternExcluded(patternKey, ex.data?.patterns),
-    toggleService: (service, exclude) => serviceMut.mutate({ service, exclude }),
     toggleSignal: (signal, exclude) =>
       signalMut.mutate({
         services: ex.data?.services ?? [],
@@ -211,5 +213,7 @@ export function useLearnExclusions(licensed: boolean): LearnExclusionControls {
           exclude,
         ),
       }),
+    toggleServices: (services, exclude) =>
+      servicesMut.mutate({ services, exclude }),
   };
 }

--- a/ui/src/pages/ServicesPage.test.tsx
+++ b/ui/src/pages/ServicesPage.test.tsx
@@ -39,6 +39,12 @@ vi.mock("@/lib/api", async (importActual) => {
       setServiceLearnExclusion: vi
         .fn()
         .mockResolvedValue({ services: [], metrics: [], patterns: [] }),
+      setServiceLearnExclusions: vi
+        .fn()
+        .mockResolvedValue({ services: [], metrics: [], patterns: [] }),
+      setLearnExclusions: vi
+        .fn()
+        .mockResolvedValue({ services: [], metrics: [], patterns: [] }),
     },
   };
 });
@@ -264,6 +270,175 @@ describe("ServicesPage Active/Ignored scope", () => {
     renderPage();
     await screen.findByLabelText("View service checkout");
     expect(screen.queryByRole("tablist", { name: "Learning scope" })).toBeNull();
+  });
+});
+
+// A bulk Ignore/Resume over N selected services must send INTENT — ONE call to
+// the batch route carrying only the names + the direction. Sending the WHOLE
+// resulting policy instead let a stale page revert a concurrent change, and
+// because that body also carries the metric + log-pattern grains, a services
+// bulk action could wipe a colleague's metric/log-pattern exclusions.
+describe("ServicesPage bulk Ignore/Resume learning", () => {
+  // Restore the module mock's community defaults so the licensed-admin surface
+  // this block opts into doesn't leak into later describes.
+  afterEach(async () => {
+    const { ApiError } = await import("@/lib/api");
+    vi.mocked(api.listBaselines).mockRejectedValue(
+      new ApiError(403, "community"),
+    );
+    vi.mocked(api.getSSODeployment).mockRejectedValue(
+      new ApiError(403, "community"),
+    );
+    vi.mocked(getSsoSession).mockRejectedValue(new ApiError(401, "no session"));
+    vi.mocked(api.getLearnExclusions).mockResolvedValue({
+      services: [],
+      metrics: [],
+      patterns: [],
+    });
+  });
+
+  function renderBulk(
+    excluded: string[],
+    otherGrains: { metrics: string[]; patterns: string[] } = {
+      metrics: [],
+      patterns: [],
+    },
+  ) {
+    vi.mocked(api.listServicesIndex).mockResolvedValue({
+      services: { checkout: svc(), payments: svc(), search: svc() },
+      total: 3,
+      next_offset: null,
+    });
+    vi.mocked(api.listBaselines).mockResolvedValue({
+      type: "metric",
+      count: 0,
+      baselines: [],
+    });
+    vi.mocked(api.getSSODeployment).mockResolvedValue({ org: "acme" });
+    vi.mocked(getSsoSession).mockResolvedValue({
+      org: "acme",
+      email: "admin@acme.test",
+      subject: "admin",
+      mfa: false,
+      role: "admin",
+      issued_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+    vi.mocked(api.getLearnExclusions).mockResolvedValue({
+      services: excluded,
+      ...otherGrains,
+    });
+    vi.mocked(api.setLearnExclusions).mockClear();
+    vi.mocked(api.setServiceLearnExclusions).mockClear();
+    vi.mocked(api.setServiceLearnExclusions).mockResolvedValue({
+      services: excluded,
+      ...otherGrains,
+    });
+    vi.mocked(api.setServiceLearnExclusion).mockClear();
+    return renderPage();
+  }
+
+  async function selectAllThree(scopeTab: RegExp) {
+    fireEvent.click(await screen.findByRole("tab", { name: scopeTab }));
+    for (const name of ["checkout", "payments", "search"]) {
+      fireEvent.click(await screen.findByLabelText(`Select service ${name}`));
+    }
+  }
+
+  it("ignores every selected service in exactly ONE batch call", async () => {
+    renderBulk([]);
+    await selectAllThree(/Active/);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Ignore learning" }),
+    );
+    await waitFor(() =>
+      expect(vi.mocked(api.setServiceLearnExclusions)).toHaveBeenCalledTimes(1),
+    );
+    expect(vi.mocked(api.setServiceLearnExclusions).mock.calls[0]).toEqual([
+      ["checkout", "payments", "search"],
+      true,
+    ]);
+    // The whole-list PUT and the racing per-service route are both out of the
+    // bulk path — the client never sends a resulting policy for this action.
+    expect(vi.mocked(api.setLearnExclusions)).not.toHaveBeenCalled();
+    expect(vi.mocked(api.setServiceLearnExclusion)).not.toHaveBeenCalled();
+  });
+
+  it("resumes every selected service in exactly ONE batch call", async () => {
+    renderBulk(["checkout", "payments", "search"]);
+    await selectAllThree(/Ignored/);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Resume learning" }),
+    );
+    await waitFor(() =>
+      expect(vi.mocked(api.setServiceLearnExclusions)).toHaveBeenCalledTimes(1),
+    );
+    expect(vi.mocked(api.setServiceLearnExclusions).mock.calls[0]).toEqual([
+      ["checkout", "payments", "search"],
+      false,
+    ]);
+    expect(vi.mocked(api.setLearnExclusions)).not.toHaveBeenCalled();
+    expect(vi.mocked(api.setServiceLearnExclusion)).not.toHaveBeenCalled();
+  });
+
+  // The metric + log-pattern grains are simply not in the request — the client
+  // sends the service names and the direction, nothing else. Carrying them (as
+  // the old whole-list PUT did) is how a services bulk action could revert a
+  // colleague's metric / log-pattern exclusions.
+  it("sends ONLY the service names and the exclude flag — no other grain", async () => {
+    renderBulk([], {
+      metrics: ["go_*", "up"],
+      patterns: ["log:checkout:abc123"],
+    });
+    await selectAllThree(/Active/);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Ignore learning" }),
+    );
+    await waitFor(() =>
+      expect(vi.mocked(api.setServiceLearnExclusions)).toHaveBeenCalledTimes(1),
+    );
+    const [services, exclude] = vi.mocked(api.setServiceLearnExclusions).mock
+      .calls[0];
+    expect(services).toEqual(["checkout", "payments", "search"]);
+    expect(exclude).toBe(true);
+    expect(vi.mocked(api.setServiceLearnExclusions).mock.calls[0]).toHaveLength(
+      2,
+    );
+    expect(vi.mocked(api.setLearnExclusions)).not.toHaveBeenCalled();
+  });
+
+  // The policy the write returns is adopted into the shared cache, so the scope
+  // counts and the partitioned table follow a bulk action with no reload.
+  it("moves every bulk-ignored service into the Ignored scope with no reload", async () => {
+    renderBulk([]);
+    await selectAllThree(/Active/);
+    // From the click on, both the write's answer and the post-write refetch
+    // report the server's new policy.
+    const after = {
+      services: ["checkout", "payments", "search"],
+      metrics: [],
+      patterns: [],
+    };
+    vi.mocked(api.setServiceLearnExclusions).mockResolvedValue(after);
+    vi.mocked(api.getLearnExclusions).mockResolvedValue(after);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Ignore learning" }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("tab", { name: /Ignored/ }).textContent,
+      ).toContain("3"),
+    );
+    expect(screen.getByRole("tab", { name: /Active/ }).textContent).toContain(
+      "0",
+    );
+    expect(screen.queryByText("payments")).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: /Ignored/ }));
+    for (const name of ["checkout", "payments", "search"]) {
+      expect(await screen.findByText(name)).toBeTruthy();
+    }
   });
 });
 

--- a/ui/src/pages/ServicesPage.tsx
+++ b/ui/src/pages/ServicesPage.tsx
@@ -344,18 +344,24 @@ export function ServicesPage() {
         bulk.clear();
         break;
       }
-      case "ignore":
-        bulk.selectedKeys
-          .filter((name) => !ignore.isServiceExcluded(name))
-          .forEach((name) => ignore.toggleService(name, true));
+      case "ignore": {
+        // Sends only intent; the server merges it under a per-org lock, so
+        // concurrent writers compose instead of clobbering each other.
+        const toIgnore = bulk.selectedKeys.filter(
+          (name) => !ignore.isServiceExcluded(name),
+        );
+        if (toIgnore.length > 0) ignore.toggleServices(toIgnore, true);
         bulk.clear();
         break;
-      case "resume":
-        bulk.selectedKeys
-          .filter((name) => ignore.isServiceExcluded(name))
-          .forEach((name) => ignore.toggleService(name, false));
+      }
+      case "resume": {
+        const toResume = bulk.selectedKeys.filter((name) =>
+          ignore.isServiceExcluded(name),
+        );
+        if (toResume.length > 0) ignore.toggleServices(toResume, false);
         bulk.clear();
         break;
+      }
       case "rename":
         if (selectedManual.length === 1) setRenameTarget(selectedManual[0]);
         break;


### PR DESCRIPTION
## What does this PR do?

Fixes a customer-reported bug where selecting several services on the **Services**
page and pressing **"Ignore learning"** only ignored **one** of them, and hardens the
learn-exclusion policy write path that caused it:

- The bulk action now sends **intent** (`{services, exclude}`) to a new server-side
  **batch** endpoint that merges against the current policy under a **per-org lock**,
  so concurrent writers compose instead of clobbering each other.
- Per-service exclusion writes are no longer an unsynchronised read-modify-write.
- A store **read failure can no longer be persisted as an empty policy** (it would
  have silently wiped an org's exclusions and returned held-out data to learning).

## Why?

Customer report: "choose more than 2 services and press ignore — it calls the API
twice but only one service is ignored." Root cause was a lost-update race: the
per-service `AddService` did `read → append → write the whole list`, so N parallel
calls each wrote their own name over the others and the last write won.

For the record, the "passes the same value" observation was a red herring — the
service name travels only in the URL path segment and the request has no body, so
the calls look identical in the network panel except the final segment.

## How to test

1. Bring up the enterprise stack (`run/enterprise.sh`), licensed, signed in as an
   admin (`runtime:manage`).
2. On **Services**, select 3+ services → **Ignore learning**. All of them must move
   to **Ignored** (counts update without a reload) and the network panel must show
   **exactly one** `POST /enterprise/api/agent/learn-exclusions/services/batch` whose
   body is only `{"services":[…],"exclude":true}`. Reload — the exclusions persist.
3. **Resume learning** on the same selection returns them all to **Active**.
4. **Concurrency:** with the Services page open, change the policy from another
   surface (add a metric or log-pattern exclusion), then bulk-ignore from the stale
   page — the other change must survive.
5. **Guards:** community → 403, viewer → 403, no session → 401; an over-cap or empty
   selection → 400 with an audited denial and no write.
6. The per-service toggle on **Service detail** still works (it uses the unchanged
   single-service route).

## Type of change

- [x] Bug fix (non-breaking)
- [x] New feature (non-breaking) — batch service-exclusion endpoint

## Checklist

- [x] `go test ./...` passes locally (enterprise module green; `./pkg/learnexclude/... -race -count=3`)
- [x] `go vet ./...` is clean (both trees)
- [x] Code is `gofmt`'d
- [x] Added or updated tests (concurrency, policy-integrity, guards, audit; UI unit + Playwright e2e)
- [ ] Updated user-facing docs under `src/` if behavior changes
- [ ] Updated `ROADMAP.md` if this closes a roadmap item
- [x] No secrets, tokens, or webhook URLs introduced in source / YAML
- [x] No new third-party dependencies

---

### Detailed changes

**Enterprise — `pkg/learnexclude`**
- New `POST /enterprise/api/agent/learn-exclusions/services/batch`, body
  `{"services":[…],"exclude":bool}`, returning the standard policy snapshot. The
  server merges the caller's intent against the stored policy; metrics, includes and
  log-patterns are never taken from the client. Same license + `runtime:manage`
  guards and the same audited action as the existing writes.
- `AddService`/`RemoveService`/`ReplaceGrains` read-modify-writes are serialised by a
  **per-org** write lock (was an unsynchronised RMW, then briefly a process-global
  mutex). `Replace`/`ReplaceWithIncludes`/`ReplaceAll` all route through the locked
  `ReplaceGrains`, so the PUT handler no longer does an unlocked preserve-read. Store
  round-trips under the lock cut 4 → 2; the hot learning path is never serialised
  behind a write.
- **Policy integrity:** `loadExclusions` now distinguishes *absent* (`nil, nil`) from
  *failed / corrupt* (`nil, err`). Every read-then-write path aborts with a 500 on a
  read error instead of writing from a zero base; admin reads surface the error
  rather than presenting `[]` as fact; the hot path fails open to the **last known
  good** cached set and never writes a failed read back. A full four-grain PUT still
  repairs a corrupt artifact.
- Audit targets now name the affected services (bounded to 10 + a `sha256` digest for
  the remainder) and are sanitised against control characters / invalid UTF-8 — also
  applied to the single-service route. An over-cap merge is rejected 400 + audited
  rather than silently truncated.

**OSS UI**
- `api.setServiceLearnExclusions(services, exclude)` posts to the batch route; the
  `log_patterns`⇄`patterns` mapping shared by all learn-exclusion calls was extracted
  into one helper.
- `useLearnExclusions.toggleServices` drives the batch route with names + flag only;
  `ServicesPage` bulk ignore/resume make one call over the applicable subset. Dead
  `toggleService` / `toggleServiceExclusions` removed.

**Toolchain**
- Pinned `toolchain go1.26.6` in both modules, clearing 6 fixable stdlib CVEs found
  during the gate (drift off the old go1.26.5 pin).

### Verification

- **QA — PASS.** Real Chromium + live stack. 3+ services now all ignore in one
  request and survive a reload; the agent reports `learning_disabled:true` for each;
  resume restores them; guards, scope counts and the detail-page toggle unaffected.
  The stale-client clobber (**QA-060**) was reproduced against the interim whole-list
  design and re-verified as **closed** after the batch-intent switch. New spec:
  `versus-enterprise/tests/e2e/disable-learn/browser/bulk-ignore-services.spec.ts`.
- **Security — PASS** (after clearing one S1). The interim design's silent
  policy-wipe on a store read failure was found, fixed and re-verified; RBAC + audit
  parity on the new route, org-scoped and safe lock keying, bounded input, no
  deadlock or hot-path stall, grains preserved, no new dependency findings.

### Known limitations / follow-ups

- The **metric** and **log-pattern** grains (`toggleSignals` / `togglePatterns`) still
  send the whole cached policy and keep the same stale-client revert exposure — they
  have no batch route yet. Pre-existing, not introduced here.
- The per-org write lock is **process-scoped**: it serialises writers within one
  replica. Multi-replica deployments would need a store-level compare-and-swap;
  deliberately not built under the current single-instance pivot.
- Last-known-good is per-process, so a restart during a store outage degrades to the
  pre-existing fail-open.
