### PR TITLE
fix(chat): humanize chat answers

### DIFF
--- a/pkg/agent/ai/chat/agent.go
+++ b/pkg/agent/ai/chat/agent.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 	"sync"
@@ -50,6 +51,7 @@ type Options struct {
 
 type Agent struct {
 	cfg          config.AgentAIConfig
+	runtime      einowrap.RuntimeAI
 	chatModel    model.ToolCallingChatModel
 	holder       *einowrap.Holder[model.ToolCallingChatModel]
 	tools        []core.Tool
@@ -84,7 +86,7 @@ func New(ctx context.Context, cfg config.AgentAIConfig, tools []core.Tool, opts 
 		filtered = append(filtered, value)
 		displays[value.Name()] = core.ToolDisplayName(value)
 	}
-	agent := &Agent{cfg: cfg, tools: filtered, toolDisplays: displays, toolTimeout: toolTimeout, toolProvider: opts.ToolProvider, seedProvider: opts.SeedProvider}
+	agent := &Agent{cfg: cfg, runtime: opts.Runtime, tools: filtered, toolDisplays: displays, toolTimeout: toolTimeout, toolProvider: opts.ToolProvider, seedProvider: opts.SeedProvider}
 	if opts.ChatModel != nil {
 		if _, err := agent.buildRunner(ctx, opts.ChatModel); err != nil {
 			return nil, err
@@ -180,6 +182,7 @@ func (agent *Agent) RunChatTurn(ctx context.Context, task core.ChatTask) (*core.
 	var sequence int64
 	messages, compacted := historyMessages(runCtx)
 	messages = append(messages, schema.UserMessage(buildUserPrompt(task)))
+	messages = normalizeHistoryMessages(messages)
 
 	core.EmitChatEvent(ctx, core.ChatEvent{Seq: atomic.AddInt64(&sequence, 1), Kind: core.ChatEventRunStarted})
 	if compacted > 0 {
@@ -201,7 +204,7 @@ func (agent *Agent) RunChatTurn(ctx context.Context, task core.ChatTask) (*core.
 			if errors.Is(event.Err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				return result, fmt.Errorf("chat: run timed out: %w", context.DeadlineExceeded)
 			}
-			return result, errModelResponseUnavailable
+			return result, newModelResponseError(agent.effectiveProvider(runCtx), agent.cfg.Model, event.Err)
 		}
 		if event.Output == nil || event.Output.MessageOutput == nil {
 			continue
@@ -215,7 +218,7 @@ func (agent *Agent) RunChatTurn(ctx context.Context, task core.ChatTask) (*core.
 		}
 		message, messageErr := consumeMessage(ctx, variant, onDelta)
 		if messageErr != nil {
-			return result, safeRunError(ctx, messageErr)
+			return result, safeRunError(ctx, messageErr, agent.effectiveProvider(runCtx), agent.cfg.Model)
 		}
 		if message == nil {
 			continue
@@ -248,10 +251,10 @@ func (agent *Agent) RunChatTurn(ctx context.Context, task core.ChatTask) (*core.
 	}
 	result.DurationMs = time.Since(started).Milliseconds()
 	if ctx.Err() != nil {
-		return result, safeRunError(ctx, ctx.Err())
+		return result, safeRunError(ctx, ctx.Err(), agent.effectiveProvider(runCtx), agent.cfg.Model)
 	}
 	if result.Markdown == "" {
-		return result, errModelResponseUnavailable
+		return result, &modelResponseError{diagnostic: modelResponseDiagnostic(agent.effectiveProvider(runCtx), agent.cfg.Model, "empty_response")}
 	}
 	return result, nil
 }
@@ -341,14 +344,126 @@ func consumeMessage(ctx context.Context, variant *adk.MessageVariant, onDelta fu
 	return schema.ConcatMessages(chunks)
 }
 
-func safeRunError(ctx context.Context, err error) error {
+func safeRunError(ctx context.Context, err error, provider, model string) error {
 	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
 		return context.Canceled
 	}
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return fmt.Errorf("chat: run timed out: %w", context.DeadlineExceeded)
 	}
-	return errModelResponseUnavailable
+	return newModelResponseError(provider, model, err)
+}
+
+type modelResponseError struct {
+	diagnostic string
+}
+
+func (err *modelResponseError) Error() string { return errModelResponseUnavailable.Error() }
+func (err *modelResponseError) Unwrap() error { return errModelResponseUnavailable }
+
+func newModelResponseError(provider, model string, cause error) error {
+	return &modelResponseError{diagnostic: modelResponseDiagnostic(provider, model, cause.Error())}
+}
+
+func modelResponseDiagnostic(provider, model, failure string) string {
+	provider = safeModelIdentifier(provider, "openai")
+	model = safeModelIdentifier(model, "configured model")
+	label := strings.ToUpper(provider[:1]) + provider[1:]
+	normalizedFailure := strings.ToLower(failure)
+	checkLogs := " Check the Versus server logs for the full provider error."
+
+	log.Printf("chat model provider error: provider=%q model=%q error=%s", provider, model, failure)
+
+	if detail := safeProviderValidationDetail(failure); detail != "" {
+		return fmt.Sprintf("%s rejected the generated chat history for model %q: %s.%s", label, model, strings.TrimSuffix(detail, "."), checkLogs)
+	}
+	switch {
+	case normalizedFailure == "empty_response":
+		return fmt.Sprintf("%s model %q returned no assistant content; increase the completion-token budget or choose a compatible model.%s", label, model, checkLogs)
+	case strings.Contains(normalizedFailure, "temperature") && (strings.Contains(normalizedFailure, "deprecated") || strings.Contains(normalizedFailure, "unsupported") || strings.Contains(normalizedFailure, "not support")):
+		return fmt.Sprintf("%s model %q rejected the configured temperature; set AGENT_AI_TEMPERATURE=-1 to omit it, restart Versus, and retry.%s", label, model, checkLogs)
+	case strings.Contains(normalizedFailure, "401"), strings.Contains(normalizedFailure, "unauthorized"), strings.Contains(normalizedFailure, "authentication"), strings.Contains(normalizedFailure, "invalid_api_key"), strings.Contains(normalizedFailure, "invalid api key"):
+		return fmt.Sprintf("%s authentication failed for model %q; verify the configured API key.%s", label, model, checkLogs)
+	case strings.Contains(normalizedFailure, "403"), strings.Contains(normalizedFailure, "forbidden"), strings.Contains(normalizedFailure, "permission denied"):
+		return fmt.Sprintf("%s denied access to model %q; verify model permissions.%s", label, model, checkLogs)
+	case strings.Contains(normalizedFailure, "404"), strings.Contains(normalizedFailure, "model_not_found"), strings.Contains(normalizedFailure, "model not found"), strings.Contains(normalizedFailure, "not_found_error"):
+		return fmt.Sprintf("%s model %q was not found or is unavailable to this account.%s", label, model, checkLogs)
+	case strings.Contains(normalizedFailure, "429"), strings.Contains(normalizedFailure, "rate limit"), strings.Contains(normalizedFailure, "rate_limit"):
+		return fmt.Sprintf("%s rate limit or quota was reached for model %q; retry later or check provider limits.%s", label, model, checkLogs)
+	case strings.Contains(normalizedFailure, "400"), strings.Contains(normalizedFailure, "invalid_request"):
+		return fmt.Sprintf("%s rejected the request for model %q as invalid; verify model compatibility and token limits.%s", label, model, checkLogs)
+	case strings.Contains(normalizedFailure, "timeout"), strings.Contains(normalizedFailure, "deadline exceeded"):
+		return fmt.Sprintf("%s timed out while calling model %q.%s", label, model, checkLogs)
+	case strings.Contains(normalizedFailure, "connection refused"), strings.Contains(normalizedFailure, "no such host"), strings.Contains(normalizedFailure, "tls"):
+		return fmt.Sprintf("Could not connect securely to %s for model %q.%s", label, model, checkLogs)
+	default:
+		return fmt.Sprintf("%s could not produce a response with model %q; verify provider configuration and model access.%s", label, model, checkLogs)
+	}
+}
+
+func safeProviderValidationDetail(failure string) string {
+	type providerErrorEnvelope struct {
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	var envelope providerErrorEnvelope
+	for offset := 0; offset < len(failure); {
+		start := strings.IndexByte(failure[offset:], '{')
+		if start < 0 {
+			return ""
+		}
+		start += offset
+		envelope = providerErrorEnvelope{}
+		if err := json.NewDecoder(strings.NewReader(failure[start:])).Decode(&envelope); err == nil && envelope.Error.Type == "invalid_request_error" {
+			break
+		}
+		offset = start + 1
+	}
+	if envelope.Error.Type != "invalid_request_error" {
+		return ""
+	}
+	detail := strings.Join(strings.Fields(envelope.Error.Message), " ")
+	lower := strings.ToLower(detail)
+	if len(detail) == 0 || len(detail) > 512 || !strings.HasPrefix(lower, "messages.") {
+		return ""
+	}
+	for _, sensitive := range []string{"sk-", "api key", "apikey", "authorization", "bearer", "password", "secret", "token="} {
+		if strings.Contains(lower, sensitive) {
+			return ""
+		}
+	}
+	return detail
+}
+
+func safeModelIdentifier(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	if len(value) > 128 {
+		return fallback
+	}
+	for _, character := range value {
+		if !((character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || (character >= '0' && character <= '9') || strings.ContainsRune("._:/-", character)) {
+			return fallback
+		}
+	}
+	return value
+}
+
+func (agent *Agent) effectiveProvider(ctx context.Context) string {
+	provider := strings.TrimSpace(agent.cfg.Provider)
+	if provider == "" {
+		provider = einowrap.DefaultProvider
+	}
+	if agent.runtime.Provider != nil {
+		if runtimeProvider, ok := agent.runtime.Provider(ctx); ok && einowrap.IsSupportedProvider(runtimeProvider) {
+			provider = runtimeProvider
+		}
+	}
+	return strings.ToLower(provider)
 }
 
 func historyMessages(ctx context.Context) ([]*schema.Message, int) {
@@ -366,10 +481,42 @@ func historyMessages(ctx context.Context) ([]*schema.Message, int) {
 		case TurnAssistant:
 			messages = append(messages, schema.AssistantMessage(capString(turn.Content, MaxOutputBytes), nil))
 		case TurnCompaction:
-			messages = append(messages, schema.SystemMessage(capString(turn.Content, 512)))
+			messages = append(messages, schema.UserMessage(capString(turn.Content, 512)))
 		}
 	}
 	return messages, compacted
+}
+
+func normalizeHistoryMessages(messages []*schema.Message) []*schema.Message {
+	firstUser := 0
+	for firstUser < len(messages) && messages[firstUser].Role != schema.User {
+		firstUser++
+	}
+	messages = messages[firstUser:]
+	normalized := make([]*schema.Message, 0, len(messages))
+	for _, message := range messages {
+		if message == nil || (message.Role != schema.User && message.Role != schema.Assistant) {
+			continue
+		}
+		if len(normalized) > 0 && normalized[len(normalized)-1].Role == message.Role {
+			previous := normalized[len(normalized)-1]
+			content := strings.TrimSpace(previous.Content)
+			if next := strings.TrimSpace(message.Content); next != "" {
+				if content != "" {
+					content += "\n\n"
+				}
+				content += next
+			}
+			if message.Role == schema.User {
+				normalized[len(normalized)-1] = schema.UserMessage(content)
+			} else {
+				normalized[len(normalized)-1] = schema.AssistantMessage(content, nil)
+			}
+			continue
+		}
+		normalized = append(normalized, message)
+	}
+	return normalized
 }
 
 type turnGuardContextKey struct{}

--- a/pkg/agent/ai/chat/agent_test.go
+++ b/pkg/agent/ai/chat/agent_test.go
@@ -1,18 +1,68 @@
 package chat
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"log"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/cloudwego/eino/adk"
+	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/schema"
 
 	"github.com/VersusControl/versus-incident/pkg/config"
 	"github.com/VersusControl/versus-incident/pkg/core"
 )
+
+func TestModelResponseDiagnosticClassifiesWithoutLeakingProviderBody(t *testing.T) {
+	const checkLogs = " Check the Versus server logs for the full provider error."
+	tests := []struct {
+		name    string
+		failure string
+		want    string
+	}{
+		{name: "authentication", failure: "status 401 invalid_api_key sk-secret", want: `Claude authentication failed for model "claude-sonnet-5"; verify the configured API key.` + checkLogs},
+		{name: "model", failure: "status 404 model_not_found sk-secret", want: `Claude model "claude-sonnet-5" was not found or is unavailable to this account.` + checkLogs},
+		{name: "quota", failure: "status 429 rate_limit sk-secret", want: `Claude rate limit or quota was reached for model "claude-sonnet-5"; retry later or check provider limits.` + checkLogs},
+		{name: "temperature", failure: "status 400 invalid_request_error: `temperature` is deprecated for this model", want: `Claude model "claude-sonnet-5" rejected the configured temperature; set AGENT_AI_TEMPERATURE=-1 to omit it, restart Versus, and retry.` + checkLogs},
+		{name: "message ordering", failure: `status 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.1: role 'system' must precede an 'assistant' message or end the array"}}`, want: `Claude rejected the generated chat history for model "claude-sonnet-5": messages.1: role 'system' must precede an 'assistant' message or end the array.` + checkLogs},
+		{name: "spaced message ordering", failure: `status 400 prefix {"type": "error", "error": {"type": "invalid_request_error", "message": "messages.2: roles must alternate"}} trailing`, want: `Claude rejected the generated chat history for model "claude-sonnet-5": messages.2: roles must alternate.` + checkLogs},
+		{name: "unsafe validation body", failure: `status 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.1: leaked sk-secret"}}`, want: `Claude rejected the request for model "claude-sonnet-5" as invalid; verify model compatibility and token limits.` + checkLogs},
+		{name: "unknown", failure: "provider exploded with sk-secret", want: `Claude could not produce a response with model "claude-sonnet-5"; verify provider configuration and model access.` + checkLogs},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := newModelResponseError("claude", "claude-sonnet-5", errors.New(test.failure))
+			var modelErr *modelResponseError
+			if !errors.Is(err, errModelResponseUnavailable) || !errors.As(err, &modelErr) {
+				t.Fatalf("error = %v, want typed model response error", err)
+			}
+			if modelErr.diagnostic != test.want {
+				t.Fatalf("diagnostic = %q, want %q", modelErr.diagnostic, test.want)
+			}
+			if strings.Contains(modelErr.diagnostic, "sk-secret") {
+				t.Fatalf("diagnostic leaked provider response: %q", modelErr.diagnostic)
+			}
+		})
+	}
+}
+
+func TestModelResponseDiagnosticLogsOriginalProviderError(t *testing.T) {
+	var output bytes.Buffer
+	originalWriter := log.Writer()
+	log.SetOutput(&output)
+	t.Cleanup(func() { log.SetOutput(originalWriter) })
+
+	failure := "HTTP 400 Bad Request: `temperature` is Deprecated for This Model"
+	_ = modelResponseDiagnostic("claude", "claude-sonnet-5", failure)
+	if !strings.Contains(output.String(), failure) {
+		t.Fatalf("log output = %q, want original provider error %q", output.String(), failure)
+	}
+}
 
 type countingTool struct{ calls int }
 
@@ -37,6 +87,29 @@ type captureChatObserver struct{ events []core.ChatEvent }
 
 func (observer *captureChatObserver) OnChatEvent(event core.ChatEvent) {
 	observer.events = append(observer.events, event)
+}
+
+type recordingChatModel struct {
+	messages []*schema.Message
+}
+
+func (chatModel *recordingChatModel) Generate(_ context.Context, messages []*schema.Message, _ ...model.Option) (*schema.Message, error) {
+	chatModel.messages = append([]*schema.Message(nil), messages...)
+	return schema.AssistantMessage("Healthy", nil), nil
+}
+
+func (chatModel *recordingChatModel) Stream(_ context.Context, messages []*schema.Message, _ ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	chatModel.messages = append([]*schema.Message(nil), messages...)
+	reader, writer := schema.Pipe[*schema.Message](1)
+	go func() {
+		defer writer.Close()
+		writer.Send(schema.AssistantMessage("Healthy", nil), nil)
+	}()
+	return reader, nil
+}
+
+func (chatModel *recordingChatModel) WithTools([]*schema.ToolInfo) (model.ToolCallingChatModel, error) {
+	return chatModel, nil
 }
 
 func (tool *countingTool) Name() string               { return "counting" }
@@ -122,6 +195,74 @@ func TestHistoryCompactionIsVisible(t *testing.T) {
 	}
 	if compacted != 3 {
 		t.Fatalf("compacted = %d, want 3", compacted)
+	}
+}
+
+func TestHistoryCompactionDoesNotInjectSystemMessages(t *testing.T) {
+	turns := []Turn{
+		{Role: TurnAssistant, Content: "Earlier answer"},
+		{Role: TurnCompaction, Content: `{"kind":"session_discovery"}`},
+		{Role: TurnUser, Content: "What is unhealthy?"},
+	}
+	messages, _ := historyMessages(withHistory(context.Background(), turns))
+	if len(messages) != len(turns) {
+		t.Fatalf("messages = %d, want %d", len(messages), len(turns))
+	}
+	for index, message := range messages {
+		if message.Role == schema.System {
+			t.Fatalf("message %d has system role in replayed history", index)
+		}
+	}
+	if messages[1].Role != schema.User || messages[1].Content != turns[1].Content {
+		t.Fatalf("compaction message = %#v, want bounded user context", messages[1])
+	}
+}
+
+func TestAgentSendsOnlyLeadingSystemMessageAfterCompaction(t *testing.T) {
+	chatModel := &recordingChatModel{}
+	agent, err := New(context.Background(), config.AgentAIConfig{Model: "test-model"}, nil, Options{ChatModel: chatModel})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := withHistory(context.Background(), []Turn{
+		{Role: TurnAssistant, Content: "Earlier answer"},
+		{Role: TurnCompaction, Content: `{"kind":"session_discovery"}`},
+	})
+	if _, err := agent.RunChatTurn(ctx, core.ChatTask{Message: "What is unhealthy?"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(chatModel.messages) != 2 || chatModel.messages[0].Role != schema.System {
+		t.Fatalf("model messages = %#v, want leading system instruction and history", chatModel.messages)
+	}
+	for index, message := range chatModel.messages[1:] {
+		if message.Role == schema.System {
+			t.Fatalf("model message %d has system role after conversation started", index+1)
+		}
+	}
+	if chatModel.messages[1].Role != schema.User || !strings.Contains(chatModel.messages[1].Content, "session_discovery") || !strings.Contains(chatModel.messages[1].Content, "What is unhealthy?") {
+		t.Fatalf("normalized user context = %#v", chatModel.messages[1])
+	}
+}
+
+func TestNormalizeHistoryMessagesAlternatesRoles(t *testing.T) {
+	messages := normalizeHistoryMessages([]*schema.Message{
+		schema.AssistantMessage("orphaned answer", nil),
+		schema.UserMessage("retained context"),
+		schema.UserMessage("current question"),
+		schema.AssistantMessage("first answer", nil),
+		schema.AssistantMessage("continued answer", nil),
+	})
+	if len(messages) != 2 {
+		t.Fatalf("messages = %#v, want two alternating messages", messages)
+	}
+	if messages[0].Role != schema.User || messages[1].Role != schema.Assistant {
+		t.Fatalf("roles = %s, %s", messages[0].Role, messages[1].Role)
+	}
+	if !strings.Contains(messages[0].Content, "retained context") || !strings.Contains(messages[0].Content, "current question") {
+		t.Fatalf("merged user content = %q", messages[0].Content)
+	}
+	if !strings.Contains(messages[1].Content, "first answer") || !strings.Contains(messages[1].Content, "continued answer") {
+		t.Fatalf("merged assistant content = %q", messages[1].Content)
 	}
 }
 

--- a/pkg/agent/ai/chat/prompt_test.go
+++ b/pkg/agent/ai/chat/prompt_test.go
@@ -49,3 +49,17 @@ func TestSystemPromptRequiresKnowledgeToolsAndHonestUnknowns(t *testing.T) {
 		}
 	}
 }
+
+func TestSystemPromptRequiresHumanReadableEvidence(t *testing.T) {
+	prompt := SystemPrompt()
+	for _, required := range []string{
+		"Write for an operator, not for an API developer",
+		"Do not expose internal tool function names",
+		"Never copy internal tool names, snake_case response keys, JSON field paths, or tool arguments",
+		"Let the UI render source citations from tool-call metadata",
+	} {
+		if !strings.Contains(prompt, required) {
+			t.Errorf("system prompt missing human-readable output rule %q", required)
+		}
+	}
+}

--- a/pkg/agent/ai/chat/prompts/OUTPUT.md
+++ b/pkg/agent/ai/chat/prompts/OUTPUT.md
@@ -2,4 +2,6 @@
 
 Answer in concise conversational Markdown. GitHub-flavored tables are allowed when comparison helps.
 
-Separate **Validated** facts from **Speculative** hypotheses. Every factual operational claim must cite the supporting tool and evidence locator. State clearly when no connected source can validate a claim.
+Write for an operator, not for an API developer. Translate tool output into natural labels and sentences. Do not expose internal tool function names, JSON keys, field paths, argument names, or raw booleans in the answer unless the user explicitly asks for raw evidence or implementation details.
+
+Separate **Validated** facts from **Speculative** hypotheses. Ground factual operational claims in tool evidence, but present that evidence in human language. State clearly when no connected source can validate a claim.

--- a/pkg/agent/ai/chat/prompts/RULES.md
+++ b/pkg/agent/ai/chat/prompts/RULES.md
@@ -9,5 +9,7 @@
 - Use `get_system_overview` with attached absolute start and end bounds for incident-window summaries, then `search_incidents` and `get_incident` for matching records and details.
 - Never infer a resolver, assignee, decision reason, pattern provenance, reliability state, license state, or source availability when a tool reports it missing or unknown.
 - Do not expose raw incident payloads, credentials, backend errors, or hidden system data.
+- Never copy internal tool names, snake_case response keys, JSON field paths, or tool arguments into ordinary user-facing prose. Summarize their meaning with human-readable operational language.
+- Let the UI render source citations from tool-call metadata; do not manufacture a Markdown source list or describe a tool call as the source.
 - Do not repeat an identical tool call after it returned the same evidence.
 - If tools remain unavailable or evidence stops changing, stop and explain the limitation.

--- a/pkg/agent/ai/chat/service.go
+++ b/pkg/agent/ai/chat/service.go
@@ -351,7 +351,14 @@ func (service *Service) execute(runCtx context.Context, session *Session, id, me
 		} else if errors.Is(runErr, errModelResponseUnavailable) {
 			terminal.Error = "model response unavailable"
 			message = "The model could not produce a response. Verify the configured AI provider credentials, model access, and completion-token budget, then retry."
-			log.Printf("chat run failed: session_id=%q code=model_response_unavailable", id)
+			logDetail := message
+			var modelErr *modelResponseError
+			if errors.As(runErr, &modelErr) && modelErr.diagnostic != "" {
+				terminal.Error = modelErr.diagnostic
+				message = modelErr.diagnostic
+				logDetail = modelErr.diagnostic
+			}
+			log.Printf("chat run failed: session_id=%q code=model_response_unavailable detail=%q", id, logDetail)
 		}
 		if err := service.persistTerminal(runCtx, id, terminal, message, events); err != nil {
 			return nil, err

--- a/pkg/agent/ai/chat/service_test.go
+++ b/pkg/agent/ai/chat/service_test.go
@@ -56,6 +56,18 @@ func (unavailableModelRunner) RunChat(context.Context, core.ChatTask) (*core.Cha
 	return nil, errModelResponseUnavailable
 }
 
+type detailedUnavailableModelRunner struct{}
+
+func (detailedUnavailableModelRunner) RunChat(context.Context, core.ChatTask) (*core.ChatTurnResult, error) {
+	return nil, newModelResponseError("claude", "claude-sonnet-5", errors.New("status 404: key=secret-value model_not_found"))
+}
+
+type deprecatedTemperatureRunner struct{}
+
+func (deprecatedTemperatureRunner) RunChat(context.Context, core.ChatTask) (*core.ChatTurnResult, error) {
+	return nil, newModelResponseError("claude", "claude-sonnet-5", errors.New("status 400: `temperature` is deprecated for this model"))
+}
+
 type captureTaskRunner struct{ task core.ChatTask }
 
 func (runner *captureTaskRunner) RunChat(_ context.Context, task core.ChatTask) (*core.ChatTurnResult, error) {
@@ -117,6 +129,42 @@ func TestServicePersistsActionableModelResponseFailure(t *testing.T) {
 	}
 	if len(last.Events) == 0 || last.Events[len(last.Events)-1].Error != "model response unavailable" {
 		t.Fatalf("failure events = %+v", last.Events)
+	}
+}
+
+func TestServicePersistsSafeModelResponseDetail(t *testing.T) {
+	service, id := newTestService(t, detailedUnavailableModelRunner{})
+	if _, err := service.Send(context.Background(), id, "what changed?", nil); !errors.Is(err, errModelResponseUnavailable) {
+		t.Fatalf("Send error = %v, want model response unavailable", err)
+	}
+	session, err := service.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	last := session.Turns[len(session.Turns)-1]
+	want := `Claude model "claude-sonnet-5" was not found or is unavailable to this account. Check the Versus server logs for the full provider error.`
+	if last.Content != want || len(last.Events) == 0 || last.Events[len(last.Events)-1].Error != want {
+		t.Fatalf("failure turn = %+v, want safe provider detail %q", last, want)
+	}
+	if strings.Contains(last.Content, "secret-value") {
+		t.Fatalf("failure detail leaked provider response: %q", last.Content)
+	}
+}
+
+func TestServicePersistsTemperatureOmissionGuidance(t *testing.T) {
+	service, id := newTestService(t, deprecatedTemperatureRunner{})
+	if _, err := service.Send(context.Background(), id, "what changed?", nil); !errors.Is(err, errModelResponseUnavailable) {
+		t.Fatalf("Send error = %v, want model response unavailable", err)
+	}
+	session, err := service.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	last := session.Turns[len(session.Turns)-1]
+	for _, required := range []string{"AGENT_AI_TEMPERATURE=-1", "restart Versus", "server logs"} {
+		if !strings.Contains(last.Content, required) || len(last.Events) == 0 || !strings.Contains(last.Events[len(last.Events)-1].Error, required) {
+			t.Fatalf("failure turn = %+v, want guidance containing %q", last, required)
+		}
 	}
 }
 

--- a/pkg/agent/ai/eino/provider_test.go
+++ b/pkg/agent/ai/eino/provider_test.go
@@ -443,3 +443,42 @@ func TestChatModel_Claude_EgressUsesAPIKeyHeader(t *testing.T) {
 		t.Errorf("Title = %q, want %q", got.Title, expected.Title)
 	}
 }
+
+func TestClaudeTemperatureCompatibility(t *testing.T) {
+	for _, test := range []struct {
+		model           string
+		temperature     float64
+		wantTemperature bool
+	}{
+		{model: "claude-3-5-sonnet-20241022", temperature: 0.2, wantTemperature: true},
+		{model: "claude-sonnet-5", temperature: 0.2, wantTemperature: true},
+		{model: "claude-sonnet-5", temperature: -1, wantTemperature: false},
+	} {
+		t.Run(test.model, func(t *testing.T) {
+			var request map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, incoming *http.Request) {
+				if err := json.NewDecoder(incoming.Body).Decode(&request); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = writer.Write([]byte(`{"id":"msg_test","type":"message","role":"assistant","model":"test","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+			}))
+			defer server.Close()
+
+			chatModel, err := einowrap.NewChatModel(context.Background(), config.AgentAIConfig{
+				Provider: "claude", APIKey: "test-key", Model: test.model,
+				MaxTokens: 64, Temperature: test.temperature,
+			}, einowrap.Options{BaseURL: server.URL, HTTPClient: server.Client()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := chatModel.Generate(context.Background(), []*schema.Message{schema.UserMessage("hello")}); err != nil {
+				t.Fatal(err)
+			}
+			_, hasTemperature := request["temperature"]
+			if hasTemperature != test.wantTemperature {
+				t.Fatalf("temperature present = %t, want %t; request=%v", hasTemperature, test.wantTemperature, request)
+			}
+		})
+	}
+}

--- a/ui/src/pages/ChatPage.test.tsx
+++ b/ui/src/pages/ChatPage.test.tsx
@@ -75,6 +75,30 @@ afterEach(() => {
 });
 
 describe("ChatPage", () => {
+  it("hides scroll-to-bottom after starting a new empty thread", async () => {
+    const populated = {
+      ...baseSession,
+      turns: [{ id: "u1", role: "user" as const, content: "Investigate latency", created_at: baseSession.created_at }],
+    };
+    vi.mocked(api.listChatSessions).mockResolvedValue([populated]);
+    vi.mocked(api.getChatSession).mockResolvedValue(populated);
+    renderPage("/agent/chat?session=session-1");
+    await screen.findByText("Investigate latency");
+
+    const conversation = screen.getByRole("log", { name: "Conversation" });
+    Object.defineProperties(conversation, {
+      scrollHeight: { value: 1000, configurable: true },
+      clientHeight: { value: 300, configurable: true },
+      scrollTop: { value: 100, writable: true, configurable: true },
+    });
+    fireEvent.scroll(conversation);
+    expect(screen.getByRole("button", { name: "Scroll to bottom" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open chat history" }));
+    fireEvent.click(screen.getByRole("button", { name: "New thread" }));
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Scroll to bottom" })).toBeNull());
+  });
+
   it("loads a deep-linked session and derives its history title", async () => {
     const full = {
       ...baseSession,
@@ -119,6 +143,20 @@ describe("ChatPage", () => {
     await waitFor(() => expect(api.createChatSession).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(screen.getAllByText("Deployment v42 changed checkout.")).toHaveLength(1));
     expect(api.streamChatMessage).toHaveBeenCalledWith("session-1", "What changed?", undefined, expect.any(Function), expect.any(AbortSignal));
+  });
+
+  it("shows safe model provider details when a chat run fails", async () => {
+    const detail = 'Claude model "claude-sonnet-5" was not found or is unavailable to this account';
+    vi.mocked(api.streamChatMessage).mockImplementation(async (_id, _message, _attachment, onEvent) => {
+      const terminal = { seq: 2, at: "", kind: "run_failed" as const, error: detail };
+      onEvent(terminal);
+      return terminal;
+    });
+    renderPage("/agent/chat?session=session-1");
+    fireEvent.change(await screen.findByLabelText("Message"), { target: { value: "What changed?" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(await screen.findByText(detail)).toBeTruthy();
   });
 
   it("uses a minimal icon-only composer without attachment or budget controls", async () => {

--- a/ui/src/pages/ChatPage.tsx
+++ b/ui/src/pages/ChatPage.tsx
@@ -632,7 +632,7 @@ export function ChatPage() {
                     <div className="sr-only" aria-live="polite">{active ? (selectedRun?.stopping ? "Stopping chat run" : "Chat run in progress") : stream.terminal ? "Chat run complete" : ""}</div>
                   </div>
                 </div>
-                {!scroll.following && <button type="button" onClick={scroll.scrollToBottom} className="absolute bottom-44 left-1/2 z-sticky flex -translate-x-1/2 items-center gap-2 rounded-full border border-ink-500/60 bg-surface px-3 py-2 text-xs text-ink-200 shadow-overlay"><ArrowDown size={14} />Scroll to bottom</button>}
+                {conversationStarted && !scroll.following && <button type="button" onClick={scroll.scrollToBottom} className="absolute bottom-44 left-1/2 z-sticky flex -translate-x-1/2 items-center gap-2 rounded-full border border-ink-500/60 bg-surface px-3 py-2 text-xs text-ink-200 shadow-overlay"><ArrowDown size={14} />Scroll to bottom</button>}
                 <div className={clsx("absolute left-0 right-0 z-sticky mx-auto max-w-3xl px-4 transition-[bottom,transform] duration-300", conversationStarted ? "bottom-4" : "bottom-[20vh]")}><Composer value={draft} onChange={setDraft} onSubmit={send} running={active} stopping={selectedRun?.stopping ?? false} onStop={stop} /></div>
               </>
             )}


### PR DESCRIPTION
## What does this PR do?

Fixes DevOps Chat runs that failed against Anthropic with an opaque
`model_response_unavailable`, and makes the failure and the answer readable for
operators.

Two independent provider defects were fixed:

1. **Message ordering.** Persisted seed and compaction markers were replayed as
   `system` messages inside the conversation. Anthropic rejects a system message
   that appears after the conversation has started, so every chat turn failed
   with HTTP 400. Replayed history is now user/assistant only, starts at the
   first user turn, and merges adjacent same-role turns, leaving ADK's single
   leading system instruction as the only system message.
2. **Deprecated sampling.** `claude-sonnet-5` rejects an explicit `temperature`.
   Omission stays an explicit operator choice through the existing negative
   sentinel (`AGENT_AI_TEMPERATURE=-1`); no model-name heuristic silently
   overrides configuration. A test pins that Claude still sends the configured
   temperature unless the sentinel is set.

Error reporting and chat UX also changed:

- The full upstream provider error is logged server-side with provider and model
  context for debugging.
- The user-facing message is a bounded classification (auth, model, quota,
  timeout, connectivity, invalid request), always points to the server log, and
  for temperature rejections names `AGENT_AI_TEMPERATURE=-1` plus restart.
- Anthropic `invalid_request_error` detail is surfaced only when it is a
  `messages.N` validation path and contains no credential markers.
- The sticky **Scroll to bottom** control renders only after a conversation has
  content, so it no longer floats over a newly created empty thread.
- The chat prompt requires operator language and forbids internal tool function
  names, snake_case response keys, JSON field paths, and tool arguments in
  ordinary prose. Evidence citations continue to render from tool-call metadata.

## Why?

Operators only saw `chat run failed: session_id=... code=model_response_unavailable`.
That is true but useless: it cannot distinguish a bad API key from an unknown
model, an exhausted quota, or a malformed request, so every failure required
reading source code. At the same time the raw provider body must not reach the
chat surface, because provider SDK errors can echo request content and masked
credential fragments.

Answers had the same problem in the opposite direction: they exposed
implementation detail such as `get_system_overview`, `incident_counts.Total`,
`incident_data_available`, and `time_range_minutes`, which is noise for the
operator the assistant is written for.

## How to test

Backend:

```sh
cd versus-incident
gofmt -l .
go test ./...
go vet ./...
```

UI:

```sh
cd versus-incident/ui
npm run lint
npm run build
npm test
```

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (config / API / default behavior)
- [ ] Documentation only
- [ ] Refactor (no functional change)
- [ ] CI / build / chore

No configuration key, API route, or default value changes. `AGENT_AI_TEMPERATURE`
keeps its existing negative-value semantics.

## Checklist

- [x] `go test ./...` passes locally
- [x] `go vet ./...` is clean
- [x] Code is `gofmt`'d
- [x] Added or updated tests for the change
- [ ] Updated user-facing docs under `src/` if behavior changes
- [ ] Updated `ROADMAP.md` if this closes a roadmap item
- [x] No secrets, tokens, or webhook URLs introduced in source / YAML
- [x] No new third-party dependencies (or justified in the description)

## Security note

The full provider error is written to the Versus server log so operators can
debug a failing model. Provider SDK errors can include request content and
masked credential fragments, so server log access should remain restricted. The
chat surface itself only ever receives the bounded classification, and the
structured `messages.N` detail is dropped when it contains credential markers.