### PR TITLE
fix(agent): apply runtime AI settings to interactive agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   cosine top-K index (no external vector DB); `Index` interface is the seam
   an enterprise hosted backend swaps in without forking the tool.
 - **Runbook corpus store + ingestion** (`pkg/runbook`) — blob-backed
-  corpus persisted via `storage.Provider` (every record carries an `OrgID`
-  for per-tenant scoping). The server auto-ingests the runbook source
+  corpus persisted via `storage.Provider`. Every record carries the manager's
+  boot write org as provenance; tenant isolation requires an org-scoped storage
+  provider because the shared blob is not filtered per record. The server auto-ingests the runbook source
   directory of Markdown runbooks (optional YAML front-matter for
   title/services/tags) at boot: it embeds new or edited runbooks and
   persists the vectors it loads into the index. Re-ingest is incremental
@@ -48,6 +49,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Helm** — `agent.tools.findRunbook.*` values + configmap wiring.
 
 ### Fixed
+
+#### Enterprise runtime AI settings
+- **Provider credentials are isolated on runtime switches.** Changing between
+  keyed providers now requires the new provider's API key in the same save;
+  otherwise the server returns HTTP 422 with `code: provider_key_required` and
+  preserves the prior provider, key, and enabled state. Switching to Ollama is
+  keyless and clears the stored runtime key. The AI-settings provider control
+  no longer offers a silent config-default save while an override exists; use
+  **Revert to YAML floor** to remove the override.
+- **Archived incident analysis respects the trusted data read scope.** Sync and
+  streaming Analyze may read the frozen default-org archive when it is present
+  in the server-computed scope, while model settings and writes remain pinned
+  to the scope's write org. Foreign incidents are rejected before model or key
+  resolution.
+- **Boot diagnostics distinguish local configuration errors from provider
+  failures.** Unsupported providers and empty models now receive actionable,
+  safe messages (including supported providers where relevant); raw SDK and
+  provider responses remain excluded from logs.
 
 #### AI SRE Agent — Telegram channel
 - **HTML-escape the agent Telegram template** (`config/agent_telegram.tmpl`,

--- a/pkg/agent/ai/analyze/agent.go
+++ b/pkg/agent/ai/analyze/agent.go
@@ -51,6 +51,7 @@ const (
 // notification path.
 type Agent struct {
 	cfg          config.AgentAIConfig
+	runtime      einowrap.RuntimeAI
 	chatModel    model.ToolCallingChatModel
 	holder       *einowrap.Holder[model.ToolCallingChatModel]
 	buildAgent   func(context.Context, model.ToolCallingChatModel) (*react.Agent, error)
@@ -65,10 +66,9 @@ type Options struct {
 	BaseURL    string
 	Timeout    time.Duration
 
-	// AuthKeyFunc is an OPTIONAL per-request Authorization override passed
-	// straight to the chat model's transport. Nil (the OSS default) leaves
-	// the YAML-keyed header untouched.
-	AuthKeyFunc func(ctx context.Context) (key string, ok bool)
+	// RuntimeKeyFunc is an optional per-request provider credential override.
+	// Nil keeps the configured YAML credential.
+	RuntimeKeyFunc func(ctx context.Context) (key string, ok bool)
 
 	// Runtime folds optional runtime overrides (provider / enabled / key
 	// state) into the model holder's rebuild signature. The zero value (the
@@ -161,6 +161,7 @@ func New(ctx context.Context, cfg config.AgentAIConfig, tools []core.Tool, opts 
 
 	a := &Agent{
 		cfg:          cfg,
+		runtime:      opts.Runtime,
 		tools:        reg,
 		toolDisplays: displays,
 		maxIter:      maxIter,
@@ -180,16 +181,16 @@ func New(ctx context.Context, cfg config.AgentAIConfig, tools []core.Tool, opts 
 	}
 
 	a.holder = einowrap.NewToolCallingChatModelHolder(cfg, einowrap.Options{
-		HTTPClient:  opts.HTTPClient,
-		BaseURL:     opts.BaseURL,
-		Timeout:     opts.Timeout,
-		AuthKeyFunc: opts.AuthKeyFunc,
+		HTTPClient:     opts.HTTPClient,
+		BaseURL:        opts.BaseURL,
+		Timeout:        opts.Timeout,
+		RuntimeKeyFunc: opts.RuntimeKeyFunc,
 	}, opts.Runtime)
 	// Build once up front so a bad config (empty model, explicitly-set
 	// unknown provider) still fails fast at construction.
 	base, err := a.holder.Get(ctx)
 	if err != nil {
-		return nil, err
+		return nil, safeAnalyzeProviderError(ctx, a.effectiveProvider(ctx), a.cfg.Model, err)
 	}
 	if _, err := buildReactAgent(ctx, base); err != nil {
 		return nil, err
@@ -224,6 +225,18 @@ func (a *Agent) Name() string { return "analyze" }
 
 // Kind implements core.AIAgent.
 func (a *Agent) Kind() core.AITaskKind { return core.AITaskAnalyze }
+
+func (a *Agent) effectiveProvider(ctx context.Context) string {
+	if a.runtime.Provider != nil {
+		if provider, ok := a.runtime.Provider(ctx); ok && einowrap.IsSupportedProvider(provider) {
+			return provider
+		}
+	}
+	if strings.TrimSpace(a.cfg.Provider) == "" {
+		return einowrap.DefaultProvider
+	}
+	return a.cfg.Provider
+}
 
 // Run implements core.AIAgent. Rejects any non-AnalyzeTask.
 func (a *Agent) Run(ctx context.Context, task core.AITask) (*core.AICallResult, error) {
@@ -268,13 +281,19 @@ func (a *Agent) run(ctx context.Context, snap core.AnalyzeIncidentSnapshot) (*co
 	// / model / runtime state changed (nil holder ⇒ fixed test override).
 	reactAgent, err := a.reactAgent(ctx)
 	if err != nil {
-		return &core.AICallResult{UserPrompt: user, Model: a.cfg.Model}, fmt.Errorf("analyze: build react agent: %w", err)
+		safeErr := safeAnalyzeProviderError(ctx, a.effectiveProvider(ctx), a.cfg.Model, err)
+		return &core.AICallResult{UserPrompt: user, Model: safeAnalyzeResultModel(a.cfg.Model, safeErr)}, safeErr
 	}
 
 	// The audit trace is built from Eino tool callbacks rather than
 	// hand instrumentation, so it captures every tool the framework
 	// dispatches (including concurrent calls in one turn).
-	collector := &traceCollector{obsCtx: ctx, toolDisplays: a.toolDisplays}
+	collector := &traceCollector{
+		obsCtx:       ctx,
+		toolDisplays: a.toolDisplays,
+		provider:     a.effectiveProvider(ctx),
+		model:        a.cfg.Model,
+	}
 	handler := utilcb.NewHandlerHelper().
 		ChatModel(collector.chatModelHandler()).
 		Tool(collector.toolHandler()).
@@ -296,12 +315,13 @@ func (a *Agent) run(ctx context.Context, snap core.AnalyzeIncidentSnapshot) (*co
 	traces := collector.ordered()
 
 	if err != nil {
+		safeErr := safeAnalyzeProviderError(ctx, a.effectiveProvider(ctx), a.cfg.Model, err)
 		return &core.AICallResult{
 			UserPrompt: user,
 			DurationMs: durationMs,
-			Model:      a.cfg.Model,
+			Model:      safeAnalyzeResultModel(a.cfg.Model, safeErr),
 			ToolCalls:  traces,
-		}, fmt.Errorf("analyze: react agent: %w", err)
+		}, safeErr
 	}
 	if out == nil {
 		return &core.AICallResult{
@@ -341,6 +361,28 @@ func (a *Agent) run(ctx context.Context, snap core.AnalyzeIncidentSnapshot) (*co
 		Model:       a.cfg.Model,
 		ToolCalls:   traces,
 	}, nil
+}
+
+func safeAnalyzeProviderError(ctx context.Context, provider, model string, err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		return context.Canceled
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("analyze: run timed out: %w", context.DeadlineExceeded)
+	}
+	var configErr *einowrap.ConfigError
+	if errors.As(err, &configErr) {
+		return configErr
+	}
+	return einowrap.SafeProviderError(provider, model, err)
+}
+
+func safeAnalyzeResultModel(configured string, err error) string {
+	var providerErr *einowrap.ProviderError
+	if errors.As(err, &providerErr) {
+		return providerErr.Model
+	}
+	return configured
 }
 
 // streamFinalMessage runs the ReAct loop in streaming mode and reassembles
@@ -404,6 +446,8 @@ type traceCollector struct {
 	// own ctx, so the observer is held here rather than read from those.
 	obsCtx       context.Context
 	toolDisplays map[string]string
+	provider     string
+	model        string
 	// drains tracks the goroutines reading each streamed model turn.
 	drains sync.WaitGroup
 }
@@ -477,7 +521,7 @@ func (c *traceCollector) chatModelHandler() *utilcb.ModelCallbackHandler {
 				Turn: int(turn),
 			}
 			if err != nil {
-				ev.Error = err.Error()
+				ev.Error = einowrap.SafeProviderError(c.provider, c.model, err).Diagnostic
 			}
 			c.emit(ev)
 			return ctx
@@ -523,7 +567,7 @@ func (c *traceCollector) drainModelStream(output *schema.StreamReader[*model.Cal
 		Output: capOutput(strings.TrimSpace(sb.String())),
 	}
 	if streamErr != nil {
-		ev.Error = streamErr.Error()
+		ev.Error = einowrap.SafeProviderError(c.provider, c.model, streamErr).Diagnostic
 	}
 	c.emit(ev)
 }

--- a/pkg/agent/ai/analyze/agent_test.go
+++ b/pkg/agent/ai/analyze/agent_test.go
@@ -3,6 +3,7 @@ package analyze
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/schema"
 
+	einowrap "github.com/VersusControl/versus-incident/pkg/agent/ai/eino"
 	"github.com/VersusControl/versus-incident/pkg/config"
 	"github.com/VersusControl/versus-incident/pkg/core"
 )
@@ -43,6 +45,18 @@ type fakeChat struct {
 	// streamCalls counts Stream dispatches, so a test can prove which of
 	// the two model entry points the agent took.
 	streamCalls int32
+}
+
+type errorChat struct{ err error }
+
+func (chat errorChat) Generate(context.Context, []*schema.Message, ...model.Option) (*schema.Message, error) {
+	return nil, chat.err
+}
+func (chat errorChat) Stream(context.Context, []*schema.Message, ...model.Option) (*schema.StreamReader[*schema.Message], error) {
+	return nil, chat.err
+}
+func (chat errorChat) WithTools([]*schema.ToolInfo) (model.ToolCallingChatModel, error) {
+	return chat, nil
 }
 
 func (f *fakeChat) next(in []*schema.Message) *schema.Message {
@@ -257,6 +271,63 @@ func TestAgent_RejectsNonAnalyzeTask(t *testing.T) {
 	a := newAgentWithFake(t, &fakeChat{turns: []*schema.Message{schema.AssistantMessage("{}", nil)}}, nil, 1)
 	if _, err := a.Run(context.Background(), core.DetectTask{}); err == nil {
 		t.Fatalf("expected error for DetectTask")
+	}
+}
+
+func TestAgent_BuildFailureUsesSafeProviderError(t *testing.T) {
+	const secret = "runtime-build-secret"
+	cfg := config.AgentAIConfig{Provider: "gemini", Model: "unsafe\r\n" + secret}
+	agent := &Agent{cfg: cfg, buildAgent: nil}
+	agent.holder = einowrap.NewModelHolder(cfg, einowrap.Options{}, einowrap.RuntimeAI{}, func(context.Context, config.AgentAIConfig, einowrap.Options) (model.ToolCallingChatModel, error) {
+		return nil, fmt.Errorf("construction reflected %s\r\nforged=true", secret)
+	})
+
+	result, err := agent.Run(context.Background(), core.AnalyzeTask{Snapshot: core.AnalyzeIncidentSnapshot{IncidentID: "inc-build"}})
+	if result == nil {
+		t.Fatal("build failure did not return an auditable result")
+	}
+	var providerErr *einowrap.ProviderError
+	if !errors.As(err, &providerErr) {
+		t.Fatalf("build failure = %T %v, want ProviderError", err, err)
+	}
+	encoded := providerErr.Provider + providerErr.Model + providerErr.Diagnostic
+	if strings.Contains(encoded, secret) || strings.Contains(encoded, "forged=true") || strings.ContainsAny(encoded, "\r\n") {
+		t.Fatalf("safe build failure retained malicious input: %+v", providerErr)
+	}
+	if result.Model != providerErr.Model {
+		t.Fatalf("result model = %q, want sanitized %q", result.Model, providerErr.Model)
+	}
+}
+
+func TestNew_PreservesTrustedInitialConfigError(t *testing.T) {
+	const secret = "initial-build-secret"
+	_, err := New(context.Background(), config.AgentAIConfig{
+		Provider: "unsupported\r\n" + secret,
+		Model:    "unsafe\r\n" + secret,
+	}, nil, Options{})
+	var configErr *einowrap.ConfigError
+	if !errors.As(err, &configErr) {
+		t.Fatalf("New error = %T %v, want ConfigError", err, err)
+	}
+	if err != configErr {
+		t.Fatalf("New error = %T %v, want the original typed ConfigError", err, err)
+	}
+	if message := configErr.Error(); strings.Contains(message, secret) || strings.ContainsAny(message, "\r\n") || !strings.Contains(message, "supported:") {
+		t.Fatalf("trusted config error is unsafe or unactionable: %q", message)
+	}
+}
+
+func TestAgent_RunPreservesContextCancellation(t *testing.T) {
+	agent, err := New(context.Background(), config.AgentAIConfig{Provider: "openai", Model: "fake"}, nil, Options{ChatModel: errorChat{err: fmt.Errorf("provider wrapper: %w", context.Canceled)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = agent.Run(context.Background(), core.AnalyzeTask{Snapshot: core.AnalyzeIncidentSnapshot{IncidentID: "inc-cancel"}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run error = %v, want context cancellation identity", err)
+	}
+	if strings.Contains(fmt.Sprint(err), "provider wrapper") {
+		t.Fatalf("cancellation exposed raw provider wrapper: %v", err)
 	}
 }
 

--- a/pkg/agent/ai/analyze/stream_test.go
+++ b/pkg/agent/ai/analyze/stream_test.go
@@ -387,7 +387,7 @@ func TestStream_EmptyChunkEmitsNoDelta(t *testing.T) {
 }
 
 // TestStream_MidStreamErrorFailsRun asserts a stream that breaks part-way
-// fails the run with the underlying cause rather than persisting a truncated
+// fails safely rather than exposing its raw cause or persisting a truncated
 // answer as if it were complete.
 func TestStream_MidStreamErrorFailsRun(t *testing.T) {
 	fake := &fakeChat{
@@ -400,8 +400,8 @@ func TestStream_MidStreamErrorFailsRun(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Run succeeded despite a broken stream; result = %+v", res)
 	}
-	if !strings.Contains(err.Error(), "connection reset") {
-		t.Fatalf("error = %v, want the underlying stream failure", err)
+	if strings.Contains(err.Error(), "connection reset") || !strings.Contains(err.Error(), "Could not connect securely") {
+		t.Fatalf("error = %v, want a sanitized connection failure", err)
 	}
 	if res == nil || res.RawResponse != "" {
 		t.Fatalf("a truncated answer was persisted as an answer: %+v", res)

--- a/pkg/agent/ai/chat/agent.go
+++ b/pkg/agent/ai/chat/agent.go
@@ -38,15 +38,15 @@ const (
 var errModelResponseUnavailable = errors.New("chat: model response unavailable")
 
 type Options struct {
-	HTTPClient   *http.Client
-	BaseURL      string
-	Timeout      time.Duration
-	AuthKeyFunc  func(context.Context) (string, bool)
-	Runtime      einowrap.RuntimeAI
-	ChatModel    model.ToolCallingChatModel
-	ToolTimeout  time.Duration
-	ToolProvider func() ([]core.Tool, error)
-	SeedProvider func() ([]core.Tool, error)
+	HTTPClient     *http.Client
+	BaseURL        string
+	Timeout        time.Duration
+	RuntimeKeyFunc func(context.Context) (string, bool)
+	Runtime        einowrap.RuntimeAI
+	ChatModel      model.ToolCallingChatModel
+	ToolTimeout    time.Duration
+	ToolProvider   func() ([]core.Tool, error)
+	SeedProvider   func() ([]core.Tool, error)
 }
 
 type Agent struct {
@@ -95,7 +95,7 @@ func New(ctx context.Context, cfg config.AgentAIConfig, tools []core.Tool, opts 
 		return agent, nil
 	}
 	agent.holder = einowrap.NewToolCallingChatModelHolder(cfg, einowrap.Options{
-		HTTPClient: opts.HTTPClient, BaseURL: opts.BaseURL, Timeout: opts.Timeout, AuthKeyFunc: opts.AuthKeyFunc,
+		HTTPClient: opts.HTTPClient, BaseURL: opts.BaseURL, Timeout: opts.Timeout, RuntimeKeyFunc: opts.RuntimeKeyFunc,
 	}, opts.Runtime)
 	chatModel, err := agent.holder.Get(ctx)
 	if err != nil {
@@ -362,95 +362,13 @@ func (err *modelResponseError) Error() string { return errModelResponseUnavailab
 func (err *modelResponseError) Unwrap() error { return errModelResponseUnavailable }
 
 func newModelResponseError(provider, model string, cause error) error {
-	return &modelResponseError{diagnostic: modelResponseDiagnostic(provider, model, cause.Error())}
+	safe := einowrap.SafeProviderError(provider, model, cause)
+	log.Printf("chat model provider error: provider=%q model=%q class=%q", safe.Provider, safe.Model, safe.Class)
+	return &modelResponseError{diagnostic: safe.Diagnostic}
 }
 
 func modelResponseDiagnostic(provider, model, failure string) string {
-	provider = safeModelIdentifier(provider, "openai")
-	model = safeModelIdentifier(model, "configured model")
-	label := strings.ToUpper(provider[:1]) + provider[1:]
-	normalizedFailure := strings.ToLower(failure)
-	checkLogs := " Check the Versus server logs for the full provider error."
-
-	log.Printf("chat model provider error: provider=%q model=%q error=%s", provider, model, failure)
-
-	if detail := safeProviderValidationDetail(failure); detail != "" {
-		return fmt.Sprintf("%s rejected the generated chat history for model %q: %s.%s", label, model, strings.TrimSuffix(detail, "."), checkLogs)
-	}
-	switch {
-	case normalizedFailure == "empty_response":
-		return fmt.Sprintf("%s model %q returned no assistant content; increase the completion-token budget or choose a compatible model.%s", label, model, checkLogs)
-	case strings.Contains(normalizedFailure, "temperature") && (strings.Contains(normalizedFailure, "deprecated") || strings.Contains(normalizedFailure, "unsupported") || strings.Contains(normalizedFailure, "not support")):
-		return fmt.Sprintf("%s model %q rejected the configured temperature; set AGENT_AI_TEMPERATURE=-1 to omit it, restart Versus, and retry.%s", label, model, checkLogs)
-	case strings.Contains(normalizedFailure, "401"), strings.Contains(normalizedFailure, "unauthorized"), strings.Contains(normalizedFailure, "authentication"), strings.Contains(normalizedFailure, "invalid_api_key"), strings.Contains(normalizedFailure, "invalid api key"):
-		return fmt.Sprintf("%s authentication failed for model %q; verify the configured API key.%s", label, model, checkLogs)
-	case strings.Contains(normalizedFailure, "403"), strings.Contains(normalizedFailure, "forbidden"), strings.Contains(normalizedFailure, "permission denied"):
-		return fmt.Sprintf("%s denied access to model %q; verify model permissions.%s", label, model, checkLogs)
-	case strings.Contains(normalizedFailure, "404"), strings.Contains(normalizedFailure, "model_not_found"), strings.Contains(normalizedFailure, "model not found"), strings.Contains(normalizedFailure, "not_found_error"):
-		return fmt.Sprintf("%s model %q was not found or is unavailable to this account.%s", label, model, checkLogs)
-	case strings.Contains(normalizedFailure, "429"), strings.Contains(normalizedFailure, "rate limit"), strings.Contains(normalizedFailure, "rate_limit"):
-		return fmt.Sprintf("%s rate limit or quota was reached for model %q; retry later or check provider limits.%s", label, model, checkLogs)
-	case strings.Contains(normalizedFailure, "400"), strings.Contains(normalizedFailure, "invalid_request"):
-		return fmt.Sprintf("%s rejected the request for model %q as invalid; verify model compatibility and token limits.%s", label, model, checkLogs)
-	case strings.Contains(normalizedFailure, "timeout"), strings.Contains(normalizedFailure, "deadline exceeded"):
-		return fmt.Sprintf("%s timed out while calling model %q.%s", label, model, checkLogs)
-	case strings.Contains(normalizedFailure, "connection refused"), strings.Contains(normalizedFailure, "no such host"), strings.Contains(normalizedFailure, "tls"):
-		return fmt.Sprintf("Could not connect securely to %s for model %q.%s", label, model, checkLogs)
-	default:
-		return fmt.Sprintf("%s could not produce a response with model %q; verify provider configuration and model access.%s", label, model, checkLogs)
-	}
-}
-
-func safeProviderValidationDetail(failure string) string {
-	type providerErrorEnvelope struct {
-		Error struct {
-			Type    string `json:"type"`
-			Message string `json:"message"`
-		} `json:"error"`
-	}
-	var envelope providerErrorEnvelope
-	for offset := 0; offset < len(failure); {
-		start := strings.IndexByte(failure[offset:], '{')
-		if start < 0 {
-			return ""
-		}
-		start += offset
-		envelope = providerErrorEnvelope{}
-		if err := json.NewDecoder(strings.NewReader(failure[start:])).Decode(&envelope); err == nil && envelope.Error.Type == "invalid_request_error" {
-			break
-		}
-		offset = start + 1
-	}
-	if envelope.Error.Type != "invalid_request_error" {
-		return ""
-	}
-	detail := strings.Join(strings.Fields(envelope.Error.Message), " ")
-	lower := strings.ToLower(detail)
-	if len(detail) == 0 || len(detail) > 512 || !strings.HasPrefix(lower, "messages.") {
-		return ""
-	}
-	for _, sensitive := range []string{"sk-", "api key", "apikey", "authorization", "bearer", "password", "secret", "token="} {
-		if strings.Contains(lower, sensitive) {
-			return ""
-		}
-	}
-	return detail
-}
-
-func safeModelIdentifier(value, fallback string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return fallback
-	}
-	if len(value) > 128 {
-		return fallback
-	}
-	for _, character := range value {
-		if !((character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || (character >= '0' && character <= '9') || strings.ContainsRune("._:/-", character)) {
-			return fallback
-		}
-	}
-	return value
+	return einowrap.SafeProviderError(provider, model, errors.New(failure)).Diagnostic
 }
 
 func (agent *Agent) effectiveProvider(ctx context.Context) string {

--- a/pkg/agent/ai/chat/agent_test.go
+++ b/pkg/agent/ai/chat/agent_test.go
@@ -19,20 +19,19 @@ import (
 )
 
 func TestModelResponseDiagnosticClassifiesWithoutLeakingProviderBody(t *testing.T) {
-	const checkLogs = " Check the Versus server logs for the full provider error."
 	tests := []struct {
 		name    string
 		failure string
 		want    string
 	}{
-		{name: "authentication", failure: "status 401 invalid_api_key sk-secret", want: `Claude authentication failed for model "claude-sonnet-5"; verify the configured API key.` + checkLogs},
-		{name: "model", failure: "status 404 model_not_found sk-secret", want: `Claude model "claude-sonnet-5" was not found or is unavailable to this account.` + checkLogs},
-		{name: "quota", failure: "status 429 rate_limit sk-secret", want: `Claude rate limit or quota was reached for model "claude-sonnet-5"; retry later or check provider limits.` + checkLogs},
-		{name: "temperature", failure: "status 400 invalid_request_error: `temperature` is deprecated for this model", want: `Claude model "claude-sonnet-5" rejected the configured temperature; set AGENT_AI_TEMPERATURE=-1 to omit it, restart Versus, and retry.` + checkLogs},
-		{name: "message ordering", failure: `status 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.1: role 'system' must precede an 'assistant' message or end the array"}}`, want: `Claude rejected the generated chat history for model "claude-sonnet-5": messages.1: role 'system' must precede an 'assistant' message or end the array.` + checkLogs},
-		{name: "spaced message ordering", failure: `status 400 prefix {"type": "error", "error": {"type": "invalid_request_error", "message": "messages.2: roles must alternate"}} trailing`, want: `Claude rejected the generated chat history for model "claude-sonnet-5": messages.2: roles must alternate.` + checkLogs},
-		{name: "unsafe validation body", failure: `status 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.1: leaked sk-secret"}}`, want: `Claude rejected the request for model "claude-sonnet-5" as invalid; verify model compatibility and token limits.` + checkLogs},
-		{name: "unknown", failure: "provider exploded with sk-secret", want: `Claude could not produce a response with model "claude-sonnet-5"; verify provider configuration and model access.` + checkLogs},
+		{name: "authentication", failure: "status 401 invalid_api_key sk-secret", want: `Claude authentication failed for model "claude-sonnet-5"; verify the configured API key.`},
+		{name: "model", failure: "status 404 model_not_found sk-secret", want: `Claude model "claude-sonnet-5" was not found or is unavailable to this account.`},
+		{name: "quota", failure: "status 429 rate_limit sk-secret", want: `Claude rate limit or quota was reached for model "claude-sonnet-5"; retry later or check provider limits.`},
+		{name: "temperature", failure: "status 400 invalid_request_error: `temperature` is deprecated for this model", want: `Claude model "claude-sonnet-5" rejected the configured temperature; set AGENT_AI_TEMPERATURE=-1 to omit it, restart Versus, and retry.`},
+		{name: "message ordering", failure: `status 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.1: role 'system' must precede an 'assistant' message or end the array"}}`, want: `Claude rejected the request for model "claude-sonnet-5" as invalid; verify model compatibility and token limits.`},
+		{name: "spaced message ordering", failure: `status 400 prefix {"type": "error", "error": {"type": "invalid_request_error", "message": "messages.2: roles must alternate"}} trailing`, want: `Claude rejected the request for model "claude-sonnet-5" as invalid; verify model compatibility and token limits.`},
+		{name: "unsafe validation body", failure: `status 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.1: leaked sk-secret"}}`, want: `Claude rejected the request for model "claude-sonnet-5" as invalid; verify model compatibility and token limits.`},
+		{name: "unknown", failure: "provider exploded with sk-secret", want: `Claude could not produce a response with model "claude-sonnet-5"; verify provider configuration and model access.`},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -51,16 +50,22 @@ func TestModelResponseDiagnosticClassifiesWithoutLeakingProviderBody(t *testing.
 	}
 }
 
-func TestModelResponseDiagnosticLogsOriginalProviderError(t *testing.T) {
+func TestModelResponseDiagnosticLogsOnlySafeClassification(t *testing.T) {
 	var output bytes.Buffer
 	originalWriter := log.Writer()
 	log.SetOutput(&output)
 	t.Cleanup(func() { log.SetOutput(originalWriter) })
 
-	failure := "HTTP 400 Bad Request: `temperature` is Deprecated for This Model"
-	_ = modelResponseDiagnostic("claude", "claude-sonnet-5", failure)
-	if !strings.Contains(output.String(), failure) {
-		t.Fatalf("log output = %q, want original provider error %q", output.String(), failure)
+	failure := "HTTP 401 reflected sk-runtime-secret\r\nforged=true"
+	_ = newModelResponseError("claude", "claude-sonnet-5", errors.New(failure))
+	logged := output.String()
+	if strings.Contains(logged, "sk-runtime-secret") || strings.Contains(logged, "forged=true") {
+		t.Fatalf("log leaked raw provider error: %q", logged)
+	}
+	for _, safe := range []string{`provider="claude"`, `model="claude-sonnet-5"`, `class="authentication"`} {
+		if !strings.Contains(logged, safe) {
+			t.Fatalf("safe log = %q, want %q", logged, safe)
+		}
 	}
 }
 

--- a/pkg/agent/ai/chat/service.go
+++ b/pkg/agent/ai/chat/service.go
@@ -50,6 +50,7 @@ type Service struct {
 	runTimeout   time.Duration
 	leaseTTL     time.Duration
 	leaseRenewal time.Duration
+	decorate     func(context.Context) context.Context
 
 	mu     sync.Mutex
 	active map[string]activeRun
@@ -78,6 +79,13 @@ func NewServiceWithLocation(store *SessionStore, chatRouter TurnRunner, seeder d
 // NewServiceWithLocationProvider resolves the current report timezone for
 // every turn so runtime settings changes do not require a process restart.
 func NewServiceWithLocationProvider(store *SessionStore, chatRouter TurnRunner, seeder discoverySeeder, now func() time.Time, location func() *time.Location) *Service {
+	return NewServiceWithLocationProviderAndContextDecorator(store, chatRouter, seeder, now, location, nil)
+}
+
+// NewServiceWithLocationProviderAndContextDecorator constructs a service that
+// decorates every detached turn context before seed, tool, and model execution.
+// A nil decorator preserves the OSS identity behavior.
+func NewServiceWithLocationProviderAndContextDecorator(store *SessionStore, chatRouter TurnRunner, seeder discoverySeeder, now func() time.Time, location func() *time.Location, decorate func(context.Context) context.Context) *Service {
 	if now == nil {
 		now = time.Now
 	}
@@ -87,7 +95,7 @@ func NewServiceWithLocationProvider(store *SessionStore, chatRouter TurnRunner, 
 	return &Service{
 		store: store, router: chatRouter, seeder: seeder, now: now, location: location,
 		owner: uuid.NewString(), runTimeout: DefaultRunTimeout, leaseTTL: defaultLeaseTTL,
-		leaseRenewal: defaultLeaseRenewal, active: map[string]activeRun{},
+		leaseRenewal: defaultLeaseRenewal, decorate: decorate, active: map[string]activeRun{},
 	}
 }
 
@@ -231,6 +239,9 @@ func (service *Service) prepare(ctx context.Context, id, message string, attachm
 	runCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), service.runTimeout)
 	recorder := &eventRecorder{delegate: core.ChatObserverFrom(ctx)}
 	runCtx = core.WithChatObserver(runCtx, recorder)
+	if service.decorate != nil {
+		runCtx = service.decorate(runCtx)
+	}
 	service.mu.Lock()
 	if _, exists := service.active[id]; exists {
 		service.mu.Unlock()

--- a/pkg/agent/ai/chat/service_test.go
+++ b/pkg/agent/ai/chat/service_test.go
@@ -75,6 +75,61 @@ func (runner *captureTaskRunner) RunChat(_ context.Context, task core.ChatTask) 
 	return &core.ChatTurnResult{Markdown: "answer"}, nil
 }
 
+type contextCaptureRunner struct {
+	ctx chan context.Context
+}
+
+func (runner *contextCaptureRunner) RunChat(ctx context.Context, _ core.ChatTask) (*core.ChatTurnResult, error) {
+	runner.ctx <- ctx
+	return &core.ChatTurnResult{Markdown: "answer"}, nil
+}
+
+type testChatObserver struct{}
+
+func (testChatObserver) OnChatEvent(core.ChatEvent) {}
+
+type chatScopeKey struct{}
+
+func TestServiceDetachedContextRetainsValuesAndReceivesScope(t *testing.T) {
+	store := NewSessionStore(storage.NewMemory(), tenancy.NewOrgScope("org-a"), time.Now)
+	runner := &contextCaptureRunner{ctx: make(chan context.Context, 1)}
+	service := NewServiceWithLocationProviderAndContextDecorator(
+		store, runner, nil, time.Now, func() *time.Location { return time.UTC },
+		func(ctx context.Context) context.Context {
+			return context.WithValue(ctx, chatScopeKey{}, "org-a")
+		},
+	)
+	session, err := service.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+	observer := testChatObserver{}
+	requestCtx, cancel := context.WithCancel(context.Background())
+	requestCtx = core.WithCallerAuthorization(requestCtx, core.CallerAuthorization{
+		Authenticated: true,
+		Permissions:   map[core.Permission]bool{core.PermissionInfrastructureView: true},
+	})
+	requestCtx = core.WithChatObserver(requestCtx, observer)
+	outcomes, err := service.Start(requestCtx, session.ID, "inspect", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	runCtx := <-runner.ctx
+	if runCtx.Value(chatScopeKey{}) != "org-a" {
+		t.Fatalf("decorated scope = %v, want org-a", runCtx.Value(chatScopeKey{}))
+	}
+	if !core.CallerAuthorized(runCtx, core.PermissionInfrastructureView) {
+		t.Fatal("detached context lost caller authorization")
+	}
+	if core.ChatObserverFrom(runCtx) == nil {
+		t.Fatal("detached context lost chat observer")
+	}
+	if err := (<-outcomes).Err; err != nil {
+		t.Fatal(err)
+	}
+}
+
 type countingSeeder struct{ calls int }
 
 func (seeder *countingSeeder) Seed(context.Context) []core.ToolCallTrace {
@@ -142,7 +197,7 @@ func TestServicePersistsSafeModelResponseDetail(t *testing.T) {
 		t.Fatal(err)
 	}
 	last := session.Turns[len(session.Turns)-1]
-	want := `Claude model "claude-sonnet-5" was not found or is unavailable to this account. Check the Versus server logs for the full provider error.`
+	want := `Claude model "claude-sonnet-5" was not found or is unavailable to this account.`
 	if last.Content != want || len(last.Events) == 0 || last.Events[len(last.Events)-1].Error != want {
 		t.Fatalf("failure turn = %+v, want safe provider detail %q", last, want)
 	}
@@ -161,7 +216,7 @@ func TestServicePersistsTemperatureOmissionGuidance(t *testing.T) {
 		t.Fatal(err)
 	}
 	last := session.Turns[len(session.Turns)-1]
-	for _, required := range []string{"AGENT_AI_TEMPERATURE=-1", "restart Versus", "server logs"} {
+	for _, required := range []string{"AGENT_AI_TEMPERATURE=-1", "restart Versus"} {
 		if !strings.Contains(last.Content, required) || len(last.Events) == 0 || !strings.Contains(last.Events[len(last.Events)-1].Error, required) {
 			t.Fatalf("failure turn = %+v, want guidance containing %q", last, required)
 		}

--- a/pkg/agent/ai/detect/agent.go
+++ b/pkg/agent/ai/detect/agent.go
@@ -10,6 +10,7 @@ package detect
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -26,7 +27,8 @@ import (
 // Agent is the detect-kind AIAgent. It binds the resolved per-task
 // config, the Eino chat model, and a sample extractor.
 type Agent struct {
-	cfg config.AgentAIConfig
+	cfg     config.AgentAIConfig
+	runtime einowrap.RuntimeAI
 	// chat is the holder that lazily (re)builds the tool-free Eino base
 	// chat model. We type its artifact as BaseChatModel (not
 	// ToolCallingChatModel) so the compiler — and the structural guard in
@@ -52,10 +54,9 @@ type Options struct {
 	BaseURL string
 	// Timeout caps each chat call. Defaults to 30s.
 	Timeout time.Duration
-	// AuthKeyFunc is an OPTIONAL per-request Authorization override passed
-	// straight to the chat model's transport. Nil (the OSS default) leaves
-	// the YAML-keyed header untouched.
-	AuthKeyFunc func(ctx context.Context) (key string, ok bool)
+	// RuntimeKeyFunc is an optional per-request provider credential override.
+	// Nil keeps the configured YAML credential.
+	RuntimeKeyFunc func(ctx context.Context) (key string, ok bool)
 
 	// Runtime folds optional runtime overrides (provider / enabled / key
 	// state) into the model holder's rebuild signature. The zero value (the
@@ -67,19 +68,20 @@ type Options struct {
 // detect task (see config.AgentAIConfig.Resolve).
 func New(ctx context.Context, cfg config.AgentAIConfig, opts Options) (*Agent, error) {
 	holder := einowrap.NewChatModelHolder(cfg, einowrap.Options{
-		HTTPClient:  opts.HTTPClient,
-		BaseURL:     opts.BaseURL,
-		Timeout:     opts.Timeout,
-		AuthKeyFunc: opts.AuthKeyFunc,
+		HTTPClient:     opts.HTTPClient,
+		BaseURL:        opts.BaseURL,
+		Timeout:        opts.Timeout,
+		RuntimeKeyFunc: opts.RuntimeKeyFunc,
 	}, opts.Runtime)
 	// Build once up front so a bad config (empty model, explicitly-set
 	// unknown provider) still fails fast at construction, exactly as the
 	// pre-holder wiring did.
 	if _, err := holder.Get(ctx); err != nil {
-		return nil, err
+		return nil, safeDetectProviderError(ctx, effectiveProvider(ctx, cfg.Provider, opts.Runtime), cfg.Model, err)
 	}
 	return &Agent{
 		cfg:      cfg,
+		runtime:  opts.Runtime,
 		chat:     holder,
 		SampleFn: defaultSampleFn,
 	}, nil
@@ -132,7 +134,7 @@ func (a *Agent) analyze(ctx context.Context, r core.AgentResult) (*core.AICallRe
 	// so a steady tick reuses the cached model at no cost.
 	chat, err := a.chat.Get(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("detect: build chat model: %w", err)
+		return nil, safeDetectProviderError(ctx, effectiveProvider(ctx, a.cfg.Provider, a.runtime), a.cfg.Model, err)
 	}
 
 	start := time.Now()
@@ -142,7 +144,7 @@ func (a *Agent) analyze(ctx context.Context, r core.AgentResult) (*core.AICallRe
 	})
 	durationMs := time.Since(start).Milliseconds()
 	if err != nil {
-		return nil, fmt.Errorf("detect: chat: %w", err)
+		return nil, safeDetectProviderError(ctx, effectiveProvider(ctx, a.cfg.Provider, a.runtime), a.cfg.Model, err)
 	}
 	if out == nil {
 		return nil, fmt.Errorf("detect: empty response")
@@ -168,6 +170,28 @@ func (a *Agent) analyze(ctx context.Context, r core.AgentResult) (*core.AICallRe
 		DurationMs:  durationMs,
 		Model:       a.cfg.Model,
 	}, nil
+}
+
+func effectiveProvider(ctx context.Context, configured string, runtime einowrap.RuntimeAI) string {
+	if runtime.Provider != nil {
+		if provider, ok := runtime.Provider(ctx); ok && einowrap.IsSupportedProvider(provider) {
+			return provider
+		}
+	}
+	if strings.TrimSpace(configured) == "" {
+		return einowrap.DefaultProvider
+	}
+	return configured
+}
+
+func safeDetectProviderError(ctx context.Context, provider, model string, err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		return context.Canceled
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("detect: run timed out: %w", context.DeadlineExceeded)
+	}
+	return einowrap.SafeProviderError(provider, model, err)
 }
 
 func defaultSampleFn(r core.AgentResult) []string {

--- a/pkg/agent/ai/detect/agent_test.go
+++ b/pkg/agent/ai/detect/agent_test.go
@@ -3,10 +3,13 @@ package detect
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 	"unsafe"
@@ -168,6 +171,37 @@ func TestAgent_RuntimeProviderOverride(t *testing.T) {
 	}
 	if _, ok := b.ChatModel().(*einoopenai.ChatModel); !ok {
 		t.Fatalf("fail-closed ChatModel = %T, want *einoopenai.ChatModel", b.ChatModel())
+	}
+}
+
+func TestAgent_RebuildFailureUsesSafeProviderError(t *testing.T) {
+	const secret = "runtime-build-secret"
+	cfg := config.AgentAIConfig{Provider: "gemini", Model: "unsafe\r\n" + secret}
+	a := &Agent{cfg: cfg, SampleFn: defaultSampleFn}
+	a.chat = einowrap.NewModelHolder(cfg, einowrap.Options{}, einowrap.RuntimeAI{}, func(context.Context, config.AgentAIConfig, einowrap.Options) (model.BaseChatModel, error) {
+		return nil, fmt.Errorf("construction reflected %s\r\nforged=true", secret)
+	})
+
+	_, err := a.Run(context.Background(), core.DetectTask{Result: core.AgentResult{PatternID: "pattern"}})
+	var providerErr *einowrap.ProviderError
+	if !errors.As(err, &providerErr) {
+		t.Fatalf("rebuild failure = %T %v, want ProviderError", err, err)
+	}
+	encoded := providerErr.Provider + providerErr.Model + providerErr.Diagnostic
+	if strings.Contains(encoded, secret) || strings.Contains(encoded, "forged=true") || strings.ContainsAny(encoded, "\r\n") {
+		t.Fatalf("safe rebuild failure retained malicious input: %+v", providerErr)
+	}
+}
+
+func TestSafeDetectProviderErrorPreservesContextIdentity(t *testing.T) {
+	for _, target := range []error{context.Canceled, context.DeadlineExceeded} {
+		err := safeDetectProviderError(context.Background(), "openai", "model", fmt.Errorf("provider wrapper: %w", target))
+		if !errors.Is(err, target) {
+			t.Errorf("safeDetectProviderError(%v) = %v, identity not preserved", target, err)
+		}
+		if strings.Contains(err.Error(), "provider wrapper") {
+			t.Errorf("safeDetectProviderError(%v) exposed raw provider wrapper: %v", target, err)
+		}
 	}
 }
 

--- a/pkg/agent/ai/eino/chatmodel.go
+++ b/pkg/agent/ai/eino/chatmodel.go
@@ -12,7 +12,6 @@ package eino
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -22,7 +21,7 @@ import (
 )
 
 // BaseURL is overridable for tests. Production code passes "" to use
-// the Eino / go-openai default (https://api.openai.com/v1). The agent
+// the provider default endpoint. It is intentionally not a config field:
 // admin endpoints never expose this; only the chatmodel test sets it
 // to point at an httptest server.
 type Options struct {
@@ -30,61 +29,75 @@ type Options struct {
 	BaseURL    string
 	Timeout    time.Duration
 
-	// AuthKeyFunc is an OPTIONAL per-request Authorization override. When
-	// non-nil the outbound transport calls it for every request: if it
-	// returns ok the request's Authorization header is replaced with
-	// "Bearer <key>" AFTER the SDK set its YAML-keyed header (so the
-	// override wins); ok=false leaves the YAML-keyed header untouched. When
-	// nil the transport is a plain pass-through and the client is used
-	// exactly as before — this is the OSS byte-for-byte path. The package
-	// stays generic: it knows nothing about who supplies the key (the agent
-	// package injects a function backed by its runtime AISettingsResolver,
-	// which avoids an import cycle because eino never imports agent).
-	AuthKeyFunc func(ctx context.Context) (key string, ok bool)
+	// RuntimeKeyFunc is an OPTIONAL per-request provider credential override.
+	// Provider builders apply it using their native authentication scheme.
+	// ok=false leaves the SDK's configured key untouched; ok=true with an
+	// empty key explicitly clears credentials for that request.
+	RuntimeKeyFunc func(ctx context.Context) (key string, ok bool)
 }
 
-// authRoundTripper injects a runtime Authorization override onto every
-// outbound request. It consults keyFn per request, so a hot-swapped key
-// takes effect without rebuilding the client. Per the http.RoundTripper
-// contract it must not mutate the input request, so it clones the request
-// (which deep-copies the header) before writing the override.
-type authRoundTripper struct {
-	base  http.RoundTripper
-	keyFn func(ctx context.Context) (key string, ok bool)
+type credentialPolicy uint8
+
+const (
+	credentialBearer credentialPolicy = iota
+	credentialClaude
+	credentialGemini
+	credentialNone
+)
+
+var credentialHeaders = []string{"Authorization", "x-api-key", "x-goog-api-key"}
+
+type runtimeKeyRoundTripper struct {
+	base   http.RoundTripper
+	keyFn  func(ctx context.Context) (key string, ok bool)
+	policy credentialPolicy
 }
 
-func (a authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	base := a.base
+func (t runtimeKeyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
 	if base == nil {
 		base = http.DefaultTransport
 	}
-	if a.keyFn == nil {
+	if t.keyFn == nil && t.policy != credentialNone {
 		return base.RoundTrip(req)
 	}
-	key, ok := a.keyFn(req.Context())
-	if !ok {
-		// No opinion: send the request exactly as the SDK built it.
+	key, ok := "", false
+	if t.keyFn != nil {
+		key, ok = t.keyFn(req.Context())
+	}
+	if !ok && t.policy != credentialNone {
 		return base.RoundTrip(req)
 	}
 	clone := req.Clone(req.Context())
-	clone.Header.Set("Authorization", "Bearer "+key)
+	for _, header := range credentialHeaders {
+		clone.Header.Del(header)
+	}
+	if key != "" {
+		switch t.policy {
+		case credentialBearer:
+			clone.Header.Set("Authorization", "Bearer "+key)
+		case credentialClaude:
+			clone.Header.Set("x-api-key", key)
+		case credentialGemini:
+			clone.Header.Set("x-goog-api-key", key)
+		}
+	}
 	return base.RoundTrip(clone)
 }
 
-// withAuthRoundTripper returns an *http.Client whose transport injects the
-// runtime Authorization override. When keyFn is nil the input client is
-// returned unchanged (nil included), so the no-resolver path is byte-for-
-// byte identical to the pre-seam wiring. The input client is never mutated:
-// a shallow copy is wrapped so the caller's client keeps its own transport.
-func withAuthRoundTripper(c *http.Client, timeout time.Duration, keyFn func(ctx context.Context) (key string, ok bool)) *http.Client {
-	if keyFn == nil {
+func (o Options) runtimeKeyFunc() func(context.Context) (string, bool) {
+	return o.RuntimeKeyFunc
+}
+
+func withRuntimeKeyRoundTripper(c *http.Client, timeout time.Duration, keyFn func(ctx context.Context) (key string, ok bool), policy credentialPolicy) *http.Client {
+	if keyFn == nil && policy != credentialNone {
 		return c
 	}
 	if c == nil {
 		c = &http.Client{Timeout: timeout}
 	}
 	wrapped := *c
-	wrapped.Transport = authRoundTripper{base: c.Transport, keyFn: keyFn}
+	wrapped.Transport = runtimeKeyRoundTripper{base: c.Transport, keyFn: keyFn, policy: policy}
 	return &wrapped
 }
 
@@ -100,7 +113,7 @@ func withAuthRoundTripper(c *http.Client, timeout time.Duration, keyFn func(ctx 
 // for tests).
 func NewChatModel(ctx context.Context, cfg config.AgentAIConfig, opts Options) (model.BaseChatModel, error) {
 	if cfg.Model == "" {
-		return nil, fmt.Errorf("eino: model is empty")
+		return nil, emptyModelConfigError(false)
 	}
 
 	timeout := opts.Timeout
@@ -121,7 +134,8 @@ func NewChatModel(ctx context.Context, cfg config.AgentAIConfig, opts Options) (
 		apiKey:      cfg.APIKey,
 		model:       cfg.Model,
 		baseURL:     opts.BaseURL,
-		httpClient:  withAuthRoundTripper(opts.HTTPClient, timeout, opts.AuthKeyFunc),
+		httpClient:  opts.HTTPClient,
+		runtimeKey:  opts.runtimeKeyFunc(),
 		timeout:     timeout,
 		maxTokens:   maxCompletionTokens,
 		temperature: resolveTemperature(cfg.Temperature, 0.2),
@@ -141,7 +155,7 @@ func NewChatModel(ctx context.Context, cfg config.AgentAIConfig, opts Options) (
 // providers to reject the tool-call turns.
 func NewToolCallingChatModel(ctx context.Context, cfg config.AgentAIConfig, opts Options) (model.ToolCallingChatModel, error) {
 	if cfg.Model == "" {
-		return nil, fmt.Errorf("eino: model is empty")
+		return nil, emptyModelConfigError(false)
 	}
 
 	timeout := opts.Timeout
@@ -160,7 +174,8 @@ func NewToolCallingChatModel(ctx context.Context, cfg config.AgentAIConfig, opts
 		apiKey:      cfg.APIKey,
 		model:       cfg.Model,
 		baseURL:     opts.BaseURL,
-		httpClient:  withAuthRoundTripper(opts.HTTPClient, timeout, opts.AuthKeyFunc),
+		httpClient:  opts.HTTPClient,
+		runtimeKey:  opts.runtimeKeyFunc(),
 		timeout:     timeout,
 		maxTokens:   maxCompletionTokens,
 		temperature: resolveTemperature(cfg.Temperature, 0.2),

--- a/pkg/agent/ai/eino/chatmodel_auth_test.go
+++ b/pkg/agent/ai/eino/chatmodel_auth_test.go
@@ -3,8 +3,10 @@ package eino_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -46,7 +48,7 @@ func newAuthCaptureServer(t *testing.T, seen *[]string, mu *sync.Mutex) *httptes
 }
 
 // TestChatModel_AuthOverride_NoFunc_UsesYAMLKey proves the OSS path: with
-// no AuthKeyFunc the outbound Authorization header is the YAML key, exactly
+// no RuntimeKeyFunc the outbound Authorization header is the YAML key, exactly
 // as before the seam (byte-for-byte pass-through transport).
 func TestChatModel_AuthOverride_NoFunc_UsesYAMLKey(t *testing.T) {
 	var mu sync.Mutex
@@ -70,7 +72,7 @@ func TestChatModel_AuthOverride_NoFunc_UsesYAMLKey(t *testing.T) {
 	}
 }
 
-// TestChatModel_AuthOverride_FuncWins proves that when AuthKeyFunc returns
+// TestChatModel_AuthOverride_FuncWins proves that when RuntimeKeyFunc returns
 // ok the outbound Authorization header is the resolver key (it overrides
 // the YAML-keyed header the SDK set), and that ok=false falls back to the
 // YAML key. Both go through ONE model instance — no rebuild — proving the
@@ -93,8 +95,8 @@ func TestChatModel_AuthOverride_FuncWins(t *testing.T) {
 
 	cfg := config.AgentAIConfig{APIKey: "yaml-key", Model: "gpt-4o-mini", MaxTokens: 16}
 	cm, err := einowrap.NewChatModel(context.Background(), cfg, einowrap.Options{
-		BaseURL:     srv.URL,
-		AuthKeyFunc: keyFn,
+		BaseURL:        srv.URL,
+		RuntimeKeyFunc: keyFn,
 	})
 	if err != nil {
 		t.Fatalf("NewChatModel: %v", err)
@@ -121,5 +123,161 @@ func TestChatModel_AuthOverride_FuncWins(t *testing.T) {
 	}
 	if seen[1] != "Bearer resolver-key" {
 		t.Errorf("call #2 Authorization = %q, want Bearer resolver-key (override wins)", seen[1])
+	}
+}
+
+type capturedEgress struct {
+	header http.Header
+	url    string
+	body   string
+}
+
+func newCredentialCaptureServer(t *testing.T, captures *[]capturedEgress, mu *sync.Mutex) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		*captures = append(*captures, capturedEgress{header: r.Header.Clone(), url: r.URL.String(), body: string(body)})
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"unavailable"}}`))
+	}))
+}
+
+func assertCredentialEgress(t *testing.T, got capturedEgress, provider, key string) {
+	t.Helper()
+	want := map[string]string{}
+	switch provider {
+	case "openai", "deepseek", "qwen":
+		if key != "" {
+			want["Authorization"] = "Bearer " + key
+		}
+	case "claude":
+		want["x-api-key"] = key
+	case "gemini":
+		want["x-goog-api-key"] = key
+	}
+	for _, header := range []string{"Authorization", "x-api-key", "x-goog-api-key"} {
+		if got.header.Get(header) != want[header] {
+			t.Errorf("%s %s = %q, want %q", provider, header, got.header.Get(header), want[header])
+		}
+	}
+	for _, secret := range []string{key, "yaml-secret"} {
+		if secret != "" && (strings.Contains(got.url, secret) || strings.Contains(got.body, secret)) {
+			t.Errorf("%s leaked credential in URL/body: url=%q body=%q", provider, got.url, got.body)
+		}
+	}
+}
+
+func TestChatModel_RuntimeCredentialEgressMatrix(t *testing.T) {
+	for _, provider := range []string{"openai", "deepseek", "qwen", "claude", "gemini", "ollama"} {
+		t.Run(provider, func(t *testing.T) {
+			var captures []capturedEgress
+			var mu sync.Mutex
+			server := newCredentialCaptureServer(t, &captures, &mu)
+			defer server.Close()
+			key := "runtime-" + provider + "-secret"
+			chatModel, err := einowrap.NewChatModel(context.Background(), config.AgentAIConfig{
+				Provider: provider, APIKey: "yaml-secret", Model: "credential-test-model", MaxTokens: 16,
+			}, einowrap.Options{BaseURL: server.URL, HTTPClient: server.Client(), RuntimeKeyFunc: func(context.Context) (string, bool) {
+				return key, true
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _ = chatModel.Generate(context.Background(), []*schema.Message{schema.UserMessage("hello")})
+			mu.Lock()
+			defer mu.Unlock()
+			if len(captures) != 1 {
+				t.Fatalf("captured %d requests, want 1", len(captures))
+			}
+			assertCredentialEgress(t, captures[0], provider, key)
+		})
+	}
+}
+
+func TestChatModel_RuntimeCredentialRotationClearAndProviderHotSwitch(t *testing.T) {
+	var captures []capturedEgress
+	var mu sync.Mutex
+	server := newCredentialCaptureServer(t, &captures, &mu)
+	defer server.Close()
+
+	provider := "openai"
+	key := "rotation-one-secret"
+	keyOK := true
+	runtime := einowrap.RuntimeAI{Provider: func(context.Context) (string, bool) { return provider, true }}
+	holder := einowrap.NewChatModelHolder(config.AgentAIConfig{
+		Provider: "openai", APIKey: "yaml-secret", Model: "credential-test-model", MaxTokens: 16,
+	}, einowrap.Options{BaseURL: server.URL, HTTPClient: server.Client(), RuntimeKeyFunc: func(context.Context) (string, bool) {
+		return key, keyOK
+	}}, runtime)
+
+	call := func() {
+		model, err := holder.Get(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = model.Generate(context.Background(), []*schema.Message{schema.UserMessage("hello")})
+	}
+	call()
+	key = "rotation-two-secret"
+	call()
+	key = ""
+	call()
+	for _, next := range []string{"claude", "gemini", "ollama"} {
+		provider = next
+		key = "switch-" + next + "-secret"
+		call()
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captures) != 6 {
+		t.Fatalf("captured %d requests, want 6", len(captures))
+	}
+	assertCredentialEgress(t, captures[0], "openai", "rotation-one-secret")
+	assertCredentialEgress(t, captures[1], "openai", "rotation-two-secret")
+	assertCredentialEgress(t, captures[2], "openai", "")
+	assertCredentialEgress(t, captures[3], "claude", "switch-claude-secret")
+	assertCredentialEgress(t, captures[4], "gemini", "switch-gemini-secret")
+	assertCredentialEgress(t, captures[5], "ollama", "switch-ollama-secret")
+}
+
+func TestChatModel_NativeRuntimeNoOpinionUsesYAMLAndClearRestoresFloor(t *testing.T) {
+	for _, provider := range []string{"claude", "gemini"} {
+		t.Run(provider, func(t *testing.T) {
+			var captures []capturedEgress
+			var mu sync.Mutex
+			server := newCredentialCaptureServer(t, &captures, &mu)
+			defer server.Close()
+			key := ""
+			keyOK := false
+			chatModel, err := einowrap.NewChatModel(context.Background(), config.AgentAIConfig{
+				Provider: provider, APIKey: "yaml-secret", Model: "credential-test-model", MaxTokens: 16,
+			}, einowrap.Options{BaseURL: server.URL, HTTPClient: server.Client(), RuntimeKeyFunc: func(context.Context) (string, bool) {
+				return key, keyOK
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			call := func() {
+				_, _ = chatModel.Generate(context.Background(), []*schema.Message{schema.UserMessage("hello")})
+			}
+			call()
+			key, keyOK = "runtime-secret", true
+			call()
+			key, keyOK = "", false
+			call()
+
+			mu.Lock()
+			defer mu.Unlock()
+			if len(captures) != 3 {
+				t.Fatalf("captured %d requests, want 3", len(captures))
+			}
+			assertCredentialEgress(t, captures[0], provider, "yaml-secret")
+			assertCredentialEgress(t, captures[1], provider, "runtime-secret")
+			assertCredentialEgress(t, captures[2], provider, "yaml-secret")
+		})
 	}
 }

--- a/pkg/agent/ai/eino/embedder.go
+++ b/pkg/agent/ai/eino/embedder.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
-	"strings"
 	"time"
 
 	einogeminiemb "github.com/cloudwego/eino-ext/components/embedding/gemini"
@@ -18,8 +17,8 @@ import (
 )
 
 // embedderRequest is the normalized input each embedder builder receives. As
-// with the chat path, HTTPClient is already auth-wrapped so a Bearer-keyed
-// provider honours the runtime key override.
+// with the chat path, HTTPClient is wrapped with the effective embedding
+// provider's native credential policy.
 type embedderRequest struct {
 	apiKey     string
 	model      string
@@ -39,7 +38,7 @@ type embedderBuilder func(ctx context.Context, req embedderRequest) (embedding.E
 // embedder — there is NO silent fallback to openai. Gemini IS wired here because
 // eino-ext ships a Gemini embedding component (gemini-embedding-001 /
 // text-embedding-004); it authenticates with the api key via x-goog-api-key, not
-// a Bearer token, so the runtime override does not apply (see buildGeminiEmbedder).
+// a Bearer token; its runtime key uses x-goog-api-key.
 var embedderBuilders = map[string]embedderBuilder{
 	"openai": buildOpenAIEmbedder,
 	"ollama": buildOllamaEmbedder,
@@ -55,6 +54,12 @@ func supportedEmbedderProviders() []string {
 	return names
 }
 
+// IsSupportedEmbedderProvider reports whether the normalized provider has a
+// registered embedding implementation.
+func IsSupportedEmbedderProvider(name string) bool {
+	return isEmbedderProvider(resolveProvider(name))
+}
+
 // NewEmbedder builds a core.Embedder for the configured provider. cfg.Provider
 // selects the backend (empty defaults to openai); an unsupported provider fails
 // fast with a clear error. cfg.Model must be set (the embedding model id, e.g.
@@ -66,7 +71,7 @@ func supportedEmbedderProviders() []string {
 // dedicated ollama provider does the same against a native Ollama daemon.
 func NewEmbedder(ctx context.Context, cfg config.AgentAIConfig, opts Options) (core.Embedder, error) {
 	if cfg.Model == "" {
-		return nil, fmt.Errorf("eino: embedding model is empty")
+		return nil, emptyModelConfigError(true)
 	}
 
 	timeout := opts.Timeout
@@ -77,14 +82,19 @@ func NewEmbedder(ctx context.Context, cfg config.AgentAIConfig, opts Options) (c
 	name := resolveProvider(cfg.Provider)
 	build, ok := embedderBuilders[name]
 	if !ok {
-		return nil, fmt.Errorf("eino: unsupported ai provider %q for embeddings (supported: %s)", name, strings.Join(supportedEmbedderProviders(), ", "))
+		return nil, unsupportedProviderConfigError(name, true, supportedEmbedderProviders())
+	}
+	apiKey := cfg.APIKey
+	runtimeKey := opts.runtimeKeyFunc()
+	if name == "gemini" {
+		apiKey, runtimeKey = geminiCredentials(apiKey, runtimeKey)
 	}
 
 	emb, err := build(ctx, embedderRequest{
-		apiKey:     cfg.APIKey,
+		apiKey:     apiKey,
 		model:      cfg.Model,
 		baseURL:    opts.BaseURL,
-		httpClient: withAuthRoundTripper(opts.HTTPClient, timeout, opts.AuthKeyFunc),
+		httpClient: withRuntimeKeyRoundTripper(opts.HTTPClient, timeout, runtimeKey, chatCredentialPolicy(name)),
 		timeout:    timeout,
 	})
 	if err != nil {
@@ -127,9 +137,8 @@ func buildOllamaEmbedder(ctx context.Context, req embedderRequest) (embedding.Em
 
 // buildGeminiEmbedder wires Google Gemini embeddings (e.g. gemini-embedding-001
 // or text-embedding-004) via the genai client. Like the Gemini chat path, the
-// api key is sent through the x-goog-api-key header rather than a Bearer token,
-// so the AuthKeyFunc override on req.httpClient does not apply; req.apiKey is
-// passed straight to the client. req.baseURL is the test-only endpoint override.
+// api key is sent through the x-goog-api-key header rather than a Bearer token;
+// the provider transport replaces it per request when a runtime key applies.
 func buildGeminiEmbedder(ctx context.Context, req embedderRequest) (embedding.Embedder, error) {
 	client, err := newGeminiClient(ctx, req.apiKey, req.baseURL, req.httpClient, req.timeout)
 	if err != nil {

--- a/pkg/agent/ai/eino/gemini_test.go
+++ b/pkg/agent/ai/eino/gemini_test.go
@@ -3,6 +3,8 @@ package eino_test
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -17,6 +19,23 @@ import (
 	"github.com/VersusControl/versus-incident/pkg/config"
 	"github.com/VersusControl/versus-incident/pkg/core"
 )
+
+func unsetGeminiAPIKeyEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{"GOOGLE_API_KEY", "GEMINI_API_KEY"} {
+		value, present := os.LookupEnv(name)
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatalf("unset %s: %v", name, err)
+		}
+		t.Cleanup(func() {
+			if present {
+				_ = os.Setenv(name, value)
+				return
+			}
+			_ = os.Unsetenv(name)
+		})
+	}
+}
 
 // TestChatModel_Gemini_EgressUsesAPIKeyHeader proves the Gemini provider path
 // end to end against a canned Generative Language API backend: the request
@@ -218,5 +237,206 @@ func TestEmbedder_Gemini_EgressUsesAPIKeyHeader(t *testing.T) {
 	}
 	if len(vecs[0]) != 3 || vecs[1][0] != float32(1.1) {
 		t.Errorf("vector narrowing wrong: %v", vecs)
+	}
+}
+
+func TestGeminiRuntimeOnlyCredentialsRotateAndClearPerRequest(t *testing.T) {
+	unsetGeminiAPIKeyEnv(t)
+	var mu sync.Mutex
+	var captures []capturedEgress
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		mu.Lock()
+		captures = append(captures, capturedEgress{header: request.Header.Clone(), url: request.URL.String(), body: string(body)})
+		mu.Unlock()
+		writer.Header().Set("Content-Type", "application/json")
+		if strings.Contains(request.URL.Path, "embedContent") {
+			_ = json.NewEncoder(writer).Encode(map[string]any{"embeddings": []map[string]any{{"values": []float64{1, 0, 0}}}})
+			return
+		}
+		_ = json.NewEncoder(writer).Encode(map[string]any{"candidates": []map[string]any{{"content": map[string]any{"role": "model", "parts": []map[string]any{{"text": "ok"}}}, "finishReason": "STOP"}}})
+	}))
+	defer server.Close()
+
+	key := "runtime-gemini-first"
+	keyOK := true
+	keyFn := func(context.Context) (string, bool) { return key, keyOK }
+	chatModel, err := einowrap.NewChatModel(context.Background(), config.AgentAIConfig{
+		Provider: "gemini", Model: "gemini-test", MaxTokens: 16,
+	}, einowrap.Options{BaseURL: server.URL, RuntimeKeyFunc: keyFn})
+	if err != nil {
+		t.Fatalf("runtime-only Gemini chat construction: %v", err)
+	}
+	embedder, err := einowrap.NewEmbedder(context.Background(), config.AgentAIConfig{
+		Provider: "gemini", Model: "gemini-embedding-test",
+	}, einowrap.Options{BaseURL: server.URL, RuntimeKeyFunc: keyFn})
+	if err != nil {
+		t.Fatalf("runtime-only Gemini embedder construction: %v", err)
+	}
+
+	callChat := func() {
+		if _, callErr := chatModel.Generate(context.Background(), []*schema.Message{schema.UserMessage("hello")}); callErr != nil {
+			t.Fatalf("Gemini chat call: %v", callErr)
+		}
+	}
+	callEmbed := func() {
+		if _, callErr := embedder.Embed(context.Background(), []string{"hello"}); callErr != nil {
+			t.Fatalf("Gemini embedding call: %v", callErr)
+		}
+	}
+	callChat()
+	callEmbed()
+	key = "runtime-gemini-rotated"
+	callChat()
+	callEmbed()
+	key = ""
+	callChat()
+	callEmbed()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captures) != 6 {
+		t.Fatalf("captured %d requests, want 6", len(captures))
+	}
+	for index, want := range []string{"runtime-gemini-first", "runtime-gemini-first", "runtime-gemini-rotated", "runtime-gemini-rotated", "", ""} {
+		assertCredentialEgress(t, captures[index], "gemini", want)
+	}
+}
+
+type geminiOrgContextKey struct{}
+
+func TestGeminiCachedHolderDoesNotCarryCredentialAcrossOrgs(t *testing.T) {
+	unsetGeminiAPIKeyEnv(t)
+	var mu sync.Mutex
+	var captures []capturedEgress
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		mu.Lock()
+		captures = append(captures, capturedEgress{header: request.Header.Clone(), url: request.URL.String(), body: string(body)})
+		mu.Unlock()
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]any{"candidates": []map[string]any{{"content": map[string]any{"role": "model", "parts": []map[string]any{{"text": "ok"}}}, "finishReason": "STOP"}}})
+	}))
+	defer server.Close()
+
+	runtimeKey := func(ctx context.Context) (string, bool) {
+		if ctx.Value(geminiOrgContextKey{}) == "org-a" {
+			return "org-a-runtime-secret", true
+		}
+		return "", false
+	}
+	holder := einowrap.NewChatModelHolder(config.AgentAIConfig{
+		Provider: "gemini", APIKey: "yaml-fallback", Model: "gemini-test", MaxTokens: 16,
+	}, einowrap.Options{BaseURL: server.URL, HTTPClient: server.Client(), RuntimeKeyFunc: runtimeKey}, einowrap.RuntimeAI{
+		KeySet: func(context.Context) (bool, bool) { return true, true },
+	})
+	call := func(org string) {
+		ctx := context.WithValue(context.Background(), geminiOrgContextKey{}, org)
+		chatModel, err := holder.Get(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := chatModel.Generate(ctx, []*schema.Message{schema.UserMessage("hello")}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	call("org-a")
+	call("org-b")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captures) != 2 {
+		t.Fatalf("captured %d requests, want 2", len(captures))
+	}
+	assertCredentialEgress(t, captures[0], "gemini", "org-a-runtime-secret")
+	assertCredentialEgress(t, captures[1], "gemini", "yaml-fallback")
+	if got := captures[1].header.Get("x-goog-api-key"); got == "org-a-runtime-secret" {
+		t.Fatal("org A runtime credential egressed for org B")
+	}
+}
+
+func TestGeminiEmptyYAMLDoesNotUseAmbientCredentials(t *testing.T) {
+	t.Setenv("GOOGLE_API_KEY", "ambient-google-secret")
+	t.Setenv("GEMINI_API_KEY", "ambient-gemini-secret")
+	var mu sync.Mutex
+	var captures []capturedEgress
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		mu.Lock()
+		captures = append(captures, capturedEgress{header: request.Header.Clone(), url: request.URL.String(), body: string(body)})
+		mu.Unlock()
+		writer.Header().Set("Content-Type", "application/json")
+		if strings.Contains(request.URL.Path, "embedContent") {
+			_ = json.NewEncoder(writer).Encode(map[string]any{"embeddings": []map[string]any{{"values": []float64{1, 0, 0}}}})
+			return
+		}
+		_ = json.NewEncoder(writer).Encode(map[string]any{"candidates": []map[string]any{{"content": map[string]any{"role": "model", "parts": []map[string]any{{"text": "ok"}}}, "finishReason": "STOP"}}})
+	}))
+	defer server.Close()
+
+	chatModel, err := einowrap.NewChatModel(context.Background(), config.AgentAIConfig{
+		Provider: "gemini", Model: "gemini-test", MaxTokens: 16,
+	}, einowrap.Options{BaseURL: server.URL, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := chatModel.Generate(context.Background(), []*schema.Message{schema.UserMessage("hello")}); err != nil {
+		t.Fatal(err)
+	}
+	embedder, err := einowrap.NewEmbedder(context.Background(), config.AgentAIConfig{
+		Provider: "gemini", Model: "gemini-embedding-test",
+	}, einowrap.Options{BaseURL: server.URL, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := embedder.Embed(context.Background(), []string{"hello"}); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captures) != 2 {
+		t.Fatalf("captured %d requests, want 2", len(captures))
+	}
+	for index, capture := range captures {
+		assertCredentialEgress(t, capture, "gemini", "")
+		for _, secret := range []string{"ambient-google-secret", "ambient-gemini-secret"} {
+			if strings.Contains(capture.url, secret) || strings.Contains(capture.body, secret) {
+				t.Fatalf("request %d leaked ambient credential outside headers", index+1)
+			}
+		}
+	}
+}
+
+func TestGeminiRuntimeClearWithEmptyYAMLOnCleanEnvironment(t *testing.T) {
+	unsetGeminiAPIKeyEnv(t)
+	var mu sync.Mutex
+	var captures []capturedEgress
+	server := newCredentialCaptureServer(t, &captures, &mu)
+	defer server.Close()
+	clearKey := func(context.Context) (string, bool) { return "", true }
+
+	chatModel, err := einowrap.NewChatModel(context.Background(), config.AgentAIConfig{
+		Provider: "gemini", Model: "gemini-test", MaxTokens: 16,
+	}, einowrap.Options{BaseURL: server.URL, HTTPClient: server.Client(), RuntimeKeyFunc: clearKey})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = chatModel.Generate(context.Background(), []*schema.Message{schema.UserMessage("hello")})
+	embedder, err := einowrap.NewEmbedder(context.Background(), config.AgentAIConfig{
+		Provider: "gemini", Model: "gemini-embedding-test",
+	}, einowrap.Options{BaseURL: server.URL, HTTPClient: server.Client(), RuntimeKeyFunc: clearKey})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = embedder.Embed(context.Background(), []string{"hello"})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captures) != 2 {
+		t.Fatalf("captured %d requests, want 2", len(captures))
+	}
+	for _, capture := range captures {
+		assertCredentialEgress(t, capture, "gemini", "")
 	}
 }

--- a/pkg/agent/ai/eino/holder.go
+++ b/pkg/agent/ai/eino/holder.go
@@ -16,7 +16,7 @@ import (
 // The model PROVIDER (openai | deepseek | qwen | ollama | claude | gemini) is
 // chosen at CONSTRUCTION time: each provider picks a different SDK/builder
 // (provider.go), so a provider change cannot hot-reload through a request
-// header the way the per-request key override (AuthKeyFunc) does — the model
+// header the way the per-request runtime key override does — the model
 // object must be REBUILT. A Holder is the rebuild lifecycle: it caches a built
 // model keyed by its effective signature and rebuilds only when that signature
 // changes, so steady-state has no per-call cost while an operator's runtime
@@ -36,7 +36,7 @@ import (
 // never rebuilt).
 //
 // Provider composes with the existing per-request key override: the key VALUE
-// still hot-reloads through the AuthKeyFunc transport WITHOUT a rebuild (it is
+// still hot-reloads through the provider-native transport WITHOUT a rebuild (it is
 // NOT part of the signature); only the provider, the model id, and the
 // enable/key-presence STATE force a rebuild.
 type RuntimeAI struct {

--- a/pkg/agent/ai/eino/holder_test.go
+++ b/pkg/agent/ai/eino/holder_test.go
@@ -183,6 +183,28 @@ func TestHolder_KeyStateRebuild(t *testing.T) {
 	}
 }
 
+func TestGeminiHolder_RuntimeOnlyKeySetClearRebuilds(t *testing.T) {
+	var keySet atomic.Bool
+	keySet.Store(true)
+	key := "runtime-gemini-key"
+	holder := einowrap.NewChatModelHolder(config.AgentAIConfig{Provider: "gemini", Model: "gemini-test"}, einowrap.Options{
+		RuntimeKeyFunc: func(context.Context) (string, bool) { return key, true },
+	}, einowrap.RuntimeAI{KeySet: func(context.Context) (bool, bool) { return keySet.Load(), true }})
+	configured, err := holder.Get(context.Background())
+	if err != nil {
+		t.Fatalf("runtime-only Gemini build: %v", err)
+	}
+	key = ""
+	keySet.Store(false)
+	cleared, err := holder.Get(context.Background())
+	if err != nil {
+		t.Fatalf("cleared Gemini rebuild: %v", err)
+	}
+	if configured == cleared {
+		t.Fatal("runtime key set-to-clear transition did not rebuild Gemini client")
+	}
+}
+
 func TestHolder_RuntimeRevisionRebuilds(t *testing.T) {
 	var revision atomic.Int64
 	runtime := einowrap.RuntimeAI{Revision: func(context.Context) (string, bool) {

--- a/pkg/agent/ai/eino/provider.go
+++ b/pkg/agent/ai/eino/provider.go
@@ -3,7 +3,6 @@ package eino
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"sort"
 	"strings"
@@ -22,20 +21,19 @@ import (
 
 // DefaultProvider is the model backend used when AgentAIConfig.Provider is
 // empty. It is the OSS default and preserves the historical OpenAI behaviour
-// byte-for-byte (JSON-mode, MaxCompletionTokens, AuthKeyFunc transport, the
+// byte-for-byte (JSON-mode, MaxCompletionTokens, runtime-key transport, the
 // test-only Options.BaseURL seam).
 const DefaultProvider = "openai"
 
 // chatModelRequest is the normalized, provider-agnostic input the registry
-// passes to each builder. The HTTPClient is already wrapped with the
-// AuthKeyFunc transport (see NewChatModel/NewToolCallingChatModel), so every
-// provider that authenticates with a Bearer Authorization header honours the
-// runtime key override for free.
+// passes to each builder. The HTTPClient is wrapped after provider resolution
+// with that provider's native runtime credential policy.
 type chatModelRequest struct {
 	apiKey      string
 	model       string
 	baseURL     string // test-only Options.BaseURL; "" uses the provider default
 	httpClient  *http.Client
+	runtimeKey  func(context.Context) (string, bool)
 	timeout     time.Duration
 	maxTokens   int
 	temperature *float32
@@ -99,6 +97,14 @@ func IsSupportedProvider(name string) bool {
 	return isChatProvider(resolveProvider(name))
 }
 
+// IsKeylessProvider reports whether a registered chat provider intentionally
+// sends no provider credential. Consumers use this registry-derived policy
+// when deciding whether a provider transition requires a replacement key.
+func IsKeylessProvider(name string) bool {
+	provider := resolveProvider(name)
+	return isChatProvider(provider) && chatCredentialPolicy(provider) == credentialNone
+}
+
 // newProviderChatModel resolves the provider and dispatches to its builder.
 // An unknown/unsupported provider fails fast here with a clear error — there
 // is NO silent fallback to openai.
@@ -106,9 +112,26 @@ func newProviderChatModel(ctx context.Context, provider string, req chatModelReq
 	name := resolveProvider(provider)
 	build, ok := chatModelBuilders[name]
 	if !ok {
-		return nil, fmt.Errorf("eino: unsupported ai provider %q (supported: %s)", name, strings.Join(supportedProviders(), ", "))
+		return nil, unsupportedProviderConfigError(name, false, supportedProviders())
 	}
+	if name == "gemini" {
+		req.apiKey, req.runtimeKey = geminiCredentials(req.apiKey, req.runtimeKey)
+	}
+	req.httpClient = withRuntimeKeyRoundTripper(req.httpClient, req.timeout, req.runtimeKey, chatCredentialPolicy(name))
 	return build(ctx, req)
+}
+
+func chatCredentialPolicy(provider string) credentialPolicy {
+	switch provider {
+	case "claude":
+		return credentialClaude
+	case "gemini":
+		return credentialGemini
+	case "ollama":
+		return credentialNone
+	default:
+		return credentialBearer
+	}
 }
 
 // openAIFixedSamplingPrefixes lists the OpenAI model-id families whose
@@ -154,7 +177,7 @@ func isFixedSamplingModel(model string) bool {
 // buildOpenAIChatModel is the default path. It preserves the historical OpenAI
 // wiring — JSON-mode response format, MaxCompletionTokens (the reasoning-safe
 // field), the configured temperature, the test-only BaseURL, and the
-// AuthKeyFunc-wrapped HTTPClient — with one model-aware refinement: for
+// runtime-key-wrapped HTTPClient — with one model-aware refinement: for
 // beta-limited / reasoning families (see isFixedSamplingModel) temperature is
 // omitted so the provider applies its fixed default instead of rejecting the
 // request. The SDK never sets top_p / n / presence_penalty / frequency_penalty
@@ -188,8 +211,7 @@ func buildOpenAIChatModel(ctx context.Context, req chatModelRequest) (model.Tool
 }
 
 // buildDeepSeekChatModel wires the OpenAI-compatible DeepSeek backend. It
-// accepts a Bearer key, so the AuthKeyFunc transport on req.httpClient works
-// unchanged.
+// accepts a Bearer key, so the provider policy uses Authorization.
 func buildDeepSeekChatModel(ctx context.Context, req chatModelRequest) (model.ToolCallingChatModel, error) {
 	conf := &einodeepseek.ChatModelConfig{
 		APIKey:     req.apiKey,
@@ -235,8 +257,9 @@ func buildQwenChatModel(ctx context.Context, req chatModelRequest) (model.ToolCa
 }
 
 // buildOllamaChatModel wires a local Ollama server. Ollama is keyless, so the
-// AuthKeyFunc transport is a harmless no-op. BaseURL defaults to the local
-// daemon when unset. JSON-mode is requested via the native `format` field.
+// runtime credential policy strips every recognized credential header.
+// BaseURL defaults to the local daemon when unset. JSON-mode is requested via
+// the native `format` field.
 func buildOllamaChatModel(ctx context.Context, req chatModelRequest) (model.ToolCallingChatModel, error) {
 	baseURL := req.baseURL
 	if baseURL == "" {
@@ -255,8 +278,8 @@ func buildOllamaChatModel(ctx context.Context, req chatModelRequest) (model.Tool
 }
 
 // buildClaudeChatModel wires Anthropic Claude (direct API). Claude authenticates
-// with the x-api-key header rather than a Bearer token, so the AuthKeyFunc
-// override does not apply; the configured APIKey is used. MaxTokens is required
+// with the x-api-key header rather than a Bearer token; the runtime policy
+// replaces the configured key in that native header. MaxTokens is required
 // (>0) by the SDK — the caller always supplies a non-zero default. Anthropic has
 // no response_format knob, so jsonMode is advisory only (detect's ParseFinding
 // is tolerant of fenced/plain JSON).
@@ -277,9 +300,8 @@ func buildClaudeChatModel(ctx context.Context, req chatModelRequest) (model.Tool
 
 // buildGeminiChatModel wires Google Gemini (the Generative Language API) via the
 // genai client. Gemini authenticates with the api key through the x-goog-api-key
-// header set by the genai client — NOT a Bearer token — so, exactly like
-// Claude's x-api-key path, the AuthKeyFunc Bearer override on req.httpClient does
-// not apply; the configured req.apiKey is passed straight to the client.
+// header set by the genai client — NOT a Bearer token — and the runtime policy
+// replaces the configured key in that native header.
 // req.baseURL is honoured as the genai HTTPOptions.BaseURL (the test-only
 // httptest seam). Gemini exposes structured JSON output only via a full
 // ResponseJSONSchema, not a bare response_mime_type toggle, so jsonMode is
@@ -301,11 +323,32 @@ func buildGeminiChatModel(ctx context.Context, req chatModelRequest) (model.Tool
 	return einogemini.NewChatModel(ctx, conf)
 }
 
+const geminiConstructionAPIKey = "versus-non-secret-placeholder"
+
+// geminiCredentials prevents the genai SDK from consulting ambient Google
+// credential environment variables or retaining a runtime org secret in its
+// cached client. Runtime resolution remains entirely request-scoped: an
+// explicit answer replaces the header (including an explicit empty clear),
+// while no opinion deterministically falls back to the configured YAML key.
+func geminiCredentials(configured string, runtime func(context.Context) (string, bool)) (string, func(context.Context) (string, bool)) {
+	if runtime == nil && configured != "" {
+		return configured, nil
+	}
+	if runtime == nil {
+		return geminiConstructionAPIKey, func(context.Context) (string, bool) { return "", true }
+	}
+	return geminiConstructionAPIKey, func(ctx context.Context) (string, bool) {
+		if key, ok := runtime(ctx); ok {
+			return key, true
+		}
+		return configured, true
+	}
+}
+
 // newGeminiClient builds the google.golang.org/genai client shared by the Gemini
 // chat and embedding builders. It pins the Gemini API backend (never Vertex) and
-// passes the api key directly: Gemini sends it via the x-goog-api-key header, so
-// the Bearer AuthKeyFunc override that req.httpClient may carry is a harmless
-// no-op for this provider. baseURL is the test-only endpoint override ("" uses
+// passes the configured api key directly; the per-instance transport may
+// replace it in x-goog-api-key at request time. baseURL is the test-only endpoint override ("" uses
 // the public Gemini endpoint); httpClient and timeout are threaded through so the
 // per-request deadline holds even when the SDK supplies its own default client.
 func newGeminiClient(ctx context.Context, apiKey, baseURL string, httpClient *http.Client, timeout time.Duration) (*genai.Client, error) {

--- a/pkg/agent/ai/eino/provider_error.go
+++ b/pkg/agent/ai/eino/provider_error.go
@@ -1,0 +1,162 @@
+package eino
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+)
+
+const maxProviderIdentifierRunes = 96
+
+// ConfigError is a trusted local validation error produced before a provider
+// SDK is called. Its message contains only bounded configuration identifiers
+// and fixed guidance, so boot diagnostics may log it directly.
+type ConfigError struct {
+	message string
+}
+
+func (err *ConfigError) Error() string {
+	if err == nil {
+		return "eino: invalid AI configuration"
+	}
+	return err.message
+}
+
+func emptyModelConfigError(embedding bool) *ConfigError {
+	if embedding {
+		return &ConfigError{message: "eino: embedding model is empty"}
+	}
+	return &ConfigError{message: "eino: model is empty"}
+}
+
+func unsupportedProviderConfigError(provider string, embedding bool, supported []string) *ConfigError {
+	provider = safeProviderIdentifier(provider, "invalid value")
+	if embedding {
+		return &ConfigError{message: fmt.Sprintf("eino: unsupported ai provider %q for embeddings (supported: %s)", provider, strings.Join(supported, ", "))}
+	}
+	return &ConfigError{message: fmt.Sprintf("eino: unsupported ai provider %q (supported: %s)", provider, strings.Join(supported, ", "))}
+}
+
+// ProviderError is the safe, public representation of a model-provider
+// failure. It deliberately does not retain or unwrap the raw provider cause.
+type ProviderError struct {
+	Provider   string
+	Model      string
+	Class      string
+	Diagnostic string
+}
+
+func (err *ProviderError) Error() string {
+	if err == nil {
+		return "AI provider unavailable"
+	}
+	return err.Diagnostic
+}
+
+// SafeProviderError classifies a raw provider failure in memory and returns a
+// bounded error containing only safe identifiers and a fixed diagnostic.
+func SafeProviderError(provider, model string, cause error) *ProviderError {
+	provider = safeProviderIdentifier(provider, "openai")
+	model = safeProviderIdentifier(model, "configured model")
+	class := providerErrorClass(cause)
+	rawClassText := ""
+	if cause != nil {
+		rawClassText = strings.ToLower(cause.Error())
+	}
+	label := strings.ToUpper(provider[:1]) + provider[1:]
+	diagnostic := fmt.Sprintf("%s could not produce a response with model %q; verify provider configuration and model access.", label, model)
+	switch class {
+	case "authentication":
+		diagnostic = fmt.Sprintf("%s authentication failed for model %q; verify the configured API key.", label, model)
+	case "permission":
+		diagnostic = fmt.Sprintf("%s denied access to model %q; verify model permissions.", label, model)
+	case "model_not_found":
+		diagnostic = fmt.Sprintf("%s model %q was not found or is unavailable to this account.", label, model)
+	case "rate_limit":
+		diagnostic = fmt.Sprintf("%s rate limit or quota was reached for model %q; retry later or check provider limits.", label, model)
+	case "invalid_request":
+		if strings.Contains(rawClassText, "temperature") && containsAny(rawClassText, "deprecated", "unsupported", "not support", "does not support") {
+			diagnostic = fmt.Sprintf("%s model %q rejected the configured temperature; set AGENT_AI_TEMPERATURE=-1 to omit it, restart Versus, and retry.", label, model)
+		} else {
+			diagnostic = fmt.Sprintf("%s rejected the request for model %q as invalid; verify model compatibility and token limits.", label, model)
+		}
+	case "empty_response":
+		diagnostic = fmt.Sprintf("%s model %q returned no content; verify model access and increase the completion-token budget, then retry.", label, model)
+	case "timeout":
+		diagnostic = fmt.Sprintf("%s timed out while calling model %q.", label, model)
+	case "connection":
+		diagnostic = fmt.Sprintf("Could not connect securely to %s for model %q.", label, model)
+	case "validation":
+		diagnostic = fmt.Sprintf("%s returned an invalid response for model %q.", label, model)
+	case "unavailable":
+		diagnostic = fmt.Sprintf("%s could not produce a response with model %q; verify provider configuration and model access.", label, model)
+	}
+	return &ProviderError{Provider: provider, Model: model, Class: class, Diagnostic: diagnostic}
+}
+
+func providerErrorClass(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	var networkError net.Error
+	if errors.As(err, &networkError) {
+		if networkError.Timeout() {
+			return "timeout"
+		}
+		return "connection"
+	}
+	message := ""
+	if err != nil {
+		message = strings.ToLower(err.Error())
+	}
+	switch {
+	case containsAny(message, "empty_response", "empty response", "no content"):
+		return "empty_response"
+	case strings.Contains(message, "temperature") && containsAny(message, "deprecated", "unsupported", "not support", "does not support"):
+		return "invalid_request"
+	case containsAny(message, "401", "unauthorized", "unauthenticated", "authentication", "invalid_api_key", "invalid api key"):
+		return "authentication"
+	case containsAny(message, "403", "forbidden", "permission denied"):
+		return "permission"
+	case containsAny(message, "404", "model_not_found", "model not found", "not_found_error"):
+		return "model_not_found"
+	case containsAny(message, "429", "rate limit", "rate_limit", "quota"):
+		return "rate_limit"
+	case containsAny(message, "400", "invalid_request", "bad request", "unsupported", "deprecated"):
+		return "invalid_request"
+	case containsAny(message, "timeout", "deadline exceeded"):
+		return "timeout"
+	case containsAny(message, "connection refused", "connection reset", "no such host", "tls", "dial tcp"):
+		return "connection"
+	case containsAny(message, "decode", "malformed", "invalid response", "validation"):
+		return "validation"
+	default:
+		return "unavailable"
+	}
+}
+
+func containsAny(value string, candidates ...string) bool {
+	for _, candidate := range candidates {
+		if strings.Contains(value, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func safeProviderIdentifier(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	count := 0
+	for _, r := range value {
+		count++
+		if count > maxProviderIdentifierRunes || !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || strings.ContainsRune("._:/-", r)) {
+			return fallback
+		}
+	}
+	return value
+}

--- a/pkg/agent/ai/eino/provider_error_test.go
+++ b/pkg/agent/ai/eino/provider_error_test.go
@@ -1,0 +1,57 @@
+package eino_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	einowrap "github.com/VersusControl/versus-incident/pkg/agent/ai/eino"
+)
+
+func TestSafeProviderErrorClassifiesWithoutRetainingCause(t *testing.T) {
+	const secret = "runtime-provider-secret"
+	tests := []struct {
+		cause string
+		class string
+	}{
+		{"status 401 invalid_api_key " + secret, "authentication"},
+		{"status 403 permission denied " + secret, "permission"},
+		{"status 404 model_not_found " + secret, "model_not_found"},
+		{"status 429 rate_limit " + secret, "rate_limit"},
+		{"status 400 invalid_request " + secret, "invalid_request"},
+		{"deadline exceeded " + secret, "timeout"},
+		{"connection refused " + secret, "connection"},
+		{"malformed invalid response " + secret, "validation"},
+		{"provider exploded " + secret, "unavailable"},
+	}
+	for _, test := range tests {
+		t.Run(test.class, func(t *testing.T) {
+			safe := einowrap.SafeProviderError("claude\r\nforged=true", "model\r\nforged=true", errors.New(test.cause))
+			if safe.Class != test.class {
+				t.Fatalf("class = %q, want %q", safe.Class, test.class)
+			}
+			encoded := safe.Provider + safe.Model + safe.Diagnostic + safe.Error()
+			if strings.Contains(encoded, secret) || strings.Contains(encoded, "\r") || strings.Contains(encoded, "\n") || strings.Contains(encoded, "forged=true") {
+				t.Fatalf("safe provider error retained untrusted input: %+v", safe)
+			}
+		})
+	}
+}
+
+func TestSafeProviderErrorRejectsEntireUnsafeIdentifiers(t *testing.T) {
+	safe := einowrap.SafeProviderError("gemini\r\nforged", "model/ok\nsecret", errors.New("provider failed"))
+	if safe.Provider != "openai" || safe.Model != "configured model" {
+		t.Fatalf("unsafe identifiers were partially retained: %+v", safe)
+	}
+}
+
+func TestSafeProviderErrorActionableResponseClassifications(t *testing.T) {
+	empty := einowrap.SafeProviderError("claude", "model", errors.New("AI returned no content"))
+	if empty.Class != "empty_response" || !strings.Contains(empty.Diagnostic, "completion-token budget") {
+		t.Fatalf("empty response classification = %+v", empty)
+	}
+	temperature := einowrap.SafeProviderError("claude", "model", errors.New("this model does not support temperature"))
+	if temperature.Class != "invalid_request" || !strings.Contains(temperature.Diagnostic, "AGENT_AI_TEMPERATURE=-1") {
+		t.Fatalf("temperature classification = %+v", temperature)
+	}
+}

--- a/pkg/agent/ai/eino/provider_test.go
+++ b/pkg/agent/ai/eino/provider_test.go
@@ -86,6 +86,9 @@ func TestSupportedProvidersExported(t *testing.T) {
 		if !einowrap.IsSupportedProvider(name) {
 			t.Fatalf("IsSupportedProvider(%q) = false, want true", name)
 		}
+		if keyless := einowrap.IsKeylessProvider(name); keyless != (name == "ollama") {
+			t.Fatalf("IsKeylessProvider(%q) = %v, want %v", name, keyless, name == "ollama")
+		}
 	}
 	// Case-insensitive, and empty normalises to the openai default.
 	if !einowrap.IsSupportedProvider("OpenAI") || !einowrap.IsSupportedProvider("  DeepSeek ") {
@@ -97,6 +100,9 @@ func TestSupportedProvidersExported(t *testing.T) {
 	// An unknown value is rejected at the boundary.
 	if einowrap.IsSupportedProvider("bogus-llm") {
 		t.Fatal("IsSupportedProvider(\"bogus-llm\") = true, want false")
+	}
+	if einowrap.IsKeylessProvider("bogus-llm") {
+		t.Fatal("IsKeylessProvider(\"bogus-llm\") = true, want false")
 	}
 }
 
@@ -268,8 +274,7 @@ func TestChatModel_Qwen_EgressBearerAndJSONMode(t *testing.T) {
 }
 
 // TestChatModel_Ollama_KeylessAndNativeFormat proves the Ollama path: Ollama is
-// keyless, so NO Authorization header is sent (the AuthKeyFunc transport is a
-// harmless no-op with no resolver), and JSON-mode is requested via the native
+// keyless, so NO Authorization header is sent, and JSON-mode is requested via the native
 // `format` field rather than an OpenAI response_format object. The reply
 // round-trips through detect.ParseFinding.
 func TestChatModel_Ollama_KeylessAndNativeFormat(t *testing.T) {

--- a/pkg/agent/aisettings.go
+++ b/pkg/agent/aisettings.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	einowrap "github.com/VersusControl/versus-incident/pkg/agent/ai/eino"
+	"github.com/VersusControl/versus-incident/pkg/tenancy"
 )
 
 // aisettings.go — the single-slot runtime AI-settings resolver seam.
@@ -42,6 +43,17 @@ type AIProviderResolver interface {
 	EffectiveProvider(ctx context.Context) (provider string, ok bool)
 }
 
+// AIContextDecorator is an OPTIONAL extension of AISettingsResolver. It lets
+// a consumer attach its private runtime-settings identity to ctx from a scope
+// the server has already resolved and trusted. OSS does not interpret the
+// scope and registers no decorator, so community contexts pass through
+// unchanged.
+type AIContextDecorator interface {
+	DecorateAIContext(ctx context.Context, scope tenancy.OrgScope) context.Context
+}
+
+type aiScopeContextKey struct{}
+
 // Process-wide single slot. A consumer registers a resolver at boot; the
 // worker reads it once per tick and the chat-model transport reads it once
 // per request. Mutex-guarded so a boot-time registration is safely visible
@@ -69,6 +81,30 @@ func aiSettingsResolver() AISettingsResolver {
 	aiSettingsMu.Lock()
 	defer aiSettingsMu.Unlock()
 	return aiSettingsResolverSlot
+}
+
+// DecorateAIContext applies the registered resolver's optional context
+// decorator for a server-resolved scope. With no resolver or no decorator it
+// returns ctx unchanged. Callers must derive scope from trusted tenancy state,
+// never from request bodies or client-selected headers.
+func DecorateAIContext(ctx context.Context, scope tenancy.OrgScope) context.Context {
+	scope = scope.Normalized()
+	ctx = context.WithValue(ctx, aiScopeContextKey{}, scope)
+	resolver := aiSettingsResolver()
+	decorator, ok := resolver.(AIContextDecorator)
+	if !ok || decorator == nil {
+		return ctx
+	}
+	return decorator.DecorateAIContext(ctx, scope)
+}
+
+// AIContextScope returns the trusted scope attached by DecorateAIContext.
+func AIContextScope(ctx context.Context) (tenancy.OrgScope, bool) {
+	if ctx == nil {
+		return tenancy.OrgScope{}, false
+	}
+	scope, ok := ctx.Value(aiScopeContextKey{}).(tenancy.OrgScope)
+	return scope.Normalized(), ok
 }
 
 // orgAISettingsGetter is the optional capability a registered
@@ -192,6 +228,11 @@ func aiRuntime() einowrap.RuntimeAI {
 		},
 		KeySet: func(ctx context.Context) (bool, bool) {
 			if r := aiSettingsResolver(); r != nil {
+				if presence, ok := r.(interface {
+					EffectiveKeySet(context.Context) (bool, bool)
+				}); ok {
+					return presence.EffectiveKeySet(ctx)
+				}
 				_, ok := r.EffectiveKey(ctx)
 				return ok, true
 			}

--- a/pkg/agent/aisettings_test.go
+++ b/pkg/agent/aisettings_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"testing"
+
+	"github.com/VersusControl/versus-incident/pkg/tenancy"
 )
 
 // stubAISettings is a fake AISettingsResolver whose answers are fixed per
@@ -94,6 +96,42 @@ type stubProviderAISettings struct {
 	stubAISettings
 	provider   string
 	providerOK bool
+}
+
+type decoratingAISettings struct {
+	stubAISettings
+}
+
+type decoratedScopeKey struct{}
+
+func (*decoratingAISettings) DecorateAIContext(ctx context.Context, scope tenancy.OrgScope) context.Context {
+	return context.WithValue(ctx, decoratedScopeKey{}, scope.Write)
+}
+
+func TestDecorateAIContext_OptionalResolverCapability(t *testing.T) {
+	SetAISettingsResolver(nil)
+	t.Cleanup(func() { SetAISettingsResolver(nil) })
+
+	ctx := context.WithValue(context.Background(), "caller", "authorized")
+	got := DecorateAIContext(ctx, tenancy.NewOrgScope("org-a"))
+	if scope, ok := AIContextScope(got); !ok || scope.Write != "org-a" || got.Value("caller") != "authorized" {
+		t.Fatalf("OSS decoration scope/value = (%+v,%v,%v)", scope, ok, got.Value("caller"))
+	}
+
+	SetAISettingsResolver(&stubAISettings{})
+	got = DecorateAIContext(ctx, tenancy.NewOrgScope("org-a"))
+	if scope, ok := AIContextScope(got); !ok || scope.Write != "org-a" || got.Value(decoratedScopeKey{}) != nil {
+		t.Fatalf("resolver without decorator changed private decoration: scope=%+v ok=%v", scope, ok)
+	}
+
+	SetAISettingsResolver(&decoratingAISettings{})
+	got = DecorateAIContext(ctx, tenancy.NewOrgScope("org-a"))
+	if got.Value(decoratedScopeKey{}) != "org-a" {
+		t.Fatalf("decorated scope = %v, want org-a", got.Value(decoratedScopeKey{}))
+	}
+	if got.Value("caller") != "authorized" {
+		t.Fatal("decoration discarded an existing caller value")
+	}
 }
 
 func (s *stubProviderAISettings) EffectiveProvider(context.Context) (string, bool) {

--- a/pkg/agent/factory_ai.go
+++ b/pkg/agent/factory_ai.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -149,12 +150,12 @@ func buildAIs(cfg config.AgentConfig, catalog *Catalog, store storage.Provider, 
 
 	// Detect-task wiring -----------------------------------------------------
 	detectAgent, err := detect.New(context.Background(), detectCfg, detect.Options{
-		HTTPClient:  httpClient,
-		AuthKeyFunc: authKeyFn,
-		Runtime:     aiRT,
+		HTTPClient:     httpClient,
+		RuntimeKeyFunc: authKeyFn,
+		Runtime:        aiRT,
 	})
 	if err != nil {
-		log.Printf("agent: detect agent disabled: %v", err)
+		logAIConstructionFailure("detect", detectCfg, err)
 		return AIBundle{}
 	}
 
@@ -227,7 +228,7 @@ func buildAIs(cfg config.AgentConfig, catalog *Catalog, store storage.Provider, 
 		// the find_runbook tool is wired with the manager's embedder +
 		// searcher. Uploads atomically rebuild the index, so newly uploaded
 		// runbooks are searchable without a restart.
-		runbookMgr = buildRunbookManager(cfg, store, httpClient)
+		runbookMgr = buildRunbookManager(cfg, store, scope, httpClient, authKeyFn, aiRT)
 		var embedder core.Embedder
 		var runbookSearcher commontools.RunbookSearcher
 		if runbookMgr != nil && runbookMgr.HasEmbedder() {
@@ -270,9 +271,9 @@ func buildAIs(cfg config.AgentConfig, catalog *Catalog, store storage.Provider, 
 		analyzeRuntime := aiRT
 		analyzeRuntime.Revision = analyzeGeneration.Revision
 		a, aErr := analyze.New(context.Background(), analyzeBaseCfg, runtimeTools, analyze.Options{
-			HTTPClient:  httpClient,
-			AuthKeyFunc: authKeyFn,
-			Runtime:     analyzeRuntime,
+			HTTPClient:     httpClient,
+			RuntimeKeyFunc: authKeyFn,
+			Runtime:        analyzeRuntime,
 			ToolProvider: func() ([]core.Tool, error) {
 				return analyzeGeneration.Filter(aitools.AgentAnalyze, runtimeTools)
 			},
@@ -280,12 +281,13 @@ func buildAIs(cfg config.AgentConfig, catalog *Catalog, store storage.Provider, 
 			ParallelTools: cfg.Tools.ParallelTools,
 		})
 		if aErr != nil {
-			log.Printf("agent: analyze agent disabled: %v", aErr)
+			logAIConstructionFailure("analyze", analyzeBaseCfg, aErr)
 		} else {
-			analyzeAgent = a
+			analyzeAgent = &bootScopedAIAgent{delegate: a, scope: scope.Normalized()}
 			analyzeRate = ai.NewRateLimiter(analyzeBaseCfg.MaxCallsPerHour)
+			safeModel := einowrap.SafeProviderError(analyzeBaseCfg.Provider, analyzeBaseCfg.Model, nil).Model
 			log.Printf("agent: analyze agent enabled model=%s tools=%d",
-				analyzeBaseCfg.Model, len(analyzeTools))
+				safeModel, len(analyzeTools))
 		}
 	}
 
@@ -300,7 +302,7 @@ func buildAIs(cfg config.AgentConfig, catalog *Catalog, store storage.Provider, 
 	chatRuntime := aiRT
 	chatRuntime.Revision = chatGeneration.Revision
 	if built, chatErr := chatagent.New(context.Background(), chatCfg, runtimeTools, chatagent.Options{
-		HTTPClient: httpClient, AuthKeyFunc: authKeyFn, Runtime: chatRuntime,
+		HTTPClient: httpClient, RuntimeKeyFunc: authKeyFn, Runtime: chatRuntime,
 		ToolProvider: func() ([]core.Tool, error) {
 			return chatGeneration.Filter(aitools.AgentChat, runtimeTools)
 		},
@@ -309,12 +311,13 @@ func buildAIs(cfg config.AgentConfig, catalog *Catalog, store storage.Provider, 
 		},
 		ToolTimeout: parseDurationOr(cfg.Tools.ToolTimeout, chatagent.DefaultToolTimeout),
 	}); chatErr != nil {
-		log.Printf("agent: chat agent disabled: %v", chatErr)
+		logAIConstructionFailure("chat", chatCfg, chatErr)
 	} else {
 		concreteChat = built
 		chatAgent = built
 		chatRate = ai.NewDistributedRateLimiter(chatCfg.MaxCallsPerHour, store, scope.Normalized().Write, time.Now)
-		log.Printf("agent: chat agent enabled model=%s tools=%d", chatCfg.Model, len(chatTools))
+		safeModel := einowrap.SafeProviderError(chatCfg.Provider, chatCfg.Model, nil).Model
+		log.Printf("agent: chat agent enabled model=%s tools=%d", safeModel, len(chatTools))
 	}
 
 	// Router wiring ----------------------------------------------------------
@@ -341,9 +344,12 @@ func buildAIs(cfg config.AgentConfig, catalog *Catalog, store storage.Provider, 
 			if serviceScope.Normalized().Write != bootScope.Write {
 				return nil
 			}
-			return chatagent.NewServiceWithLocationProvider(
+			return chatagent.NewServiceWithLocationProviderAndContextDecorator(
 				chatagent.NewSessionStore(store, serviceScope, time.Now), r, concreteChat, time.Now,
 				locationProvider,
+				func(ctx context.Context) context.Context {
+					return DecorateAIContext(ctx, serviceScope)
+				},
 			)
 		}
 	}
@@ -363,6 +369,33 @@ func buildAIs(cfg config.AgentConfig, catalog *Catalog, store storage.Provider, 
 		ToolSnapshot:        toolSnapshot,
 		ObserveSourceHealth: detectionHealth.Observe,
 	}
+}
+
+func logAIConstructionFailure(task string, cfg config.AgentAIConfig, cause error) {
+	var configErr *einowrap.ConfigError
+	if errors.As(cause, &configErr) {
+		log.Printf("agent: %s agent disabled: configuration error: %v", task, configErr)
+		return
+	}
+	safe := einowrap.SafeProviderError(cfg.Provider, cfg.Model, cause)
+	log.Printf("agent: %s agent disabled: provider=%q model=%q class=%q", task, safe.Provider, safe.Model, safe.Class)
+}
+
+type bootScopedAIAgent struct {
+	delegate core.AIAgent
+	scope    tenancy.OrgScope
+}
+
+func (agent *bootScopedAIAgent) Name() string { return agent.delegate.Name() }
+
+func (agent *bootScopedAIAgent) Kind() core.AITaskKind { return agent.delegate.Kind() }
+
+func (agent *bootScopedAIAgent) Run(ctx context.Context, task core.AITask) (*core.AICallResult, error) {
+	requestScope, ok := AIContextScope(ctx)
+	if !ok || requestScope.Write != agent.scope.Write {
+		return nil, fmt.Errorf("analyze: requested scope is unavailable")
+	}
+	return agent.delegate.Run(ctx, task)
 }
 
 func loadCurrentTools(manager *aitools.Manager, scope tenancy.OrgScope, snapshot func(tenancy.OrgScope) aitools.Snapshot, agent aitools.AgentKind, runtime []core.Tool) ([]core.Tool, error) {
@@ -669,7 +702,11 @@ func boundCapabilityText(value string) string {
 // embedding model is configured the manager still loads the corpus so
 // operators can upload/list/delete runbooks; those runbooks become
 // searchable once an embedding model is set and the corpus re-ingested.
-func buildRunbookManager(cfg config.AgentConfig, store storage.Provider, httpClient *http.Client) *runbook.Manager {
+func buildRunbookManager(cfg config.AgentConfig, store storage.Provider, scope tenancy.OrgScope, httpClient *http.Client, runtimeKey func(context.Context) (string, bool), runtime einowrap.RuntimeAI) *runbook.Manager {
+	return buildRunbookManagerFromDir(cfg, store, scope, httpClient, runtimeKey, runtime, filepath.Join(storage.DefaultDataDir, runbook.SourceSubdir))
+}
+
+func buildRunbookManagerFromDir(cfg config.AgentConfig, store storage.Provider, scope tenancy.OrgScope, httpClient *http.Client, runtimeKey func(context.Context) (string, bool), runtime einowrap.RuntimeAI, sourceDir string) *runbook.Manager {
 	if store == nil {
 		log.Printf("agent: runbooks disabled: no storage backend for runbook corpus")
 		return nil
@@ -684,38 +721,102 @@ func buildRunbookManager(cfg config.AgentConfig, store storage.Provider, httpCli
 	var embedder core.Embedder
 	embCfg := cfg.Tools.FindRunbook
 	if embCfg.EmbeddingModel != "" {
-		e, embErr := einowrap.NewEmbedder(context.Background(), config.AgentAIConfig{
+		base := config.AgentAIConfig{
 			Provider: cfg.AI.Provider,
 			Model:    embCfg.EmbeddingModel,
 			APIKey:   cfg.AI.APIKey,
-		}, einowrap.Options{
-			HTTPClient: httpClient,
-		})
-		if embErr != nil {
-			log.Printf("agent: find_runbook disabled: embedder init failed: %v", embErr)
+		}
+		embeddingKey := func(ctx context.Context) (string, bool) {
+			if runtime.Provider != nil {
+				if provider, ok := runtime.Provider(ctx); ok && !einowrap.IsSupportedEmbedderProvider(provider) {
+					return "", false
+				}
+			}
+			if runtimeKey == nil {
+				return "", false
+			}
+			return runtimeKey(ctx)
+		}
+		holder := einowrap.NewEmbedderHolder(base, einowrap.Options{
+			HTTPClient:     httpClient,
+			RuntimeKeyFunc: embeddingKey,
+		}, runtime)
+		bootCtx := DecorateAIContext(context.Background(), scope)
+		if _, embErr := holder.Get(bootCtx); embErr != nil {
+			var configErr *einowrap.ConfigError
+			if errors.As(embErr, &configErr) {
+				log.Printf("agent: find_runbook disabled: embedder configuration error: %v", configErr)
+			} else {
+				safeErr := einowrap.SafeProviderError(effectiveEmbeddingProvider(bootCtx, base.Provider, runtime), base.Model, embErr)
+				log.Printf("agent: find_runbook disabled: embedder init failed: %v", safeErr)
+			}
 		} else {
-			embedder = e
+			embedder = &runtimeEmbedder{holder: holder, scope: scope.Normalized(), provider: base.Provider, model: embCfg.EmbeddingModel, runtime: runtime}
 		}
 	}
 
-	mgr := runbook.NewManager(rbStore, embedder)
+	bootScope := scope.Normalized()
+	mgr := runbook.NewManager(rbStore, embedder, bootScope.Write, func(ctx context.Context) context.Context {
+		return DecorateAIContext(ctx, bootScope)
+	})
 
 	// Auto-ingest the runbook source dir so operators never run a separate
 	// CLI. Ingestion is incremental — unchanged runbooks reuse their cached
 	// vector, so a reboot with no edits makes no embedding calls. A no-op
 	// when no embedder is configured. Non-fatal: we still serve the
 	// previously-persisted corpus on failure.
-	dir := filepath.Join(storage.DefaultDataDir, runbook.SourceSubdir)
-	if n, ingErr := mgr.IngestDir(context.Background(), dir, ""); ingErr != nil {
+	if n, ingErr := mgr.IngestDir(context.Background(), sourceDir); ingErr != nil {
 		log.Printf("agent: find_runbook: runbook ingest failed: %v (serving previously-persisted corpus)", ingErr)
 	} else if n > 0 {
-		log.Printf("agent: find_runbook: ingested %d runbook(s) from %s", n, dir)
+		log.Printf("agent: find_runbook: ingested %d runbook(s) from %s", n, sourceDir)
 	}
 
 	if embedder != nil {
-		log.Printf("agent: find_runbook enabled model=%s runbooks=%d", embCfg.EmbeddingModel, rbStore.Len())
+		safeModel := einowrap.SafeProviderError(cfg.AI.Provider, embCfg.EmbeddingModel, nil).Model
+		log.Printf("agent: find_runbook enabled model=%s runbooks=%d", safeModel, rbStore.Len())
 	} else {
 		log.Printf("agent: runbooks UI enabled (no embedding model; uploads not searchable until configured) runbooks=%d", rbStore.Len())
 	}
 	return mgr
+}
+
+type runtimeEmbedder struct {
+	holder   *einowrap.Holder[core.Embedder]
+	scope    tenancy.OrgScope
+	provider string
+	model    string
+	runtime  einowrap.RuntimeAI
+}
+
+func (embedder *runtimeEmbedder) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	requestScope, ok := AIContextScope(ctx)
+	if !ok || requestScope.Write != embedder.scope.Write {
+		return nil, fmt.Errorf("AI scope mismatch")
+	}
+	current, err := embedder.holder.Get(ctx)
+	if err != nil {
+		return nil, einowrap.SafeProviderError(embedder.effectiveProvider(ctx), embedder.model, err)
+	}
+	vectors, err := current.Embed(ctx, texts)
+	if err != nil {
+		return nil, einowrap.SafeProviderError(embedder.effectiveProvider(ctx), embedder.model, err)
+	}
+	return vectors, nil
+}
+
+func (embedder *runtimeEmbedder) effectiveProvider(ctx context.Context) string {
+	return effectiveEmbeddingProvider(ctx, embedder.provider, embedder.runtime)
+}
+
+func effectiveEmbeddingProvider(ctx context.Context, configured string, runtime einowrap.RuntimeAI) string {
+	if runtime.Provider != nil {
+		if provider, ok := runtime.Provider(ctx); ok && einowrap.IsSupportedEmbedderProvider(provider) {
+			return strings.ToLower(strings.TrimSpace(provider))
+		}
+	}
+	provider := strings.ToLower(strings.TrimSpace(configured))
+	if provider == "" {
+		return einowrap.DefaultProvider
+	}
+	return provider
 }

--- a/pkg/agent/factory_ai_aisettings_test.go
+++ b/pkg/agent/factory_ai_aisettings_test.go
@@ -1,10 +1,15 @@
 package agent
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"log"
+	"strings"
 	"testing"
 	"time"
 
+	einowrap "github.com/VersusControl/versus-incident/pkg/agent/ai/eino"
 	"github.com/VersusControl/versus-incident/pkg/config"
 	"github.com/VersusControl/versus-incident/pkg/storage"
 	"github.com/VersusControl/versus-incident/pkg/tenancy"
@@ -118,5 +123,59 @@ func TestBuildAIsForScopeWithChatLocationUsesProvider(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("location provider calls = %d, want 1", calls)
+	}
+}
+
+func TestAIConstructionFailureLogDoesNotRetainRawProviderCause(t *testing.T) {
+	const secret = "reflected-runtime-secret"
+	var output bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&output)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	for _, task := range []string{"detect", "chat"} {
+		logAIConstructionFailure(task, config.AgentAIConfig{Provider: "gemini", Model: "gemini-test"}, errors.New("status 401: key="+secret+"\r\nforged=true"))
+	}
+	got := output.String()
+	if strings.Contains(got, secret) || strings.Contains(got, "forged=true") {
+		t.Fatalf("construction log retained raw provider cause: %q", got)
+	}
+	for _, field := range []string{`detect agent disabled`, `chat agent disabled`, `provider="gemini"`, `model="gemini-test"`, `class="authentication"`} {
+		if !strings.Contains(got, field) {
+			t.Errorf("construction log %q missing %q", got, field)
+		}
+	}
+}
+
+func TestAIConstructionFailureLogExplainsTrustedConfigurationErrors(t *testing.T) {
+	var output bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&output)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	_, unsupportedErr := einowrap.NewChatModel(context.Background(), config.AgentAIConfig{Provider: "unknown", Model: "model"}, einowrap.Options{})
+	_, emptyModelErr := einowrap.NewChatModel(context.Background(), config.AgentAIConfig{Provider: "openai"}, einowrap.Options{})
+	_, embedderErr := einowrap.NewEmbedder(context.Background(), config.AgentAIConfig{Provider: "claude", Model: "embedding"}, einowrap.Options{})
+	for _, constructionErr := range []error{unsupportedErr, emptyModelErr, embedderErr} {
+		var configErr *einowrap.ConfigError
+		if !errors.As(constructionErr, &configErr) {
+			t.Fatalf("construction error = %T, want *eino.ConfigError", constructionErr)
+		}
+	}
+	logAIConstructionFailure("detect", config.AgentAIConfig{}, unsupportedErr)
+	logAIConstructionFailure("analyze", config.AgentAIConfig{}, emptyModelErr)
+	logAIConstructionFailure("find_runbook", config.AgentAIConfig{}, embedderErr)
+
+	got := output.String()
+	for _, want := range []string{
+		`configuration error: eino: unsupported ai provider "unknown"`,
+		`supported: claude, deepseek, gemini, ollama, openai, qwen`,
+		`configuration error: eino: model is empty`,
+		`unsupported ai provider "claude" for embeddings`,
+		`supported: gemini, ollama, openai`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("construction diagnostics %q missing %q", got, want)
+		}
 	}
 }

--- a/pkg/agent/factory_ai_runbook_runtime_test.go
+++ b/pkg/agent/factory_ai_runbook_runtime_test.go
@@ -1,0 +1,279 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	einowrap "github.com/VersusControl/versus-incident/pkg/agent/ai/eino"
+	"github.com/VersusControl/versus-incident/pkg/config"
+	"github.com/VersusControl/versus-incident/pkg/runbook"
+	"github.com/VersusControl/versus-incident/pkg/storage"
+	"github.com/VersusControl/versus-incident/pkg/tenancy"
+)
+
+type runbookRuntimeOrgKey struct{}
+
+type runbookRuntimeResolver struct {
+	mu       sync.RWMutex
+	key      string
+	provider string
+}
+
+func (resolver *runbookRuntimeResolver) EffectiveKey(ctx context.Context) (string, bool) {
+	if _, ok := ctx.Value(runbookRuntimeOrgKey{}).(string); !ok {
+		return "", false
+	}
+	resolver.mu.RLock()
+	defer resolver.mu.RUnlock()
+	return resolver.key, true
+}
+
+func (*runbookRuntimeResolver) EffectiveEnabled(context.Context) (bool, bool) { return true, true }
+
+func (resolver *runbookRuntimeResolver) EffectiveProvider(context.Context) (string, bool) {
+	resolver.mu.RLock()
+	defer resolver.mu.RUnlock()
+	return resolver.provider, true
+}
+
+func (resolver *runbookRuntimeResolver) EffectiveKeySet(context.Context) (bool, bool) {
+	resolver.mu.RLock()
+	defer resolver.mu.RUnlock()
+	return resolver.key != "", true
+}
+
+func (*runbookRuntimeResolver) DecorateAIContext(ctx context.Context, scope tenancy.OrgScope) context.Context {
+	return context.WithValue(ctx, runbookRuntimeOrgKey{}, scope.Normalized().Write)
+}
+
+func (resolver *runbookRuntimeResolver) set(provider, key string) {
+	resolver.mu.Lock()
+	resolver.provider = provider
+	resolver.key = key
+	resolver.mu.Unlock()
+}
+
+type runbookRewriteTransport struct {
+	target *url.URL
+	base   http.RoundTripper
+}
+
+func (transport runbookRewriteTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	clone := request.Clone(request.Context())
+	clonedURL := *request.URL
+	clonedURL.Scheme = transport.target.Scheme
+	clonedURL.Host = transport.target.Host
+	clone.URL = &clonedURL
+	return transport.base.RoundTrip(clone)
+}
+
+func TestRunbookEmbeddingUsesScopedRuntimeSettings(t *testing.T) {
+	const firstKey = "runbook-runtime-first"
+	const rotatedKey = "runbook-runtime-rotated"
+	var captureMu sync.Mutex
+	var authorizations []string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		var payload struct {
+			Input []string `json:"input"`
+			Model string   `json:"model"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		captureMu.Lock()
+		authorizations = append(authorizations, request.Header.Get("Authorization"))
+		captureMu.Unlock()
+		data := make([]map[string]any, len(payload.Input))
+		for index := range payload.Input {
+			data[index] = map[string]any{"object": "embedding", "index": index, "embedding": []float64{1, 0, 0}}
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]any{"object": "list", "data": data, "model": payload.Model})
+	}))
+	defer server.Close()
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	previousLogWriter := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previousLogWriter) })
+	resolver := &runbookRuntimeResolver{provider: "openai", key: firstKey}
+	SetAISettingsResolver(resolver)
+	t.Cleanup(func() { SetAISettingsResolver(nil) })
+
+	catalog, store := newBuildCatalog(t)
+	client := &http.Client{Transport: runbookRewriteTransport{target: target, base: http.DefaultTransport}}
+	bundle := BuildAIsForScope(config.AgentConfig{
+		AI:    config.AgentAIConfig{Enable: true, Provider: "openai", Model: "gpt-4o-mini"},
+		Tools: config.ToolsConfig{FindRunbook: config.FindRunbookToolConfig{EmbeddingModel: "text-embedding-3-small"}},
+	}, catalog, store, tenancy.NewOrgScope("org-a"), client)
+	if bundle.Runbooks == nil || !bundle.Runbooks.HasEmbedder() {
+		t.Fatal("runtime runbook embedder was not built")
+	}
+	ctx := DecorateAIContext(context.Background(), tenancy.NewOrgScope("org-a"))
+	foreignUploadCtx := DecorateAIContext(context.Background(), tenancy.NewOrgScope("org-b"))
+	if _, err := bundle.Runbooks.Upload(foreignUploadCtx, []runbook.UploadFile{{Name: "disk.md", Content: []byte("# Disk full\n\nFree space safely.")}}); err != nil {
+		t.Fatal(err)
+	}
+	if records := bundle.Runbooks.List(); len(records) != 1 || records[0].OrgID != "org-a" {
+		t.Fatalf("uploaded records = %+v, want manager boot org org-a", records)
+	}
+	if _, err := bundle.Runbooks.Embedder().Embed(ctx, []string{"disk full"}); err != nil {
+		t.Fatal(err)
+	}
+	resolver.set("openai", rotatedKey)
+	if _, err := bundle.Runbooks.Embedder().Embed(ctx, []string{"disk pressure"}); err != nil {
+		t.Fatal(err)
+	}
+	resolver.set("claude", "claude-chat-only-secret")
+	if _, err := bundle.Runbooks.Embedder().Embed(ctx, []string{"fallback query"}); err != nil {
+		t.Fatal(err)
+	}
+
+	beforeForeign := len(authorizations)
+	foreign := DecorateAIContext(context.Background(), tenancy.NewOrgScope("org-b"))
+	if _, err := bundle.Runbooks.Embedder().Embed(foreign, []string{"must fail"}); err == nil {
+		t.Fatal("foreign scope embedded a query")
+	}
+	captureMu.Lock()
+	got := append([]string(nil), authorizations...)
+	captureMu.Unlock()
+	if len(got) != beforeForeign || len(got) != 4 {
+		t.Fatalf("embedding calls = %q, want four and no foreign call", got)
+	}
+	want := []string{"Bearer " + firstKey, "Bearer " + firstKey, "Bearer " + rotatedKey, ""}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("Authorization call %d = %q, want %q", index+1, got[index], want[index])
+		}
+	}
+
+	corpus, _ := json.Marshal(bundle.Runbooks.List())
+	for _, secret := range []string{firstKey, rotatedKey, "claude-chat-only-secret"} {
+		if strings.Contains(string(corpus), secret) || strings.Contains(logs.String(), secret) {
+			t.Fatalf("runtime embedding key leaked outside transport: %q", secret)
+		}
+	}
+}
+
+func TestRunbookBootIngestUsesRuntimeCredentialFromRealDirectory(t *testing.T) {
+	const runtimeKey = "runbook-boot-runtime-secret"
+	var seenHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		seenHeader = request.Header.Get("Authorization")
+		var payload struct {
+			Input []string `json:"input"`
+		}
+		_ = json.NewDecoder(request.Body).Decode(&payload)
+		data := make([]map[string]any, len(payload.Input))
+		for index := range payload.Input {
+			data[index] = map[string]any{"object": "embedding", "index": index, "embedding": []float64{1, 0, 0}}
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]any{"object": "list", "data": data})
+	}))
+	defer server.Close()
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "disk.md"), []byte("# Disk full\n\nFree space safely."), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resolver := &runbookRuntimeResolver{provider: "openai", key: runtimeKey}
+	SetAISettingsResolver(resolver)
+	t.Cleanup(func() { SetAISettingsResolver(nil) })
+	runtime := einowrap.RuntimeAI{Provider: resolver.EffectiveProvider, KeySet: resolver.EffectiveKeySet}
+	client := &http.Client{Transport: runbookRewriteTransport{target: target, base: http.DefaultTransport}}
+	manager := buildRunbookManagerFromDir(config.AgentConfig{
+		AI:    config.AgentAIConfig{Provider: "openai", Model: "gpt-4o-mini"},
+		Tools: config.ToolsConfig{FindRunbook: config.FindRunbookToolConfig{EmbeddingModel: "text-embedding-3-small"}},
+	}, storage.NewMemory(), tenancy.NewOrgScope("org-a"), client, resolver.EffectiveKey, runtime, dir)
+	if manager == nil {
+		t.Fatal("boot ingest manager is nil")
+	}
+	if got := len(manager.List()); got != 1 {
+		t.Fatalf("boot ingest runbooks = %d, want one", got)
+	}
+	if seenHeader != "Bearer "+runtimeKey {
+		t.Fatalf("boot ingest Authorization = %q, want runtime credential", seenHeader)
+	}
+}
+
+func TestRuntimeEmbedderErrorReportsResolvedProviderSafely(t *testing.T) {
+	const runtimeKey = "runbook-reflected-runtime-secret"
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusUnauthorized)
+		_, _ = writer.Write([]byte(`{"error":{"message":"reflected ` + runtimeKey + `\r\nforged=true"}}`))
+	}))
+	defer server.Close()
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := &runbookRuntimeResolver{provider: "gemini", key: runtimeKey}
+	SetAISettingsResolver(resolver)
+	t.Cleanup(func() { SetAISettingsResolver(nil) })
+	runtime := einowrap.RuntimeAI{Provider: resolver.EffectiveProvider, KeySet: resolver.EffectiveKeySet}
+	client := &http.Client{Transport: runbookRewriteTransport{target: target, base: http.DefaultTransport}}
+	manager := buildRunbookManagerFromDir(config.AgentConfig{
+		AI:    config.AgentAIConfig{Provider: "gemini", Model: "unused"},
+		Tools: config.ToolsConfig{FindRunbook: config.FindRunbookToolConfig{EmbeddingModel: "unsafe\r\n" + runtimeKey}},
+	}, storage.NewMemory(), tenancy.NewOrgScope("org-a"), client, resolver.EffectiveKey, runtime, t.TempDir())
+	ctx := DecorateAIContext(context.Background(), tenancy.NewOrgScope("org-a"))
+	_, err = manager.Embedder().Embed(ctx, []string{"disk full"})
+	var providerErr *einowrap.ProviderError
+	if !errors.As(err, &providerErr) {
+		t.Fatalf("embed error = %T %v, want ProviderError", err, err)
+	}
+	if providerErr.Provider != "gemini" || providerErr.Model != "configured model" {
+		t.Fatalf("provider error identifiers = %+v", providerErr)
+	}
+	if strings.Contains(providerErr.Diagnostic, runtimeKey) || strings.Contains(providerErr.Diagnostic, "forged=true") {
+		t.Fatalf("provider error leaked reflected runtime key: %+v", providerErr)
+	}
+}
+
+func TestRunbookBootLogsActionableUnsupportedEmbedderProvider(t *testing.T) {
+	var logs bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	manager := buildRunbookManagerFromDir(config.AgentConfig{
+		AI: config.AgentAIConfig{Provider: "claude", Model: "chat-model"},
+		Tools: config.ToolsConfig{FindRunbook: config.FindRunbookToolConfig{
+			EmbeddingModel: "embedding-model",
+		}},
+	}, storage.NewMemory(), tenancy.DefaultOrgScope(), nil, nil, einowrap.RuntimeAI{}, t.TempDir())
+	if manager == nil || manager.HasEmbedder() {
+		t.Fatalf("runbook manager/embedder = %v/%v, want manager without embedder", manager != nil, manager != nil && manager.HasEmbedder())
+	}
+
+	got := logs.String()
+	for _, want := range []string{
+		"find_runbook disabled: embedder configuration error",
+		`unsupported ai provider "claude" for embeddings`,
+		"supported: gemini, ollama, openai",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("runbook boot log %q missing %q", got, want)
+		}
+	}
+}

--- a/pkg/agent/worker_seam_test.go
+++ b/pkg/agent/worker_seam_test.go
@@ -3,12 +3,16 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	aidetect "github.com/VersusControl/versus-incident/pkg/agent/ai/detect"
+	einowrap "github.com/VersusControl/versus-incident/pkg/agent/ai/eino"
 	"github.com/VersusControl/versus-incident/pkg/config"
 	"github.com/VersusControl/versus-incident/pkg/core"
 	"github.com/VersusControl/versus-incident/pkg/storage"
@@ -19,6 +23,12 @@ import (
 type batchSource struct {
 	name    string
 	signals []core.Signal
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
 }
 
 func (s *batchSource) Name() string { return s.name }
@@ -110,6 +120,63 @@ func TestWorker_Seam_DetectEmitsUnknown(t *testing.T) {
 
 	if emit != 1 {
 		t.Fatalf("detect emitted %d times, want 1 (one unknown pattern)", emit)
+	}
+}
+
+func TestWorker_Seam_DetectSanitizesReflectedRuntimeKey(t *testing.T) {
+	const runtimeKey = "runtime-secret\r\nforged=true"
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("provider reflected authorization %q", req.Header.Get("Authorization"))
+	})}
+	detectAgent, err := aidetect.New(context.Background(), config.AgentAIConfig{
+		Provider: "openai",
+		APIKey:   "yaml-key",
+		Model:    "gpt-4o-mini",
+	}, aidetect.Options{
+		HTTPClient: client,
+		BaseURL:    "https://provider.invalid/v1",
+		RuntimeKeyFunc: func(context.Context) (string, bool) {
+			return runtimeKey, true
+		},
+		Runtime: einowrap.RuntimeAI{
+			KeySet: func(context.Context) (bool, bool) { return true, true },
+		},
+	})
+	if err != nil {
+		t.Fatalf("New detect agent: %v", err)
+	}
+
+	src := &batchSource{name: "es", signals: repeatSignals("service=api reflected id=", 5)}
+	w := newSeamWorker(t, "detect", src, AIBundle{Detect: detectAgent}, func(*core.AIFinding, core.AgentResult, string, string) error {
+		return nil
+	})
+	store := storage.NewMemory()
+	w.detect, err = LoadDetectLog(store, 10)
+	if err != nil {
+		t.Fatalf("LoadDetectLog: %v", err)
+	}
+
+	logs := captureLog(t, func() { w.tickSource(context.Background(), src, "detect") })
+	if err := w.detect.Persist(); err != nil {
+		t.Fatalf("persist DetectLog: %v", err)
+	}
+	reloaded, err := LoadDetectLog(store, 10)
+	if err != nil {
+		t.Fatalf("reload DetectLog: %v", err)
+	}
+	events := reloaded.All()
+	if len(events) != 1 {
+		t.Fatalf("persisted events = %d, want 1", len(events))
+	}
+	event := events[0]
+	if strings.Contains(logs, runtimeKey) || strings.Contains(logs, "forged=true") || strings.ContainsAny(event.Error, "\r\n") ||
+		strings.Contains(event.Error, runtimeKey) || strings.Contains(event.Error, "forged=true") ||
+		strings.Contains(event.RawResponse, runtimeKey) || strings.Contains(event.UserPrompt, runtimeKey) || strings.Contains(event.Template, runtimeKey) ||
+		strings.Contains(strings.Join(event.Samples, ""), runtimeKey) {
+		t.Fatalf("runtime credential leaked: logs=%q event=%+v", logs, event)
+	}
+	if event.Error == "" || event.Outcome != "emitted_basic_error" || event.RawResponse != "" || event.UserPrompt != "" {
+		t.Fatalf("persisted safe failure = %+v, want useful error class and no model artifacts", event)
 	}
 }
 

--- a/pkg/controllers/analyze_stream_test.go
+++ b/pkg/controllers/analyze_stream_test.go
@@ -1,20 +1,30 @@
 package controllers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
+	"log"
+	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
 
+	"github.com/VersusControl/versus-incident/pkg/agent"
+	einowrap "github.com/VersusControl/versus-incident/pkg/agent/ai/eino"
+	"github.com/VersusControl/versus-incident/pkg/config"
 	"github.com/VersusControl/versus-incident/pkg/core"
+	"github.com/VersusControl/versus-incident/pkg/middleware"
 	"github.com/VersusControl/versus-incident/pkg/services"
 	"github.com/VersusControl/versus-incident/pkg/storage"
+	"github.com/VersusControl/versus-incident/pkg/tenancy"
 )
 
 // scriptedAgent is a stand-in analyze agent. It replays a fixed list of events
@@ -23,6 +33,187 @@ type scriptedAgent struct {
 	events []core.AnalyzeEvent
 	result *core.AICallResult
 	err    error
+}
+
+type analyzeRuntimeOrgKey struct{}
+
+type analyzeRuntimeResolver struct{ key string }
+
+func (resolver *analyzeRuntimeResolver) EffectiveKey(ctx context.Context) (string, bool) {
+	_, ok := ctx.Value(analyzeRuntimeOrgKey{}).(string)
+	return resolver.key, ok
+}
+
+func (*analyzeRuntimeResolver) EffectiveEnabled(context.Context) (bool, bool) { return true, true }
+
+func (*analyzeRuntimeResolver) EffectiveProvider(context.Context) (string, bool) {
+	return "openai", true
+}
+
+func (*analyzeRuntimeResolver) EffectiveKeySet(context.Context) (bool, bool) { return true, true }
+
+func (*analyzeRuntimeResolver) DecorateAIContext(ctx context.Context, scope tenancy.OrgScope) context.Context {
+	return context.WithValue(ctx, analyzeRuntimeOrgKey{}, scope.Normalized().Write)
+}
+
+type analyzeRewriteTransport struct {
+	target *url.URL
+	base   http.RoundTripper
+}
+
+func (transport analyzeRewriteTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	clone := request.Clone(request.Context())
+	clonedURL := *request.URL
+	clonedURL.Scheme = transport.target.Scheme
+	clonedURL.Host = transport.target.Host
+	clone.URL = &clonedURL
+	return transport.base.RoundTrip(clone)
+}
+
+func TestAnalyzeHTTPPathsUseRuntimeCredentialAndSanitizeReflectedErrors(t *testing.T) {
+	const runtimeKey = "runtime-analyze-secret"
+	var capturesMu sync.Mutex
+	var authorizations []string
+	provider := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		capturesMu.Lock()
+		authorizations = append(authorizations, request.Header.Get("Authorization"))
+		capturesMu.Unlock()
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(writer).Encode(map[string]any{"error": map[string]any{"message": "reflected " + runtimeKey + "\r\nforged=true"}})
+	}))
+	defer provider.Close()
+	target, err := url.Parse(provider.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	previousLogWriter := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previousLogWriter) })
+
+	resolver := &analyzeRuntimeResolver{key: runtimeKey}
+	agent.SetAISettingsResolver(resolver)
+	middleware.SetOrgResolver(func(*fiber.Ctx) string { return "org-a" })
+	t.Cleanup(func() {
+		agent.SetAISettingsResolver(nil)
+		middleware.SetOrgResolver(nil)
+		services.SetStorage(nil)
+		services.SetAnalyzeAgent(nil)
+	})
+
+	store := storage.NewMemory()
+	record := seedStreamIncident(t, store)
+	record.OrgID = "org-a"
+	if err := store.SaveIncident(record); err != nil {
+		t.Fatal(err)
+	}
+	catalog, err := agent.LoadCatalog(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{Transport: analyzeRewriteTransport{target: target, base: http.DefaultTransport}}
+	bundle := agent.BuildAIsForScope(config.AgentConfig{AI: config.AgentAIConfig{
+		Enable: true, Provider: "openai", APIKey: "", Model: "gpt-4o-mini", MaxTokens: 32,
+	}}, catalog, store, tenancy.NewOrgScope("org-a"), client)
+	if bundle.Analyze == nil {
+		t.Fatal("Analyze agent was not built")
+	}
+	services.SetStorage(store)
+	services.SetAnalyzeAgent(bundle.Analyze)
+
+	controller := NewIncidentAdminController()
+	app := fiber.New()
+	app.Use(middleware.OrgInjector())
+	app.Post("/incidents/:id/analyze", controller.analyze)
+	app.Post("/incidents/:id/analyze/stream", controller.analyzeStream)
+
+	syncResponse, err := app.Test(httptest.NewRequest("POST", "/incidents/inc-1/analyze", nil), 10_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	syncBody, _ := io.ReadAll(syncResponse.Body)
+	syncResponse.Body.Close()
+	streamResponse, streamBody := callStream(t, app)
+	if syncResponse.StatusCode != fiber.StatusBadGateway || streamResponse.status != fiber.StatusOK {
+		t.Fatalf("statuses sync=%d stream=%d", syncResponse.StatusCode, streamResponse.status)
+	}
+
+	analyses, err := store.ListAnalyses(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	persisted, _ := json.Marshal(analyses)
+	for name, value := range map[string]string{
+		"sync response": string(syncBody), "SSE response": streamBody, "logs": logs.String(), "persistence": string(persisted),
+	} {
+		if strings.Contains(value, runtimeKey) || strings.Contains(value, "forged=true") {
+			t.Fatalf("%s leaked reflected provider error: %q", name, value)
+		}
+	}
+	for _, analysis := range analyses {
+		if strings.Contains(analysis.RawResponse, runtimeKey) || strings.Contains(analysis.Error, runtimeKey) {
+			t.Fatalf("analysis leaked runtime key: %+v", analysis)
+		}
+		for _, trace := range analysis.ToolCalls {
+			encoded, _ := json.Marshal(trace)
+			if strings.Contains(string(encoded), runtimeKey) {
+				t.Fatalf("tool trace leaked runtime key: %s", encoded)
+			}
+		}
+	}
+	capturesMu.Lock()
+	defer capturesMu.Unlock()
+	if len(authorizations) != 2 {
+		t.Fatalf("captured Authorization headers = %q, want two calls", authorizations)
+	}
+	for _, authorization := range authorizations {
+		if authorization != "Bearer "+runtimeKey {
+			t.Fatalf("Authorization = %q, want runtime key", authorization)
+		}
+	}
+}
+
+func TestAnalyzeHTTPPathsSanitizeBuildFailureInSyncSSEAndPersistence(t *testing.T) {
+	const secret = "runtime-build-reflection-secret"
+	store := storage.NewMemory()
+	seedStreamIncident(t, store)
+	services.SetStorage(store)
+	buildErr := einowrap.SafeProviderError("gemini\r\nforged=true", "unsafe\r\n"+secret, errors.New("build reflected "+secret))
+	services.SetAnalyzeAgent(&scriptedAgent{
+		result: &core.AICallResult{Model: buildErr.Model},
+		err:    buildErr,
+	})
+	t.Cleanup(func() {
+		services.SetStorage(nil)
+		services.SetAnalyzeAgent(nil)
+	})
+
+	controller := NewIncidentAdminController()
+	app := fiber.New()
+	app.Post("/incidents/:id/analyze", controller.analyze)
+	app.Post("/incidents/:id/analyze/stream", controller.analyzeStream)
+	syncResponse, err := app.Test(httptest.NewRequest("POST", "/incidents/inc-1/analyze", nil), 10_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	syncBody, _ := io.ReadAll(syncResponse.Body)
+	syncResponse.Body.Close()
+	streamResponse, streamBody := callStream(t, app)
+	if syncResponse.StatusCode != fiber.StatusBadGateway || streamResponse.status != fiber.StatusOK {
+		t.Fatalf("statuses sync=%d stream=%d", syncResponse.StatusCode, streamResponse.status)
+	}
+	analyses, err := store.ListAnalyses(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	persisted, _ := json.Marshal(analyses)
+	for name, value := range map[string]string{"sync response": string(syncBody), "SSE response": streamBody, "persistence": string(persisted)} {
+		if strings.Contains(value, secret) || strings.Contains(value, "forged=true") {
+			t.Fatalf("%s leaked malicious build failure: %q", name, value)
+		}
+	}
 }
 
 func (s *scriptedAgent) Name() string          { return "analyze" }
@@ -504,6 +695,9 @@ type ctxProbeAgent struct {
 	errDuringRun error
 	hasDeadline  bool
 	remaining    time.Duration
+	org          string
+	authorized   bool
+	hasObserver  bool
 }
 
 func (c *ctxProbeAgent) Name() string          { return "analyze" }
@@ -516,5 +710,200 @@ func (c *ctxProbeAgent) Run(ctx context.Context, _ core.AITask) (*core.AICallRes
 	if ok {
 		c.remaining = time.Until(dl)
 	}
+	c.org, _ = ctx.Value(analyzeOrgKey{}).(string)
+	c.authorized = core.CallerAuthorized(ctx, core.PermissionInfrastructureView)
+	c.hasObserver = core.AnalyzeObserverFrom(ctx) != nil
 	return c.result, nil
+}
+
+type analyzeOrgKey struct{}
+
+type analyzeContextResolver struct {
+	scopes []tenancy.OrgScope
+}
+
+func (*analyzeContextResolver) EffectiveKey(context.Context) (string, bool) {
+	return "", false
+}
+
+func (*analyzeContextResolver) EffectiveEnabled(context.Context) (bool, bool) {
+	return false, false
+}
+
+func (resolver *analyzeContextResolver) DecorateAIContext(ctx context.Context, scope tenancy.OrgScope) context.Context {
+	resolver.scopes = append(resolver.scopes, scope.Normalized())
+	return context.WithValue(ctx, analyzeOrgKey{}, scope.Write)
+}
+
+func TestAnalyzeHandlersDecorateTrustedRequestScope(t *testing.T) {
+	store := storage.NewMemory()
+	record := seedStreamIncident(t, store)
+	record.OrgID = "org-a"
+	if err := store.SaveIncident(record); err != nil {
+		t.Fatal(err)
+	}
+	agent.SetAISettingsResolver(&analyzeContextResolver{})
+	middleware.SetOrgResolver(func(*fiber.Ctx) string { return "org-a" })
+	t.Cleanup(func() {
+		agent.SetAISettingsResolver(nil)
+		middleware.SetOrgResolver(nil)
+		services.SetStorage(nil)
+		services.SetAnalyzeAgent(nil)
+	})
+	services.SetStorage(store)
+
+	controller := NewIncidentAdminController()
+	streamProbe := &ctxProbeAgent{result: okResult()}
+	services.SetAnalyzeAgent(streamProbe)
+	streamApp := fiber.New()
+	streamApp.Use(func(ctx *fiber.Ctx) error {
+		middleware.SetRequestPermission(ctx, string(core.PermissionInfrastructureView), true)
+		return ctx.Next()
+	})
+	streamApp.Use(middleware.OrgInjector())
+	streamApp.Post("/incidents/:id/analyze/stream", controller.analyzeStream)
+	callStream(t, streamApp)
+	if streamProbe.org != "org-a" {
+		t.Fatalf("stream analyze org = %q, want org-a", streamProbe.org)
+	}
+	if !streamProbe.authorized || !streamProbe.hasObserver {
+		t.Fatalf("stream context lost authorization or observer: authorized=%v observer=%v", streamProbe.authorized, streamProbe.hasObserver)
+	}
+
+	syncProbe := &ctxProbeAgent{result: okResult()}
+	services.SetAnalyzeAgent(syncProbe)
+	syncApp := fiber.New()
+	syncApp.Use(func(ctx *fiber.Ctx) error {
+		middleware.SetRequestPermission(ctx, string(core.PermissionInfrastructureView), true)
+		return ctx.Next()
+	})
+	syncApp.Use(middleware.OrgInjector())
+	syncApp.Post("/incidents/:id/analyze", controller.analyze)
+	response, err := syncApp.Test(httptest.NewRequest("POST", "/incidents/inc-1/analyze", nil), 10_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if syncProbe.org != "org-a" {
+		t.Fatalf("sync analyze org = %q, want org-a", syncProbe.org)
+	}
+	if !syncProbe.authorized || syncProbe.hasObserver {
+		t.Fatalf("sync context authorization/observer = %v/%v, want true/false", syncProbe.authorized, syncProbe.hasObserver)
+	}
+}
+
+type analyzeScopedStore struct {
+	storage.Provider
+	scope tenancy.OrgScope
+}
+
+func (store analyzeScopedStore) OrgScope() tenancy.OrgScope { return store.scope }
+
+func TestAnalyzeHandlersAdmitTrustedReadScopeAndPinRuntimeToWriteOrg(t *testing.T) {
+	base := storage.NewMemory()
+	writeRecord := seedStreamIncident(t, base)
+	writeRecord.OrgID = "licensed"
+	if err := base.SaveIncident(writeRecord); err != nil {
+		t.Fatal(err)
+	}
+	archiveRecord := *writeRecord
+	archiveRecord.ID = "inc-archive"
+	archiveRecord.OrgID = storage.DefaultOrgID
+	if err := base.SaveIncident(&archiveRecord); err != nil {
+		t.Fatal(err)
+	}
+	foreignRecord := *writeRecord
+	foreignRecord.ID = "inc-foreign"
+	foreignRecord.OrgID = "foreign"
+	if err := base.SaveIncident(&foreignRecord); err != nil {
+		t.Fatal(err)
+	}
+
+	store := analyzeScopedStore{Provider: base, scope: tenancy.NewOrgScope("licensed", storage.DefaultOrgID)}
+	resolver := &analyzeContextResolver{}
+	agent.SetAISettingsResolver(resolver)
+	middleware.SetOrgResolver(func(*fiber.Ctx) string { return "licensed" })
+	t.Cleanup(func() {
+		agent.SetAISettingsResolver(nil)
+		middleware.SetOrgResolver(nil)
+		services.SetStorage(nil)
+		services.SetAnalyzeAgent(nil)
+	})
+	services.SetStorage(store)
+	controller := NewIncidentAdminController()
+
+	for _, path := range []string{"analyze", "analyze/stream"} {
+		for _, incidentID := range []string{"inc-1", "inc-archive"} {
+			probe := &ctxProbeAgent{result: okResult()}
+			services.SetAnalyzeAgent(probe)
+			app := fiber.New()
+			app.Use(middleware.OrgInjector())
+			app.Post("/incidents/:id/analyze", controller.analyze)
+			app.Post("/incidents/:id/analyze/stream", controller.analyzeStream)
+			response, err := app.Test(httptest.NewRequest("POST", "/incidents/"+incidentID+"/"+path, nil), 10_000)
+			if err != nil {
+				t.Fatal(err)
+			}
+			response.Body.Close()
+			if response.StatusCode != fiber.StatusOK || !probe.ran || probe.org != "licensed" {
+				t.Fatalf("%s %s status/run/runtime = %d/%v/%q", path, incidentID, response.StatusCode, probe.ran, probe.org)
+			}
+		}
+	}
+	for _, scope := range resolver.scopes {
+		if scope.Write != "licensed" || !scope.Contains(storage.DefaultOrgID) {
+			t.Fatalf("decorated scope = %#v, want licensed write plus default read", scope)
+		}
+	}
+
+	probe := &ctxProbeAgent{result: okResult()}
+	decorationsBeforeForeign := len(resolver.scopes)
+	services.SetAnalyzeAgent(probe)
+	app := fiber.New()
+	app.Use(middleware.OrgInjector())
+	app.Post("/incidents/:id/analyze", controller.analyze)
+	response, err := app.Test(httptest.NewRequest("POST", "/incidents/inc-foreign/analyze", nil), 10_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != fiber.StatusNotFound || probe.ran {
+		t.Fatalf("foreign status/run = %d/%v, want 404/false", response.StatusCode, probe.ran)
+	}
+	if len(resolver.scopes) != decorationsBeforeForeign {
+		t.Fatal("foreign incident reached runtime scope/key decoration")
+	}
+}
+
+func TestAnalyzeHandlersRejectForeignIncidentBeforeAgentRun(t *testing.T) {
+	store := storage.NewMemory()
+	seedStreamIncident(t, store)
+	middleware.SetOrgResolver(func(*fiber.Ctx) string { return "org-b" })
+	t.Cleanup(func() {
+		middleware.SetOrgResolver(nil)
+		services.SetStorage(nil)
+		services.SetAnalyzeAgent(nil)
+	})
+	services.SetStorage(store)
+	probe := &ctxProbeAgent{result: okResult()}
+	services.SetAnalyzeAgent(probe)
+	controller := NewIncidentAdminController()
+	app := fiber.New()
+	app.Use(middleware.OrgInjector())
+	app.Post("/incidents/:id/analyze", controller.analyze)
+	app.Post("/incidents/:id/analyze/stream", controller.analyzeStream)
+
+	for _, path := range []string{"/incidents/inc-1/analyze", "/incidents/inc-1/analyze/stream"} {
+		response, err := app.Test(httptest.NewRequest("POST", path, nil), 10_000)
+		if err != nil {
+			t.Fatal(err)
+		}
+		response.Body.Close()
+		if response.StatusCode != fiber.StatusNotFound {
+			t.Fatalf("%s status = %d, want 404", path, response.StatusCode)
+		}
+	}
+	if probe.ran {
+		t.Fatal("Analyze agent ran for a foreign incident scope")
+	}
 }

--- a/pkg/controllers/incidents_admin.go
+++ b/pkg/controllers/incidents_admin.go
@@ -17,6 +17,7 @@ import (
 	"github.com/VersusControl/versus-incident/pkg/middleware"
 	"github.com/VersusControl/versus-incident/pkg/services"
 	"github.com/VersusControl/versus-incident/pkg/storage"
+	"github.com/VersusControl/versus-incident/pkg/tenancy"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
@@ -780,6 +781,11 @@ func (i *IncidentAdminController) analyze(c *fiber.Ctx) error {
 	if err != nil {
 		return incidentStorageError(c, "get incident for analysis", err)
 	}
+	requestOrg := storage.NormalizeOrgID(middleware.OrgFromContext(c))
+	requestScope := tenancy.ScopeForWrite(store, requestOrg)
+	if !requestScope.Contains(rec.OrgID) {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "not found"})
+	}
 
 	var body analyzeRequest
 	// Body is optional; tolerate parse errors as "no body".
@@ -789,6 +795,7 @@ func (i *IncidentAdminController) analyze(c *fiber.Ctx) error {
 	// forever. The agent has its own iteration cap on top of this.
 	ctx, cancel := context.WithTimeout(callerContext(c, c.UserContext()), analyzeRunTimeout)
 	defer cancel()
+	ctx = agent.DecorateAIContext(ctx, requestScope)
 
 	analysis, runErr, saveErr := runAndPersistAnalysis(ctx, rec, body.RequestedBy)
 	if saveErr != nil {
@@ -897,6 +904,11 @@ func (i *IncidentAdminController) analyzeStream(c *fiber.Ctx) error {
 	if err != nil {
 		return incidentStorageError(c, "get incident for analysis stream", err)
 	}
+	requestOrg := storage.NormalizeOrgID(middleware.OrgFromContext(c))
+	requestScope := tenancy.ScopeForWrite(store, requestOrg)
+	if !requestScope.Contains(rec.OrgID) {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "not found"})
+	}
 
 	var body analyzeRequest
 	_ = c.BodyParser(&body)
@@ -905,6 +917,7 @@ func (i *IncidentAdminController) analyzeStream(c *fiber.Ctx) error {
 	events := make(chan core.AnalyzeEvent, 256)
 
 	runCtx, cancel := context.WithTimeout(callerContext(c, context.Background()), analyzeRunTimeout)
+	runCtx = agent.DecorateAIContext(runCtx, requestScope)
 	go func() {
 		defer cancel()
 		defer close(events)

--- a/pkg/controllers/runbooks_admin.go
+++ b/pkg/controllers/runbooks_admin.go
@@ -156,7 +156,7 @@ func (c *RunbookAdminController) upload(ctx *fiber.Ctx) error {
 		files = append(files, runbook.UploadFile{Name: fh.Filename, Content: data})
 	}
 
-	n, err := c.mgr.Upload(ctx.UserContext(), files, "")
+	n, err := c.mgr.Upload(ctx.UserContext(), files)
 	if err != nil {
 		return ctx.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}

--- a/pkg/runbook/manager.go
+++ b/pkg/runbook/manager.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/VersusControl/versus-incident/pkg/core"
 	"github.com/VersusControl/versus-incident/pkg/runbook/vectorindex"
+	"github.com/VersusControl/versus-incident/pkg/storage"
 )
 
 // UploadFile is one operator-uploaded runbook: the original filename and
@@ -31,19 +32,26 @@ type UploadFile struct {
 // vectorindex.Index returned by Index(), keeping the analyze read-only
 // import-graph guard green.
 type Manager struct {
-	mu       sync.Mutex // serializes mutations (upload/delete/ingest)
-	store    *Store
-	embedder core.Embedder // may be nil when embeddings are not configured
-	index    atomic.Pointer[vectorindex.Memory]
+	mu              sync.Mutex // serializes mutations (upload/delete/ingest)
+	store           *Store
+	embedder        core.Embedder // may be nil when embeddings are not configured
+	writeOrg        string
+	decorateContext func(context.Context) context.Context
+	index           atomic.Pointer[vectorindex.Memory]
 }
 
-// NewManager builds a manager over an existing corpus store and an
-// optional embedder. It snapshots the current corpus into the live
-// index so reads work immediately. A nil embedder is allowed: CRUD still
-// works, but uploaded runbooks are stored without vectors (not
-// searchable until embeddings are configured and the corpus re-ingested).
-func NewManager(store *Store, embedder core.Embedder) *Manager {
-	m := &Manager{store: store, embedder: embedder}
+// NewManager builds a manager over an existing corpus store and pins every
+// mutation to writeOrg. decorateContext, when non-nil, stamps the same boot
+// scope onto embedding calls; request-provided identity never selects a write
+// scope. A nil embedder is allowed: CRUD still works, but uploaded runbooks are
+// stored without vectors until embeddings are configured and re-ingested.
+func NewManager(store *Store, embedder core.Embedder, writeOrg string, decorateContext func(context.Context) context.Context) *Manager {
+	m := &Manager{
+		store:           store,
+		embedder:        embedder,
+		writeOrg:        storage.NormalizeOrgID(writeOrg),
+		decorateContext: decorateContext,
+	}
 	m.index.Store(store.BuildIndex(0))
 	return m
 }
@@ -117,7 +125,7 @@ func (m *Manager) Delete(id string) error {
 // is rebuilt so the new runbooks are immediately searchable. Re-uploading
 // a file with the same basename replaces the existing runbook. Returns
 // the number of runbooks written.
-func (m *Manager) Upload(ctx context.Context, files []UploadFile, orgID string) (int, error) {
+func (m *Manager) Upload(ctx context.Context, files []UploadFile) (int, error) {
 	if m == nil {
 		return 0, ErrNotFound
 	}
@@ -127,12 +135,12 @@ func (m *Manager) Upload(ctx context.Context, files []UploadFile, orgID string) 
 	items := make([]ingestItem, 0, len(files))
 	for _, f := range files {
 		rel := uploadName(f.Name)
-		rec := parseRunbook(f.Content, rel, orgID)
+		rec := parseRunbook(f.Content, rel, m.writeOrg)
 		rec.Source = rel
 		items = append(items, ingestItem{rec: rec, text: rec.Title + "\n\n" + rec.Body})
 	}
 
-	n, err := ingestItems(ctx, m.store, m.embedder, items)
+	n, err := ingestItems(m.writeContext(ctx), m.store, m.embedder, items)
 	if err != nil {
 		return 0, err
 	}
@@ -145,7 +153,7 @@ func (m *Manager) Upload(ctx context.Context, files []UploadFile, orgID string) 
 // auto-ingest entry point. With no embedder configured it is a no-op
 // (find_runbook is disabled, so there is nothing to embed). A missing
 // dir is treated as an empty corpus.
-func (m *Manager) IngestDir(ctx context.Context, dir, orgID string) (int, error) {
+func (m *Manager) IngestDir(ctx context.Context, dir string) (int, error) {
 	if m == nil {
 		return 0, ErrNotFound
 	}
@@ -154,9 +162,16 @@ func (m *Manager) IngestDir(ctx context.Context, dir, orgID string) (int, error)
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	n, err := IngestDir(ctx, m.store, m.embedder, dir, orgID)
+	n, err := IngestDir(m.writeContext(ctx), m.store, m.embedder, dir, m.writeOrg)
 	m.rebuildIndexLocked()
 	return n, err
+}
+
+func (m *Manager) writeContext(ctx context.Context) context.Context {
+	if m.decorateContext == nil {
+		return ctx
+	}
+	return m.decorateContext(ctx)
 }
 
 // rebuildIndexLocked rebuilds the in-memory cosine index from the current

--- a/pkg/runbook/manager_test.go
+++ b/pkg/runbook/manager_test.go
@@ -19,9 +19,9 @@ func newTestManager(t *testing.T, embedder *fakeEmbedder) (*Manager, storage.Pro
 		emb = embedder
 	}
 	if emb == nil {
-		return NewManager(s, nil), prov
+		return NewManager(s, nil, "manager-org", nil), prov
 	}
-	return NewManager(s, emb), prov
+	return NewManager(s, emb, "manager-org", nil), prov
 }
 
 func TestManager_UploadListGetDelete(t *testing.T) {
@@ -32,7 +32,7 @@ func TestManager_UploadListGetDelete(t *testing.T) {
 		{Name: "pool.md", Content: []byte("---\ntitle: Pool Exhaustion\nservice: api\n---\nRestart the pool.")},
 		{Name: "disk.md", Content: []byte("# Disk Full\nFree space.")},
 	}
-	n, err := mgr.Upload(context.Background(), files, "")
+	n, err := mgr.Upload(context.Background(), files)
 	if err != nil {
 		t.Fatalf("Upload: %v", err)
 	}
@@ -59,6 +59,9 @@ func TestManager_UploadListGetDelete(t *testing.T) {
 	}
 	if len(rec.Vector) == 0 {
 		t.Error("uploaded record has no vector despite embedder")
+	}
+	if rec.OrgID != "manager-org" {
+		t.Errorf("uploaded record org = %q, want manager-org", rec.OrgID)
 	}
 
 	// Persistence: reload the corpus from storage.
@@ -102,7 +105,7 @@ func TestManager_IndexSearchableAfterUpload(t *testing.T) {
 
 	if _, err := mgr.Upload(context.Background(), []UploadFile{
 		{Name: "api.md", Content: []byte("---\ntitle: API Restart\nservice: api\n---\nbody")},
-	}, ""); err != nil {
+	}); err != nil {
 		t.Fatalf("Upload: %v", err)
 	}
 
@@ -118,7 +121,7 @@ func TestManager_IndexSearchableAfterUpload(t *testing.T) {
 	// A second upload is immediately searchable (live index swap).
 	if _, err := mgr.Upload(context.Background(), []UploadFile{
 		{Name: "db.md", Content: []byte("# DB\nbody")},
-	}, ""); err != nil {
+	}); err != nil {
 		t.Fatalf("Upload 2: %v", err)
 	}
 	if got := len(mgr.Index().Search([]float32{1, 0, 0}, "", 5)); got != 2 {
@@ -134,7 +137,7 @@ func TestManager_UploadWithoutEmbedder(t *testing.T) {
 
 	n, err := mgr.Upload(context.Background(), []UploadFile{
 		{Name: "x.md", Content: []byte("# X\nbody")},
-	}, "")
+	})
 	if err != nil {
 		t.Fatalf("Upload without embedder: %v", err)
 	}
@@ -157,7 +160,7 @@ func TestManager_UploadWithoutEmbedder(t *testing.T) {
 
 func TestManager_IngestDirNoopWithoutEmbedder(t *testing.T) {
 	mgr, _ := newTestManager(t, nil)
-	n, err := mgr.IngestDir(context.Background(), t.TempDir(), "")
+	n, err := mgr.IngestDir(context.Background(), t.TempDir())
 	if err != nil {
 		t.Fatalf("IngestDir: %v", err)
 	}
@@ -173,7 +176,7 @@ func TestManager_UploadNameSanitizesAndAddsExt(t *testing.T) {
 	if _, err := mgr.Upload(context.Background(), []UploadFile{
 		{Name: "../../etc/passwd", Content: []byte("# Evil\nbody")},
 		{Name: "noext", Content: []byte("# NoExt\nbody")},
-	}, ""); err != nil {
+	}); err != nil {
 		t.Fatalf("Upload: %v", err)
 	}
 	if _, err := mgr.Get("passwd.md"); err != nil {

--- a/pkg/runbook/store.go
+++ b/pkg/runbook/store.go
@@ -8,9 +8,9 @@
 //
 // Persistence goes through storage.Provider (ReadBlob/WriteBlob), the
 // same seam the pattern catalog and shadow log use — never os.WriteFile.
-// Every record carries an OrgID (default storage.DefaultOrgID) so the
-// enterprise org-injection seam scopes runbooks per-tenant with zero OSS
-// change.
+// Every record carries the manager's boot write org as provenance. The shared
+// blob is not filtered per record; deployments that need isolated corpora must
+// provide an org-scoped storage.Provider.
 package runbook
 
 import (
@@ -50,10 +50,9 @@ const excerptMaxRunes = 600
 // alongside the record so the corpus never needs re-embedding at boot.
 type Record struct {
 	ID string `json:"id"`
-	// OrgID scopes the runbook to one organization. Defaults to
-	// storage.DefaultOrgID ("default") so single-tenant OSS users never
-	// see or set it; enterprise multi-tenant routing reads it to isolate
-	// per-org corpora.
+	// OrgID records the manager's boot write org. It defaults to
+	// storage.DefaultOrgID ("default") for single-tenant OSS deployments.
+	// Isolation is provided by the storage.Provider, not record filtering.
 	OrgID     string    `json:"org_id,omitempty"`
 	Title     string    `json:"title"`
 	Services  []string  `json:"services,omitempty"`

--- a/pkg/tenancy/scope.go
+++ b/pkg/tenancy/scope.go
@@ -12,6 +12,12 @@ type OrgScope struct {
 	Read  []string
 }
 
+// ScopeSource exposes a trusted organization scope computed by a storage or
+// tenancy boundary. Implementations must not derive it from request input.
+type ScopeSource interface {
+	OrgScope() OrgScope
+}
+
 // NormalizeOrgID returns a non-empty organization ID.
 func NormalizeOrgID(orgID string) string {
 	if orgID == "" {
@@ -56,4 +62,31 @@ func (s OrgScope) Normalized() OrgScope {
 func (s OrgScope) OrgIDs() []string {
 	normalized := s.Normalized()
 	return normalized.Read
+}
+
+// Contains reports whether orgID is in the normalized read scope.
+func (s OrgScope) Contains(orgID string) bool {
+	orgID = NormalizeOrgID(orgID)
+	for _, candidate := range s.Normalized().Read {
+		if candidate == orgID {
+			return true
+		}
+	}
+	return false
+}
+
+// ScopeForWrite returns source's trusted read scope when it is pinned to the
+// requested write org. A missing or mismatched source fails closed to a
+// single-org scope for writeOrg.
+func ScopeForWrite(source any, writeOrg string) OrgScope {
+	fallback := NewOrgScope(writeOrg)
+	scoped, ok := source.(ScopeSource)
+	if !ok || scoped == nil {
+		return fallback
+	}
+	candidate := scoped.OrgScope().Normalized()
+	if candidate.Write != fallback.Write {
+		return fallback
+	}
+	return candidate
 }

--- a/pkg/tenancy/scope_test.go
+++ b/pkg/tenancy/scope_test.go
@@ -37,3 +37,20 @@ func TestOrgScopeNormalizesBlankAndOwnsReadSlice(t *testing.T) {
 		t.Fatalf("OrgIDs returned aliased storage: scope.Read = %v", scope.Read)
 	}
 }
+
+type testScopeSource struct{ scope OrgScope }
+
+func (source *testScopeSource) OrgScope() OrgScope { return source.scope }
+
+func TestScopeForWriteUsesOnlyMatchingTrustedScope(t *testing.T) {
+	source := &testScopeSource{scope: NewOrgScope("licensed", DefaultOrgID)}
+	got := ScopeForWrite(source, "licensed")
+	if !got.Contains("licensed") || !got.Contains(DefaultOrgID) || got.Contains("foreign") {
+		t.Fatalf("matching scope = %#v", got)
+	}
+
+	got = ScopeForWrite(source, "foreign")
+	if !reflect.DeepEqual(got, NewOrgScope("foreign")) {
+		t.Fatalf("mismatched scope = %#v, want foreign-only fallback", got)
+	}
+}

--- a/src/agent/tools/find-runbook.md
+++ b/src/agent/tools/find-runbook.md
@@ -35,6 +35,17 @@ corpus is re-ingested.
 > [AI Analyze mode](../ai-analyze-mode.md). The same
 > `agent.ai.api_key` is reused for the embeddings call.
 
+Runtime AI settings are resolved for every upload and query. OpenAI uses
+`Authorization: Bearer`, Gemini uses `x-goog-api-key`, and Ollama sends no AI
+credential. Key rotation is visible on the next embedding request.
+
+Embedding support is intentionally narrower than chat support: OpenAI, Gemini,
+and Ollama are registered. If a runtime switch selects a chat-only provider
+such as Claude, DeepSeek, or Qwen, runbook embedding stays on the configured
+embedding provider and the runtime key is not applied. The configured YAML key
+for that embedding provider remains the fallback. This prevents a key selected
+for one provider from reaching another provider's embedding endpoint.
+
 ## What the agent sees
 
 The agent calls the tool with a natural-language query and gets back
@@ -217,6 +228,11 @@ egresses raw.
 To keep embeddings fully inside your own network, set `agent.ai.provider`
 to `ollama` (or `gemini`) — the embedder selects its backend from the same
 provider as the chat path. No code change is required.
+
+Boot ingestion is pinned to the server's boot scope. Uploads use the trusted
+middleware write org, and query embedding inherits the decorated Chat or
+Analyze context. A missing or mismatched scope fails before an embedding
+request is sent.
 
 ## Pre-baking the corpus (optional)
 

--- a/src/enterprise/slo.md
+++ b/src/enterprise/slo.md
@@ -60,6 +60,13 @@ The advisor needs AI. Enable it and set an API key from the admin UI — see
 and a key is present, the enable toggle on the **SLOs** page stays disabled and
 shows the reason.
 
+When changing to OpenAI, DeepSeek, Qwen, Claude, or Gemini, enter a new key for
+the selected provider in the same save. A provider-only change is rejected with
+HTTP 422 and `code: provider_key_required`, leaving the previous provider, key,
+and enabled state active. Switching to Ollama clears the stored runtime key.
+Use **Revert to YAML floor** to remove the override and return to the provider
+and key configured in YAML.
+
 ## 2. Enable the feature and set the cadence
 
 Open **SLOs**. As an admin you'll see an **Enable SLI/SLO auto-define** toggle

--- a/ui/src/components/AgentAISettingsControl.tsx
+++ b/ui/src/components/AgentAISettingsControl.tsx
@@ -215,27 +215,21 @@ function SettingsBody({
 
   const busy = save.isPending || clear.isPending;
   const onOverride = view.source === "override";
+  const blankWouldChangePersistedProvider =
+    onOverride && (view.provider ?? "").trim() !== "";
   const noKeyMsg = noEncryptionKeyMessage(save.error);
 
-  // When the operator stages a provider change
-  // without entering the matching key, warn that the previous key would be
-  // reused (Bearer providers) or fall back to the YAML key (claude/gemini
-  // header-auth). Save then asks for an explicit confirmation.
+  // Keyed provider changes require a matching key in the same save. Ollama is
+  // keyless and clears any stored runtime credential.
   const providerNotice = providerKeyNotice(
     view.provider ?? "",
     provider,
     keyInput.trim().length > 0,
+    onOverride,
   );
 
   const onSave = () => {
-    if (
-      providerNotice.requireKey &&
-      !window.confirm(
-        `${providerNotice.message}\n\nSave anyway and reuse the existing key?`,
-      )
-    ) {
-      return; // operator backed out — let them enter the matching key first
-    }
+    if (providerNotice.requireKey) return;
     save.mutate({ enabled, provider, apiKey: keyInput.trim() });
   };
 
@@ -286,7 +280,11 @@ function SettingsBody({
           onChange={(e) => setProvider(e.target.value)}
           className="input h-9 max-w-sm text-sm"
         >
-          <option value="">Use config default</option>
+          <option value="" disabled={blankWouldChangePersistedProvider}>
+            {blankWouldChangePersistedProvider
+              ? "Revert to YAML floor below"
+              : "Use config default"}
+          </option>
           {AI_PROVIDERS.map((p) => (
             <option key={p} value={p}>
               {p}
@@ -321,7 +319,11 @@ function SettingsBody({
         <label className="field-label" htmlFor="ai-api-key">
           API key{" "}
           <span className="font-normal text-ink-400">
-            (leave blank to keep the current key)
+            {providerNotice.requireKey
+              ? `(required for ${provider})`
+              : provider === "ollama"
+                ? "(cleared when saved)"
+                : "(leave blank to keep the current key)"}
           </span>
         </label>
         <div className="relative max-w-sm">
@@ -367,7 +369,7 @@ function SettingsBody({
       <div className="flex flex-wrap gap-2">
         <button
           type="button"
-          disabled={busy}
+          disabled={busy || providerNotice.requireKey}
           onClick={onSave}
           className="btn btn-primary"
         >

--- a/ui/src/lib/agentAI.test.ts
+++ b/ui/src/lib/agentAI.test.ts
@@ -6,7 +6,6 @@ import {
   detectAiDisabledRemedy,
   extractCode,
   extractRemedy,
-  isHeaderAuthProvider,
   keySetLabel,
   noEncryptionKeyMessage,
   providerKeyNotice,
@@ -111,22 +110,7 @@ describe("keySetLabel", () => {
   });
 });
 
-describe("isHeaderAuthProvider", () => {
-  it("flags claude/gemini as header-auth (per-org key falls back to YAML)", () => {
-    expect(isHeaderAuthProvider("claude")).toBe(true);
-    expect(isHeaderAuthProvider("gemini")).toBe(true);
-    expect(isHeaderAuthProvider(" gemini ")).toBe(true);
-  });
-
-  it("treats the Bearer providers as NOT header-auth", () => {
-    expect(isHeaderAuthProvider("openai")).toBe(false);
-    expect(isHeaderAuthProvider("deepseek")).toBe(false);
-    expect(isHeaderAuthProvider("qwen")).toBe(false);
-    expect(isHeaderAuthProvider("")).toBe(false);
-  });
-});
-
-describe("providerKeyNotice (B35 — provider-switch key prompt)", () => {
+describe("providerKeyNotice", () => {
   it("is silent when the provider is unchanged", () => {
     const n = providerKeyNotice("openai", "openai", false);
     expect(n.show).toBe(false);
@@ -134,21 +118,20 @@ describe("providerKeyNotice (B35 — provider-switch key prompt)", () => {
     expect(n.message).toBe("");
   });
 
-  it("warns + requires a key when switching provider with NO new key (Bearer)", () => {
+  it("requires a new key when switching between keyed providers", () => {
     const n = providerKeyNotice("openai", "deepseek", false);
     expect(n.show).toBe(true);
     expect(n.requireKey).toBe(true);
     expect(n.tone).toBe("warn");
     expect(n.message).toMatch(/deepseek/);
-    expect(n.message).toMatch(/existing per-org key will be reused/);
+    expect(n.message).toMatch(/cannot be reused/);
   });
 
-  it("warns about the YAML fallback when switching to a header-auth provider with no key", () => {
+  it("requires a new key for every keyed provider authentication style", () => {
     const n = providerKeyNotice("openai", "claude", false);
     expect(n.requireKey).toBe(true);
     expect(n.tone).toBe("warn");
-    expect(n.message).toMatch(/authenticates by header/);
-    expect(n.message).toMatch(/YAML-configured key/);
+    expect(n.message).toMatch(/new API key/);
   });
 
   it("is informational (no key required) when a new key is entered with the switch", () => {
@@ -159,15 +142,37 @@ describe("providerKeyNotice (B35 — provider-switch key prompt)", () => {
     expect(n.message).toMatch(/key you entered/);
   });
 
-  it("treats picking 'config default' (blank) as a change off a saved provider", () => {
+  it("treats a blank provider as preserve", () => {
     const n = providerKeyNotice("openai", "", false);
-    expect(n.show).toBe(true);
-    expect(n.requireKey).toBe(true);
-    expect(n.message).toMatch(/config default/);
+    expect(n.show).toBe(false);
+    expect(n.requireKey).toBe(false);
   });
 
-  it("does not fire when both saved and selected are blank (config default)", () => {
-    const n = providerKeyNotice("", "", false);
+  it("directs an active override to the explicit YAML revert action", () => {
+    const n = providerKeyNotice("openai", "", false, true);
+    expect(n.show).toBe(true);
+    expect(n.requireKey).toBe(false);
+    expect(n.tone).toBe("info");
+    expect(n.message).toMatch(/Revert to YAML floor/);
+    expect(n.message).toMatch(/keep its current provider/);
+  });
+
+  it("keeps a blank saved override valid when the selection remains blank", () => {
+    const n = providerKeyNotice("", "", false, true);
     expect(n.show).toBe(false);
+    expect(n.requireKey).toBe(false);
+  });
+
+  it("warns that ollama clears the stored runtime key without requiring one", () => {
+    const n = providerKeyNotice("openai", "ollama", false);
+    expect(n.show).toBe(true);
+    expect(n.requireKey).toBe(false);
+    expect(n.tone).toBe("warn");
+    expect(n.message).toMatch(/clear the stored runtime API key/);
+  });
+
+  it("requires a key when moving from legacy blank state to a keyed provider", () => {
+    const n = providerKeyNotice("", "gemini", false);
+    expect(n.requireKey).toBe(true);
   });
 });

--- a/ui/src/lib/agentAI.ts
+++ b/ui/src/lib/agentAI.ts
@@ -76,70 +76,68 @@ export function keySetLabel(keySet: boolean, last4: string): string {
   return tail ? `Key set ····${tail}` : "Key set";
 }
 
-// HEADER_AUTH_PROVIDERS are the model backends that authenticate with a
-// provider-specific HEADER (claude → `x-api-key`, gemini → `x-goog-api-key`)
-// rather than a Bearer token. The enterprise per-org runtime key override is
-// injected via the Bearer `AuthKeyFunc` path ONLY, so for these
-// providers the per-org key does NOT apply at runtime — the agent falls back to
-// the YAML-configured key. Per-org key rotation today therefore fully applies
-// only to the Bearer providers (openai/deepseek/qwen). This mirrors the
-// enterprise AI-settings doc note.
-export const HEADER_AUTH_PROVIDERS = ["claude", "gemini"] as const;
-
-// isHeaderAuthProvider reports whether a provider authenticates by header
-// (claude/gemini) rather than Bearer.
-export function isHeaderAuthProvider(provider: string): boolean {
-  return (HEADER_AUTH_PROVIDERS as readonly string[]).includes(provider.trim());
-}
-
 // ProviderKeyNotice is the pure verdict for the AI-settings provider `<select>`.
-// It tells the control whether a
-// provider change is staged and, if so, whether the operator still owes the
-// matching key — so Save can warn/confirm before reusing the previous key.
+// It tells the control whether a provider change is staged and whether the
+// operator must supply the selected provider's key before Save can proceed.
 export interface ProviderKeyNotice {
   // show — a provider change is staged (the selection differs from the saved
   // provider); render the inline notice.
   show: boolean;
-  // requireKey — the provider changed but NO new key was entered, so Save would
-  // reuse the previous per-org key (Bearer providers) or fall back to the YAML
-  // key (claude/gemini). The control should warn + confirm before saving.
+  // requireKey — a keyed provider changed but no new key was entered. The
+  // control must block Save; the server independently enforces the invariant.
   requireKey: boolean;
-  // tone — "warn" when a key is still owed, "info" when the change is fully
-  // specified (new key entered).
+  // tone — "warn" when a key is owed or a stored key will be cleared.
   tone: "warn" | "info";
   message: string;
 }
 
 // providerKeyNotice computes the staged-provider-change verdict from the saved
 // provider, the currently-selected provider, and whether a new key was entered.
-// It is the single source of truth for both the inline notice and the Save
-// confirmation, kept DOM-free so it can be unit-tested in the node vitest env.
+// It is the single source of truth for the inline notice and Save disabled
+// state, kept DOM-free so it can be unit-tested in the node vitest env.
 export function providerKeyNotice(
   savedProvider: string,
   selectedProvider: string,
   keyEntered: boolean,
+  onOverride = false,
 ): ProviderKeyNotice {
   const sel = selectedProvider.trim();
-  const changed = sel !== savedProvider.trim();
+  if (sel === "" && onOverride && savedProvider.trim() !== "") {
+    return {
+      show: true,
+      requireKey: false,
+      tone: "info",
+      message:
+        "To use the provider from YAML, use Revert to YAML floor below. Saving this override will keep its current provider.",
+    };
+  }
+  // A blank provider remains an explicit preserve operation at the API
+  // boundary for enable-only writes and legacy clients.
+  const changed = sel !== "" && sel !== savedProvider.trim();
   if (!changed) {
     return { show: false, requireKey: false, tone: "info", message: "" };
   }
-  const target = sel || "the config default";
+  if (sel === "ollama") {
+    return {
+      show: true,
+      requireKey: false,
+      tone: "warn",
+      message:
+        "Saving will switch the model provider to ollama and clear the stored runtime API key.",
+    };
+  }
   if (keyEntered) {
     return {
       show: true,
       requireKey: false,
       tone: "info",
-      message: `Saving will switch the model provider to ${target} with the key you entered.`,
+      message: `Saving will switch the model provider to ${sel} with the key you entered.`,
     };
   }
-  const reuse = isHeaderAuthProvider(sel)
-    ? `${sel} authenticates by header (not Bearer), so the per-org key override does not apply to it yet — it will use the YAML-configured key. Enter ${sel}'s key (and rotate the YAML key) to be sure the right credential is used.`
-    : `the existing per-org key will be reused on the new endpoint. Enter the matching key for ${target} to avoid sending the wrong credential.`;
   return {
     show: true,
     requireKey: true,
     tone: "warn",
-    message: `You're switching the model provider to ${target} without entering a new key — ${reuse}`,
+    message: `Enter a new API key for ${sel} to switch providers. The existing provider key cannot be reused.`,
   };
 }


### PR DESCRIPTION
## What does this PR do?

Fixes DevOps Chat and Analyze calls that ignored an API key saved from **Settings
→ Agent** and instead called the configured model with an empty YAML key.

The shared AI runtime now propagates the trusted organization scope through
detached Chat turns, synchronous/streaming Analyze, and runbook embedding work.
It also applies runtime credentials using each provider's native authentication
scheme and sanitizes provider failures before they cross a log, API, SSE, or
persistence boundary.

## Why?

Enterprise runtime AI keys are stored per organization and resolved from the
execution context. Chat detached work onto `context.Background()`, and Analyze
used a request context without the runtime-AI organization marker. The resolver
therefore returned no key and the transport fell back to the static YAML value,
which may be empty:

```text
401 Unauthorized: You didn't provide an API key
```

A credential fix also needs strict provider isolation. A key intended for
OpenAI must not be sent to Claude, Gemini, or Ollama after a provider switch,
and provider errors must not be able to reflect credentials into logs or stored
analysis records.

## How to test

Backend:

```sh
cd versus-incident

env -u TEST_POSTGRES_DSN -u TEST_POSTGRES_UPGRADE_DSN go test -race ./...
go vet ./...
```

Focused runtime-provider tests:

```sh
go test -race ./pkg/agent/ai/eino/... \
  ./pkg/agent/ai/chat/... \
  ./pkg/agent/ai/analyze/... \
  ./pkg/agent/ai/detect/... \
  ./pkg/agent/... \
  ./pkg/controllers/... \
  ./pkg/runbook/... -count=1
```

UI:

```sh
cd ui
npm test
npm run lint
npx tsc -b --pretty false
npm run build
```

Manual Enterprise flow:

1. Leave `agent.ai.api_key` empty in YAML.
2. Sign in as the local admin or through SSO.
3. Open **Settings → Agent**, select OpenAI, enter a valid key, and save.
4. Open `/agent/chat` and send a message without restarting Versus.
5. Confirm the turn succeeds and the server no longer reports a missing API
   key.
6. Run Analyze on an incident and confirm it uses the same runtime setting.
7. Rotate the key and confirm the next Chat/Analyze call uses it without a
   restart.
8. Revert to the YAML floor and confirm the runtime override is removed.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (config / API / default behavior)
- [ ] Documentation only
- [ ] Refactor (no functional change)
- [ ] CI / build / chore

The Enterprise settings API now requires a new matching key when switching
between keyed providers. This is an intentional credential-isolation change.

## Checklist

- [x] `go test ./...` passes locally
- [x] `go vet ./...` is clean
- [x] Code is `gofmt`'d
- [x] Added or updated tests for the change
- [x] Updated user-facing docs under `src/` if behavior changes
- [ ] Updated `ROADMAP.md` if this closes a roadmap item
- [x] No secrets, tokens, or webhook URLs introduced in source / YAML
- [x] No new third-party dependencies (or justified in the description)